### PR TITLE
Small changes continued from fuse update

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -972,7 +972,6 @@ function generateDisplayMesh(id) {
 
     //Flatten the assembly to remove hierarchy
     const flattened = flattenAssembly(library[id]);
-    //Here we need to extrude anything which isn't already 3D
 
     flattened.forEach((displayObject) => {
       var cleanedGeometry = [];


### PR DESCRIPTION
- Difference input one to return separate parts as intersection does. 
- Add error catch to shrinkWrap
- Change flattenAssembly function to return object so we can get rid of color iterating display loop.