### PR TITLE
Re-center SVG

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -614,6 +614,7 @@ async function importingSVG(targetID, svg, width) {
     library[targetID] = {
       geometry: [drawnSVG.clone().translate(-center[0], -center[1])],
       tags: [],
+      plane: new Plane().pivot(0, "Y"),
       color: "#FF9065",
       bom: [],
     };


### PR DESCRIPTION
Tweaking svg import to recenter when it loads. For some reason it was loading way off frame. It's still not an ideal import/maybe needs better error handling but i'm going to work on fixing it.