### PR TITLE
Add compute button to cut layout

### DIFF
--- a/src/molecules/cutlayout.js
+++ b/src/molecules/cutlayout.js
@@ -2,6 +2,7 @@ import Atom from "../prototypes/atom.js";
 import GlobalVariables from "../js/globalvariables.js";
 //import GlobalVariables from '../js/globalvariables.js'
 import { proxy } from "comlink";
+import { button, LevaInputs } from "leva";
 
 
 /**
@@ -159,9 +160,16 @@ export default class CutLayout extends Atom {
     }
   }
   /**
-   * Pass the input geometry to a worker function to compute the translation.
+   * We only want the layout to update when the button is pressed not when the inputs update so we block the regular update value behavior
    */
   updateValue() {
+
+  }
+
+  /**
+   * Pass the input geometry to a worker function to compute the translation.
+   */
+  updateValueButton() {
     super.updateValue();
 
     if (this.inputs.every((x) => x.ready)) {
@@ -213,5 +221,18 @@ export default class CutLayout extends Atom {
         })
         .catch(this.alertingErrorHandler());
     }
+  }
+
+  /**
+   * Add the "Compute Layout" button to the leva inputs.
+   */
+  createLevaInputs() {
+      let inputParams = super.createLevaInputs();
+  
+      inputParams["Compute Layout"] = button(() => {
+          this.updateValueButton();
+      });
+  
+      return inputParams;
   }
 }


### PR DESCRIPTION
Since computing a cut layout is quite processor intensive and only really needs to be done at the end of a project we can have the cut layout only re-compute when a button is pressed instead of every time one of the inputs updates.

<img width="290" alt="image" src="https://github.com/user-attachments/assets/f9427cc6-1c9c-4d26-901e-d9b2eb4d46c8">
