### PR TITLE
Default Text display if no output

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -434,7 +434,6 @@ function molecule(targetID, inputID) {
   return started.then(() => {
     if (library[inputID] != undefined) {
       library[targetID] = library[inputID];
-      console.log("setting molecule library id");
     } else {
       throw new Error("output ID is undefined");
     }


### PR DESCRIPTION
- Adds a text display "No output to display" when topMolecule is selected but nothing is connected to the output
- (Doesn't yet take care of the issue where nothing is displayed when you first open a molecule. That's an issue related to when the sendToRender call is made vs when the mesh finishes computing. Will address in a future PR)
<img width="1034" alt="Screenshot 2024-09-22 at 11 59 00 AM" src="https://github.com/user-attachments/assets/a85df1fb-1649-493a-b70e-801cfa52c9ef">
