### PR TITLE
change size of radius and input arrow

### DIFF
--- a/src/molecules/input.js
+++ b/src/molecules/input.js
@@ -134,7 +134,7 @@ export default class Input extends Atom {
     GlobalVariables.c.beginPath();
     GlobalVariables.c.moveTo(0, yInPixels + this.height / 2);
     GlobalVariables.c.lineTo(this.width, yInPixels + this.height / 2);
-    GlobalVariables.c.lineTo(this.width + radiusInPixels, yInPixels);
+    GlobalVariables.c.lineTo(this.width + radiusInPixels / 2, yInPixels);
     GlobalVariables.c.lineTo(this.width, yInPixels - this.height / 2);
     GlobalVariables.c.lineTo(0, yInPixels - this.height / 2);
     GlobalVariables.c.lineWidth = 1;

--- a/src/prototypes/atom.js
+++ b/src/prototypes/atom.js
@@ -47,7 +47,7 @@ export default class Atom {
      * This atom's radius as displayed on the screen is 1/72 width
      * @type {number}
      */
-    this.radius = 1 / 50;
+    this.radius = 1 / 60;
     /**
      * This atom's default color (ie when not selected or processing)
      * @type {string}


### PR DESCRIPTION
Making atoms smaller again and changing input atom shape so it will not overlap expanding bubble.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Refined the visual rendering of input elements by adjusting drawing positions for improved alignment.
	- Updated the displayed size of graphical elements for a more refined appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->