### PR TITLE
Draw api switch

### DIFF
--- a/replicad-app-example/src/worker.js
+++ b/replicad-app-example/src/worker.js
@@ -324,7 +324,6 @@ function actOnLeafs(assembly, action) {
     assembly.geometry.length == 1 &&
     assembly.geometry[0].geometry == undefined
   ) {
-    console.log(assembly);
     return action(assembly);
   }
   //This is a branch


### PR DESCRIPTION
- Switching to have draw as our replicad shape creator instead of sketch. Everything still needs to be turned into sketches but drawing it first will allow us to translate,scale, and do things to drawings that sketches don't have methods for.