### PR TITLE
change to atom symbols and size

### DIFF
--- a/src/molecules/constant.js
+++ b/src/molecules/constant.js
@@ -70,6 +70,25 @@ export default class Constant extends Atom {
    */
   draw() {
     super.draw("rect");
+    let pixelsX = GlobalVariables.widthToPixels(this.x);
+    let pixelsY = GlobalVariables.heightToPixels(this.y);
+    let pixelsRadius = GlobalVariables.widthToPixels(this.radius);
+    /**
+     * Relates height to radius
+     * @type {number}
+     */
+    this.height = pixelsRadius;
+
+    GlobalVariables.c.beginPath();
+    GlobalVariables.c.fillStyle = "#484848";
+    GlobalVariables.c.font = `${pixelsRadius}px Work Sans Bold`;
+    GlobalVariables.c.fillText(
+      String.fromCharCode(0x039b),
+      pixelsX - pixelsRadius / 3,
+      pixelsY + this.height / 1.5
+    );
+    GlobalVariables.c.fill();
+    GlobalVariables.c.closePath();
   }
   /**
    * Create Leva Menu Input - returns to ParameterEditor

--- a/src/molecules/equation.js
+++ b/src/molecules/equation.js
@@ -69,12 +69,12 @@ export default class Equation extends Atom {
 
     GlobalVariables.c.beginPath();
     GlobalVariables.c.fillStyle = "#484848";
-    GlobalVariables.c.font = `${pixelsRadius / 1.5}px Work Sans Bold`;
+    GlobalVariables.c.font = `${pixelsRadius / 1}px Work Sans Bold`;
 
     GlobalVariables.c.fillText(
-      "X + Y",
-      pixelsX - pixelsRadius / 1.2,
-      pixelsY + this.height / 3
+      "\u221A" + "(+)",
+      pixelsX - pixelsRadius / 1,
+      pixelsY + this.height / 2
     );
     GlobalVariables.c.fill();
     GlobalVariables.c.closePath();

--- a/src/molecules/extracttag.js
+++ b/src/molecules/extracttag.js
@@ -71,9 +71,9 @@ export default class ExtractTag extends Atom {
     GlobalVariables.c.fillStyle = "#484848";
     GlobalVariables.c.font = `${pixelsRadius}px Work Sans Bold`;
     GlobalVariables.c.fillText(
-      String.fromCharCode(0x2191, 0x0023, 0x2191),
-      pixelsX - pixelsRadius / 1.2,
-      pixelsY + this.height / 3
+      String.fromCharCode(0x2191, 0x0040, 0x2191),
+      pixelsX - pixelsRadius / 1,
+      pixelsY + this.height / 2
     );
     GlobalVariables.c.fill();
     GlobalVariables.c.closePath();

--- a/src/molecules/tag.js
+++ b/src/molecules/tag.js
@@ -21,7 +21,7 @@ export default class Tag extends Atom {
      * This atom's name
      * @type {string}
      */
-    this.name = "Add Tag";
+    this.name = "Tag";
     /**
      * This atom's type
      * @type {string}
@@ -61,11 +61,11 @@ export default class Tag extends Atom {
 
     GlobalVariables.c.beginPath();
     GlobalVariables.c.fillStyle = "#484848";
-    GlobalVariables.c.font = `${pixelsRadius}px Work Sans Bold`;
+    GlobalVariables.c.font = `${pixelsRadius * 1.3}px Work Sans Bold`;
     GlobalVariables.c.fillText(
-      String.fromCharCode(0x0023),
-      GlobalVariables.widthToPixels(this.x - this.radius / 3),
-      GlobalVariables.heightToPixels(this.y) + this.height / 3
+      "@",
+      GlobalVariables.widthToPixels(this.x - this.radius / 1.5),
+      GlobalVariables.heightToPixels(this.y) + this.height / 1.5
     );
     GlobalVariables.c.fill();
     GlobalVariables.c.closePath();

--- a/src/prototypes/atom.js
+++ b/src/prototypes/atom.js
@@ -183,10 +183,10 @@ export default class Atom {
     GlobalVariables.c.beginPath();
     if (drawType == "rect") {
       GlobalVariables.c.rect(
-        xInPixels - radiusInPixels,
-        yInPixels - this.height / 2,
-        2 * radiusInPixels,
-        this.height
+        xInPixels - radiusInPixels * 1.25,
+        yInPixels - this.height / 1.5,
+        2.5 * radiusInPixels,
+        this.height * 1.5
       );
     } else {
       GlobalVariables.c.arc(


### PR DESCRIPTION
I'm changing the size and symbols of a few atoms (equation, tag, constant, extract tag) in an attempt to make them more readable on the screen. Let me know if you find it awful that they are bigger. 

<img width="917" alt="Screenshot 2024-09-13 at 4 22 57 PM" src="https://github.com/user-attachments/assets/aa7579be-9fdd-4cc4-a034-46b94e271144">
