### PR TITLE
Toggle wireframe & Solid 

### DIFF
--- a/replicad-app-example/src/components/CreateMode.jsx
+++ b/replicad-app-example/src/components/CreateMode.jsx
@@ -34,6 +34,7 @@ function CreateMode(props) {
   const [gridParam, setGrid] = useState(true);
   const [axesParam, setAxes] = useState(true);
   const [wireParam, setWire] = useState(true);
+  const [solidParam, setSolid] = useState(true);
   /** State for save progress bar */
   const [saveState, setSaveState] = useState(0);
   const [savePopUp, setSavePopUp] = useState(false);
@@ -328,6 +329,7 @@ function CreateMode(props) {
                 setGrid={setGrid}
                 setAxes={setAxes}
                 setWire={setWire}
+                setSolid={setSolid}
               />
             ) : null}
 
@@ -336,9 +338,11 @@ function CreateMode(props) {
                 gridParam: gridParam,
                 axesParam: axesParam,
                 wireParam: wireParam,
+                solidParam: solidParam,
                 saveProject: saveProject,
                 setSaveState: setSaveState,
                 setSaveState: setSaveState,
+                setSolid: setSolid,
               }}
               displayProps={{
                 mesh: mesh,

--- a/replicad-app-example/src/components/ParameterEditor.jsx
+++ b/replicad-app-example/src/components/ParameterEditor.jsx
@@ -10,6 +10,7 @@ export default (function ParamsEditor({
   setGrid,
   setAxes,
   setWire,
+  setSolid,
 }) {
   let inputParams = {};
   let bomParams = {};
@@ -69,23 +70,30 @@ export default (function ParamsEditor({
     {
       grid: {
         value: true,
-        label: "Show grid",
+        label: "Show Grid",
         onChange: (value) => {
           setGrid(value);
         },
       },
       axes: {
         value: true,
-        label: "Show axes",
+        label: "Show Axes",
         onChange: (value) => {
           setAxes(value);
         },
       },
       wire: {
         value: true,
-        label: "Show wireframe",
+        label: "Show Wire",
         onChange: (value) => {
           setWire(value);
+        },
+      },
+      solid: {
+        value: true,
+        label: "Show Solid",
+        onChange: (value) => {
+          setSolid(value);
         },
       },
     },

--- a/replicad-app-example/src/components/lowerHalf.jsx
+++ b/replicad-app-example/src/components/lowerHalf.jsx
@@ -66,7 +66,9 @@ export default memo(function LowerHalf(props) {
               {props.props.wireParam ? (
                 <WireframeMesh edges={wireMesh.edges} faces={wireMesh.faces} />
               ) : null}
-              <ReplicadMesh edges={mesh.edges} faces={mesh.faces} />
+              {props.props.solidParam ? (
+                <ReplicadMesh edges={mesh.edges} faces={mesh.faces} />
+              ) : null}
             </ThreeContext>
           ) : (
             <div


### PR DESCRIPTION
Menu option to hide solid and wireframe. Might need to change since now full wire for molecule is what is displayed, might be nice to switch to toggle between wire and solid for selected atom while still having the option to turn full wire on. 