### PR TITLE
Remove pivot controls

### DIFF
--- a/src/components/render/ThreeContext.jsx
+++ b/src/components/render/ThreeContext.jsx
@@ -3,7 +3,6 @@ import { Canvas } from "@react-three/fiber";
 import {
   Wireframe,
   Grid,
-  PivotControls,
   OrthographicCamera,
 } from "@react-three/drei";
 import * as THREE from "three";
@@ -23,10 +22,6 @@ export default function ext({ children, ...props }) {
 
   const cameraRef = useRef();
   const [gridScale, setGridScale] = useState(10 / cameraZoom);
-
-  function PivotControl() {
-    return <PivotControls disableRotations={true} scale={axesScale} />;
-  }
 
   const [cellSection, setCellSection] = useState(100);
   const [axesScale, setAxesScale] = useState(0.3);
@@ -73,7 +68,6 @@ export default function ext({ children, ...props }) {
           zoom={cameraZoom}
           position={[3000, 3000, 5000]}
         />
-        {props.axesParam ? <PivotControl /> : null}
         {props.gridParam ? (
           <Grid
             position={[0, 0, 0]}


### PR DESCRIPTION
Removes the pivot controls in the middle. I found them to be kinda distracting and they keep changing size and or not actually being in the center so I think it's easier to just remove them