### PR TITLE
New fuse function -  digFuse - Thumnail generate fix

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -929,7 +929,6 @@ function digFuse(assembly) {
     });
     return chainFuse(flattened);
   } else {
-    console.log("not an assembly to dig, returning single geometry ");
     return assembly.geometry[0];
   }
 }


### PR DESCRIPTION
I made a new fuse function that can replace the flatten and chainfuse function combination. Instead of taking in geometry that has been flattened into a non hierarchical array, it takes in an assembly and goes deeper and deeper down it, only fusing the parts once it has found single non assembly geometries. 
The current flattenAssembly we have, assumes that all geometries can be acted on the same but after trying to model the closetRack parts in replicad I realized fusing needs to happen in a particular order for it not to throw computation errors. 

- Makes New assembly fuse function (digFuse)
- Applies new function to generateThumbnail function in worker. 