### PR TITLE
Reduce angluar tolearnce to speed up rendering

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -1536,14 +1536,14 @@ function generateDisplayMesh(id) {
           .clone()
           .extrude(0.0001);
         return {
-          faces: threeDShape.mesh(),
-          edges: threeDShape.meshEdges(),
+          faces: threeDShape.mesh({ tolerance: 0.1, angularTolerance: 0.5 }),
+          edges: threeDShape.meshEdges({ tolerance: 0.1, angularTolerance: 0.5 }),
         };
       } else {
         finalMeshes.push({
           cameraZoom: cameraZoom,
-          faces: meshgeometry.geometry.mesh(),
-          edges: meshgeometry.geometry.meshEdges(),
+          faces: meshgeometry.geometry.mesh({ tolerance: 0.1, angularTolerance: 0.5 }),
+          edges: meshgeometry.geometry.meshEdges({ tolerance: 0.1, angularTolerance: 0.5 }),
           color: meshgeometry.color,
         });
       }


### PR DESCRIPTION
This speeds up the rendering for me like 10x.

No actual impact to the shapes being generated, they are just displayed with lower resolution.