### PR TITLE
add offset as parameter to serialize

### DIFF
--- a/src/molecules/color.js
+++ b/src/molecules/color.js
@@ -205,8 +205,8 @@ export default class Color extends Atom {
   /**
    * Add the color choice to the object which is saved for this molecule
    */
-  serialize() {
-    var superSerialObject = super.serialize();
+  serialize(offset = { x: 0, y: 0 }) {
+    var superSerialObject = super.serialize(offset);
 
     //Write the current color selection to the serialized object
     superSerialObject.selectedColorIndex = this.selectedColorIndex;

--- a/src/molecules/equation.js
+++ b/src/molecules/equation.js
@@ -206,8 +206,8 @@ export default class Equation extends Atom {
   /**
    * Add the equation choice to the object which is saved for this molecule
    */
-  serialize() {
-    var superSerialObject = super.serialize();
+  serialize(offset = { x: 0, y: 0 }) {
+    var superSerialObject = super.serialize(offset);
 
     //Write the current equation to the serialized object
     superSerialObject.currentEquation = this.currentEquation;

--- a/src/molecules/export.js
+++ b/src/molecules/export.js
@@ -182,8 +182,8 @@ export default class Export extends Atom {
   /**
    * Add the file name to the object which is saved for this molecule
    */
-  serialize() {
-    var superSerialObject = super.serialize();
+  serialize(offset = { x: 0, y: 0 }) {
+    var superSerialObject = super.serialize(offset);
     superSerialObject.type = this.type;
     superSerialObject.resolution = this.resolution;
     superSerialObject.importIndex = this.importIndex;

--- a/src/molecules/extracttag.js
+++ b/src/molecules/extracttag.js
@@ -122,8 +122,8 @@ export default class ExtractTag extends Atom {
   /**
    * Keeps track of tag to be extracted
    */
-  serialize() {
-    var superSerialObject = super.serialize();
+  serialize(offset = { x: 0, y: 0 }) {
+    var superSerialObject = super.serialize(offset);
     superSerialObject.tag = this.tag;
     superSerialObject.tagIndex = this.tagIndex;
 

--- a/src/molecules/import.js
+++ b/src/molecules/import.js
@@ -234,8 +234,8 @@ export default class Import extends Atom {
   /**
    * Add the file name to the object which is saved for this molecule
    */
-  serialize() {
-    var superSerialObject = super.serialize();
+  serialize(offset = { x: 0, y: 0 }) {
+    var superSerialObject = super.serialize(offset);
 
     //Write the current equation to the serialized object
     superSerialObject.fileName = this.fileName; // might delete, maybe we just save as library object

--- a/src/molecules/molecule.js
+++ b/src/molecules/molecule.js
@@ -356,7 +356,7 @@ export default class Molecule extends Atom {
     this.nodesOnTheScreen.forEach((atom) => {
       if (atom.selected) {
         GlobalVariables.atomsSelected.push(
-          atom.serialize({ x: 0.03, y: 0.03 })
+          atom.serialize({ x: 0.05, y: 0.05 })
         );
       }
     });

--- a/src/molecules/tag.js
+++ b/src/molecules/tag.js
@@ -150,8 +150,8 @@ export default class Tag extends Atom {
   /**
    * Add the file name to the object which is saved for this molecule
    */
-  serialize() {
-    var superSerialObject = super.serialize();
+  serialize(offset = { x: 0, y: 0 }) {
+    var superSerialObject = super.serialize(offset);
     superSerialObject.tags = this.tags;
     superSerialObject.cutTag = this.cutTag;
 

--- a/src/molecules/text.js
+++ b/src/molecules/text.js
@@ -125,8 +125,8 @@ export default class Text extends Atom {
       .catch(this.alertingErrorHandler());
   }
 
-  serialize() {
-    var thisAsObject = super.serialize();
+  serialize(offset = { x: 0, y: 0 }) {
+    var thisAsObject = super.serialize(offset);
 
     var ioValues = [];
     this.inputs.forEach((io) => {


### PR DESCRIPTION
Should get rid of bug where some atoms when copied and paste appeared directly on top of each other. By adding offset as a parameter to atoms that have individual serialize functions, the copy offset does not get lost.