### PR TITLE
SVG draw replaces addSVG

### DIFF
--- a/src/molecules/import.js
+++ b/src/molecules/import.js
@@ -53,7 +53,6 @@ export default class Import extends Atom {
      */
     this.sha = null;
 
-    this.SVGdepth = 10;
     this.SVGwidth = 10;
 
     this.addIO("output", "geometry", this, "geometry", "");
@@ -124,12 +123,10 @@ export default class Import extends Atom {
             throw "Invalid file type";
           }
 
-          funcToCall(this.uniqueID, file, this.SVGdepth, this.SVGwidth).then(
-            (result) => {
-              this.basicThreadValueProcessing();
-              this.sendToRender();
-            }
-          );
+          funcToCall(this.uniqueID, file, this.SVGwidth).then((result) => {
+            this.basicThreadValueProcessing();
+            this.sendToRender();
+          });
         });
       }
     } catch (err) {
@@ -197,14 +194,6 @@ export default class Import extends Atom {
             this.updateValue();
           },
         };
-        inputParams["Depth"] = {
-          value: this.SVGdepth, //href to the file
-          label: "Depth",
-          onChange: (value) => {
-            this.SVGdepth = value;
-            this.updateValue();
-          },
-        };
       }
       inputParams["Loaded File"] = {
         value: this.fileName, //href to the file
@@ -252,7 +241,6 @@ export default class Import extends Atom {
     superSerialObject.fileName = this.fileName; // might delete, maybe we just save as library object
     superSerialObject.name = this.name;
     superSerialObject.type = this.type;
-    superSerialObject.SVGdepth = this.SVGdepth;
     superSerialObject.SVGwidth = this.SVGwidth;
 
     return superSerialObject;

--- a/src/worker.js
+++ b/src/worker.js
@@ -516,7 +516,7 @@ async function importingSTL(targetID, file) {
   return true;
 }
 
-async function importingSVG(targetID, svg, depth, width) {
+async function importingSVG(targetID, svg, width) {
   const baseWidth = width + width * 0.05;
   const baseShape = drawRectangle(baseWidth, baseWidth)
     .sketchOnPlane()


### PR DESCRIPTION
I found a new function which lets us just draw the SVG instead of having to add it to a solid. This avoids having to use a base shape and just makes a drawing from the SVG paths
<img width="748" alt="Screenshot 2024-08-05 at 5 37 26 PM" src="https://github.com/user-attachments/assets/c55741e5-e42c-4e3e-849c-9e438813b746">
