### PR TITLE
New project Bug fix

### DIFF
--- a/src/components/main-routes/LoginMode.jsx
+++ b/src/components/main-routes/LoginMode.jsx
@@ -472,7 +472,6 @@ const ShowProjects = (props) => {
 
     repoSearchRequest(projectToShow)
       .then((result) => {
-        console.log(result);
         if (result["repos"].length == 0 && props.user !== "") {
           forkDummyProject(authorizedUserOcto).then(() => {
             repoSearchRequest().then((result) => {
@@ -508,8 +507,6 @@ const ShowProjects = (props) => {
       setPageNumber(0);
     }
   };
-
-  console.log(projectToShow);
 
   return (
     <>

--- a/src/components/secondary/NewProjectPopUp.jsx
+++ b/src/components/secondary/NewProjectPopUp.jsx
@@ -103,14 +103,13 @@ const NewProjectPopUp = (props) => {
         setPending(false);
       })
       .then((result) => {
-        console.log(result);
         setNewProjectBar(10);
         //Once we have created the new repo we need to create a file within it to store the project in
         currentRepoName = result.data.name;
         currentUser = GlobalVariables.currentUser;
 
         var jsonRepOfProject = GlobalVariables.topLevelMolecule.serialize();
-        console.log(jsonRepOfProject);
+
         jsonRepOfProject.filetypeVersion = 1;
         const projectContent = window.btoa(
           JSON.stringify(jsonRepOfProject, null, 4)


### PR DESCRIPTION
Ok, this takes care of the issue you pointed out to me last night that showed up when creating a new project. It ended up being a bit more complicated than I originally thought and the solution is a bit verbose and there is definitely room for improvement. 
The issue was being caused by the fact that when creating a new project the currentRepo was being set to the API response that we got from github instead of the aws object which is what we are currently setting as our currentRepo. The reason it is more complicated than I thought is that aws has no concise way of adding an item to the table and returning it at the same time so as of now at the beginning of createProject we are adding an item to the table and at the end making a new call to retrieve that item. I think both of these actions could eventually live in a single request to a lambda function but since I already have the scanAbundanceProjects lambda set up this seemed like the most straightforward way to get there. 