### PR TITLE
Cut assembly 2

### DIFF
--- a/replicad-app-example/src/worker.js
+++ b/replicad-app-example/src/worker.js
@@ -355,14 +355,13 @@ function cutAssembly(partToCut, cuttingParts, assemblyID, index) {
     let assemblyToCut = partToCut.geometry;
     let assemblyCut = [];
     assemblyToCut.forEach((part) => {
-      //make sure you fix id
       // make new assembly from cut parts
       assemblyCut.push(cutAssembly(part, cuttingParts, assemblyID, assemblyID));
     });
-    let newID = assemblyID * 10 + index;
+    let subID = assemblyID * 10 + index + Math.random(100); // needs to be randomized?
     //returns new assembly that has been cut
-    library[newID] = { geometry: assemblyCut, tags: partToCut.tags };
-    return library[newID];
+    library[subID] = { geometry: assemblyCut, tags: partToCut.tags };
+    return library[subID];
   } else {
     // if part to cut is a single part send to cutting function with cutting parts
     var partCutCopy = partToCut.geometry[0];


### PR DESCRIPTION
This pull request:

- Makes it possible to use assemblies as inputs for an assembly. Maintains individual parts of assemblies after they've been cut.
- Adds a function to check if an object containing geometries is an assembly

* Is this handling of IDs ok or should we find a better solution?