### PR TITLE
Git molecule Search side panel: beta

### DIFF
--- a/replicad-app-example/src/components/GitSearch.jsx
+++ b/replicad-app-example/src/components/GitSearch.jsx
@@ -118,7 +118,21 @@ function GitSearch(props) {
                 left: GlobalVariables.lastClick[0] - 350 + "px",
               }}
             >
-              <img src={"/imgs/defaultThumbnail.svg"}></img>
+              <div className="GitInfoLeft">
+                <img src={"/imgs/defaultThumbnail.svg"}></img>
+                <div style={{ display: "flex" }}>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    style={{ transform: "scale(.7)" }}
+                    width="16"
+                    height="16"
+                  >
+                    <path d="M8 .2l4.9 15.2L0 6h16L3.1 15.4z" />
+                  </svg>
+                  <p>{panelItem.stargazers_count}</p>
+                </div>
+              </div>
+
               <div className="GitInfo">
                 <span>Project Name: {panelItem.name}</span>
                 <span>Owner: {panelItem.owner.login}</span>

--- a/replicad-app-example/src/components/LoginMode.jsx
+++ b/replicad-app-example/src/components/LoginMode.jsx
@@ -444,7 +444,7 @@ const ShowProjects = (props) => {
             {node.name}
           </p>
           <img className="project_image" src="/imgs/defaultThumbnail.svg"></img>
-          <div style={{ display: "flex" }}>
+          <div style={{ display: "inline" }}>
             <svg
               xmlns="http://www.w3.org/2000/svg"
               style={{ transform: "scale(.7)" }}
@@ -453,7 +453,7 @@ const ShowProjects = (props) => {
             >
               <path d="M8 .2l4.9 15.2L0 6h16L3.1 15.4z" />
             </svg>
-            <p>{node.stargazers_count}</p>
+            <p style={{ fontSize: ".5em" }}>{node.stargazers_count}</p>
           </div>
         </div>
       </Link>

--- a/replicad-app-example/src/maslowCreate.css
+++ b/replicad-app-example/src/maslowCreate.css
@@ -913,6 +913,8 @@ Sidebar navigation
 .GitProjectInfoPanel img {
   width: 100px;
   height: 100px;
+}
+.GitInfoLeft {
   align-self: center;
 }
 .GitInfo {


### PR DESCRIPTION
ADDS hover panel to gitsearch component. Side panel shows project name and description of project when hovering over the list of filtered github molecules after inputting a string.


-- I wanted to add the sidepanel to the github molecule search function. I'll flesh out the CSS later but I just wanted to have a placeholder for all the info that we are going to want to show when looking for github molecules. 

One of the things I'm unsure about with this component is how it's getting placed. Right now I have it positioned through inline styles that grab from a Globalvariable which has the last click stored (which should be when the click on the menu happened) - I'm unsure that this is the best way to place it and whether it's confusing to have a global variable named last click when it just gets updated in the menu component but it doesn't always reflect last click.