### PR TITLE
puppeter-html : regression testing prep

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -88,10 +88,16 @@ export default function ReplicadApp() {
             });
         } else {
           /* reset mesh view if in output mode*/
+
           cad
             .resetView()
             .then((m) => {
               setWireMesh(m);
+              /* Creates an element to check with Puppeteer if the molecule is fully loaded*/
+              const invisibleDiv = document.createElement("div");
+              invisibleDiv.id = "molecule-fully-render-puppeteer";
+              invisibleDiv.style.display = "none";
+              document.body.appendChild(invisibleDiv);
             })
             .catch((e) => {
               console.error("reset view not working" + e);

--- a/src/molecules/molecule.js
+++ b/src/molecules/molecule.js
@@ -544,6 +544,7 @@ export default class Molecule extends Atom {
    */
   recomputeMolecule(outputID) {
     //super.updateValue();
+    console.log("recompute");
 
     try {
       this.processing = true;
@@ -558,10 +559,9 @@ export default class Molecule extends Atom {
         });
         if (this.selected) {
           this.sendToRender();
-        } else {
-          const loadingDots = document.querySelector(".loading");
-          loadingDots.style.display = "none";
         }
+        const loadingDots = document.querySelector(".loading");
+        loadingDots.style.display = "none";
       });
     } catch (err) {
       this.setAlert(err);


### PR DESCRIPTION
Adds an Html element when molecule's output fully loads to use as a flag that puppeteer can recognize before taking a screenshot.