### PR TITLE
Catch for no output

### DIFF
--- a/replicad-app-example/To-do-list
+++ b/replicad-app-example/To-do-list
@@ -7,7 +7,10 @@ now:
 - model some things :S
 
 - assemblies self deleting sometimes after moving parts several times: haven’t found bug source
+
 - Problems placing connector when there’s github molecules in project
+  i think the problem we are having is that the loaded project github molecule ID is different from the uniqueID on the saved project so it's having problems displaying the geometry and placing connectors
+
 - Make it so that you can rename constants
 - make load bar for creating new project and disable button while project is being created
 - Wireframe visible \_ make on off toggle // maybe implement with drei for more complex wireframe

--- a/replicad-app-example/src/components/flowCanvas.jsx
+++ b/replicad-app-example/src/components/flowCanvas.jsx
@@ -39,9 +39,14 @@ export default memo(function FlowCanvas(props) {
       console.log("write to display running " + id);
 
       cad.generateDisplayMesh(id).then((m) => setMesh(m));
-      cad
-        .generateDisplayMesh(GlobalVariables.currentMolecule.output.value)
-        .then((w) => setWireMesh(w));
+      // if something is connected to the output, set a wireframe mesh
+      if (GlobalVariables.currentMolecule.output.value !== undefined) {
+        cad
+          .generateDisplayMesh(GlobalVariables.currentMolecule.output.value)
+          .then((w) => setWireMesh(w));
+      } else {
+        console.warn("no wire to display");
+      }
     };
 
     GlobalVariables.cad = cad;


### PR DESCRIPTION
- Creates a catch for when there's no output set so displaymesh doesn't run. I think we need something better than this if statement but the error of no output is making it hard to see what is happening with other bugs so for now this seems ok. 
