### PR TITLE
Initial version of part nesting using the svg-nest engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@react-three/drei": "^9.97.0",
         "@react-three/fiber": "8.15.16",
         "@uiw/react-codemirror": "^4.22.0",
-        "any-nest": "1.0.2",
         "circular-menu": "^1.0.6",
         "codemirror": "^6.0.1",
         "comlink": "^4.4.1",
@@ -467,26 +466,6 @@
         "@codemirror/state": "^6.4.0",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -2622,26 +2601,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw=="
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
-    },
     "node_modules/@tweenjs/tween.js": {
       "version": "23.1.2",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.2.tgz",
@@ -2866,28 +2825,6 @@
         "vite": "^4.2.0 || ^5.0.0"
       }
     },
-    "node_modules/acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.3.tgz",
-      "integrity": "sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==",
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -2910,21 +2847,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/any-nest": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/any-nest/-/any-nest-1.0.2.tgz",
-      "integrity": "sha512-agX8MFiF2rPOer90znZHTP94ZTKl9whjVilhu/TDJgu7nxCcDu0GaamOpjtTXWiF7IcFLi3wS057p3/mBCkgTA==",
-      "dependencies": {
-        "comlink": "^4.4.1",
-        "js-clipper": "^1.0.1",
-        "ts-node": "^10.9.2"
-      }
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "node_modules/assign-symbols": {
       "version": "1.0.0",
@@ -3198,11 +3120,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
-    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
@@ -3307,14 +3224,6 @@
       "integrity": "sha512-36QeGHSXYcJ/RfrnPEScR8GDprbXFG4ZhXsfVNVHztZr38+fRxgHnJl3CjYXXjbeRUhu3ZZBJh6Lg0A9v0Qd8A==",
       "dependencies": {
         "webgl-constants": "^1.1.1"
-      }
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/dom-helpers": {
@@ -3705,11 +3614,6 @@
       "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
       "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw=="
     },
-    "node_modules/js-clipper": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/js-clipper/-/js-clipper-1.0.1.tgz",
-      "integrity": "sha512-0XYAS0ZoCki5K0fWwj8j8ug4mgxHXReW3ayPbVqr4zXPJuIs2pyvemL1sALadsEiAywZwW5Ify1XfU4bNJvokg=="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3892,11 +3796,6 @@
         "@types/three": ">=0.144.0",
         "three": ">=0.144.0"
       }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "node_modules/mathjs": {
       "version": "12.4.3",
@@ -4757,48 +4656,6 @@
       "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.49.0.tgz",
       "integrity": "sha512-1xZHoJrG0HFfCvT/iyN41DvI/nRykiBtHqFkGaGgJwq5iXfIZFBiPPEHFpPpgyKM3Oo5ITHXP5wM2TNQszYdVg=="
     },
-    "node_modules/ts-node": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tslib": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
@@ -4937,11 +4794,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
-    },
     "node_modules/v8n": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/v8n/-/v8n-1.5.1.tgz",
@@ -5061,14 +4913,6 @@
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@react-three/drei": "^9.97.0",
     "@react-three/fiber": "8.15.16",
     "@uiw/react-codemirror": "^4.22.0",
-    "any-nest": "1.0.2",
     "circular-menu": "^1.0.6",
     "codemirror": "^6.0.1",
     "comlink": "^4.4.1",

--- a/src/molecules/cutlayout.js
+++ b/src/molecules/cutlayout.js
@@ -209,6 +209,7 @@ export default class CutLayout extends Atom {
           }
           this.progress = 1.0;
           this.cancelationHandle = undefined;
+          this.processing = false;
         })
         .catch(this.alertingErrorHandler());
     }


### PR DESCRIPTION
Lots of notes here since this is a big change

@alzatin check out the change to actOnLeafs which allows removal of leafs. I think this is innocuous but actOnLeafs gets used all over the place so I wanted to flag this change to you in case you know of a place where it might cause breakages.

General UX notes:
* the cutlayout molecule now has a lot of inputs. Specifically:
  * stock width - default 96in or 2438mm
  * stock height - default to 48 in or 1219mm
  * stock thickness - default to 3/4in or 19mm
  * part padding - min space between shapes - default to 6mm or 1/2 in
  * bin padding - min space between part and the edge of the stock material - default to 3in or 75mm 
* Parts which are too large to fit on the stock are removed from the output and cutlayout raises a warning.
* If there are so many parts that multiple sheets of stock are needed the layout will stack the per-sheet layouts in the y-axis direction
* Changing inputs will interrupt and restart the layout computation

Limitations / follow up work that I'm thinking about:
* **Too many inputs?** - There's actually a few more configs which it'd be nice to surface but I didn't want to swamp the UI. Do we have a more dense way to provide inputs to the molecule? eg: a json blob of configuration information?
  * Parameters i'd like to add are those which influence the speed / accuracy of the packing algorithm eg: precision of the meshes used for placement, generations to run the GE before picking best solution
* **Output is an assembly** - We may need a way to select a subset
  * eg: a user might want to shift parts after the system layout
  * or: in the case where we have multiple sheets of layout I think we need a way to pick a single sheet to generate gcode for?
* **Always recomputes layout from scratch** - Instead it'd be nice to cache the layout then have a button with which users could manually re-trigger the layout computation.
* **Big rebase** - There's a bug somewhere deep in the version of the nesting implementation we're using. It breaks for non-rectangular inputs and when 'searchEdges' is true in the config (no way to set this to true in our UI). Rather than tracking this down I want to rebase to a recent version of https://github.com/yuriilychak/SVGnest, but this'll require substantial work to get the interface consistent. I haven't undertaken that yet but might be necessary if we ever want to support non-rectangle inputs.
* **Better weighting heuristics** - currently our nesting algorithm squeezes shapes towards a squat rectangle shape. But for some arrangements of shapes this doesn't feel most well packed. Eg: with a couple big ones and a few much smaller ones there can be a lot of space between the small parts because their position doesn't influence the overall rectangle perimeter. There are other heuristics (eg: concave hull?) which might improve this behavior. Again, a deep change to the algo which will take ???? amount of effort.