### PR TITLE
Fork reload fix

### DIFF
--- a/Lambda AWS Functions/post-new-project-abundance/lambda_function.py
+++ b/Lambda AWS Functions/post-new-project-abundance/lambda_function.py
@@ -3,45 +3,60 @@ import os
 import json
 from datetime import datetime
 
-def lambda_handler(event:any, context:any):
-    
-    
+
+def lambda_handler(event: any, context: any):
+
     returnObject = {}
-    
-    #create a dynamodb client
+
+    # create a dynamodb client
     dynamodb = boto3.resource("dynamodb")
-    #get the item from the table
+    # get the item from the table
     table_name = os.environ["TABLE_NAME"]
     table = dynamodb.Table(table_name)
-    
+
     print(event)
-    
+
     try:
         owner = event["owner"]
         repoName = event["repoName"]
-        ranking =event["ranking"]
+        ranking = event["ranking"]
         forks = event["forks"]
-        topMoleculeID =event["topMoleculeID"]
+        topMoleculeID = event["topMoleculeID"]
         topics = event["topics"]
         readMe = event["readme"]
-        contentURL =event["contentURL"]
-        svgURL =event["svgURL"]
-        dateCreated = event["dateCreated"]   
-        
+        contentURL = event["contentURL"]
+        svgURL = event["svgURL"]
+        dateCreated = event["dateCreated"]
+        parentRepo = event["parentRepo"]
+        githubMoleculesUsed = event["githubMoleculesUsed"]
+
         newYear = datetime.now().year
         print(newYear)
-          
-        table.put_item(Item={"owner": owner, "repoName": repoName, "ranking":ranking,"forks": forks, "topMoleculeID": topMoleculeID, "svgURL": svgURL, "topics":topics, "readMe":readMe,"dateCreated":dateCreated, "contentURL":contentURL, "yyyy": newYear})
-        returnObject['statusCode']= 200
-        message = "Success put item"  
-        
+
+        itemToPut = {"owner": owner,
+                     "repoName": repoName,
+                     "ranking": ranking,
+                     "forks": forks,
+                     "topMoleculeID": topMoleculeID,
+                     "svgURL": svgURL,
+                     "topics": topics,
+                     "readMe": readMe,
+                     "dateCreated": dateCreated,
+                     "contentURL": contentURL,
+                     "parentRepo": parentRepo,
+                     "githubMoleculesUsed": githubMoleculesUsed,
+                     "yyyy": newYear}
+
+        table.put_item(Item=itemToPut)
+        returnObject['statusCode'] = 200
+        message = "Success put item"
+
     except:
-        returnObject['statusCode']= 400
-        message= 'no'
-         
-   
+        returnObject['statusCode'] = 400
+        message = 'no'
+
     returnObject['headers'] = {}
-    returnObject["body"]= json.dumps("hello")
+    returnObject["body"] = json.dumps(message)
     returnObject['headers']['Content-Type'] = 'application/json'
-    
+
     return returnObject

--- a/src/components/secondary/NewProjectPopUp.jsx
+++ b/src/components/secondary/NewProjectPopUp.jsx
@@ -124,6 +124,7 @@ const NewProjectPopUp = (props) => {
           topMoleculeID: GlobalVariables.topLevelMolecule.uniqueID,
           topics: topics,
           html_url: result.data.html_url,
+          parentRepo: null,
           readme:
             "https://raw.githubusercontent.com/" +
             result.data.full_name +

--- a/src/components/secondary/RunNavigation.jsx
+++ b/src/components/secondary/RunNavigation.jsx
@@ -261,7 +261,7 @@ function RunNavigation(props) {
               owner: GlobalVariables.currentUser,
               ranking: result.data.stargazers_count,
               repoName: result.data.name,
-              forks: result.data.forks_count,
+              forks: 0,
               topMoleculeID: GlobalVariables.topLevelMolecule.uniqueID,
               topics: [],
               readme:
@@ -277,6 +277,7 @@ function RunNavigation(props) {
                 result.data.name +
                 "/master/project.abundance?sanitize=true",
               githubMoleculesUsed: [],
+              parentRepo: owner + "/" + repo,
               svgURL:
                 "https://raw.githubusercontent.com/" +
                 GlobalVariables.currentUser +

--- a/src/molecules/molecule.js
+++ b/src/molecules/molecule.js
@@ -209,7 +209,7 @@ export default class Molecule extends Atom {
       });
     }
 
-    if (GlobalVariables.currentRepo.fork) {
+    if (GlobalVariables.currentRepo.parentRepo != null) {
       inputParams["Reload from Github"] = button(() => {
         //Future compare to main branch
         this.reloadFork();
@@ -269,18 +269,19 @@ export default class Molecule extends Atom {
 
   async reloadFork() {
     const octokit = new Octokit();
-    var owner = GlobalVariables.currentRepo.owner.login;
-    var repo = GlobalVariables.currentRepo.repoName;
+    let parent = GlobalVariables.currentRepo.parentRepo.split("/");
+    let parentOwner = parent[0];
+    let parentRepo = parent[1];
     octokit
       .request("GET /repos/{owner}/{repo}", {
-        owner: owner,
-        repo: repo,
+        owner: parentOwner,
+        repo: parentRepo,
       })
       .then((response) => {
         octokit.rest.repos
           .getContent({
-            owner: response.data.source.owner.login,
-            repo: response.data.source.name,
+            owner: response.data.owner.login,
+            repo: response.data.name,
             path: "project.abundance",
           })
           .then((response) => {


### PR DESCRIPTION
- Fixes reload from github feature for forked projects 
- Adds parentRepo, githubmolecules used attributes to project object on AWS 
- Formatting for post-new-project function

Note: This feature will not work for projects which have already been forked since the information of the parent was not stored in aws when the repo was created but if it seems important that you have that option for existing projects I can look into updating old forks to include the attribute. 
