### PR TITLE
wireframe to id

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -86,11 +86,10 @@ export default function ReplicadApp() {
             activeAtom.setAlert("Can't display Mesh " + e);
           });
         /*Set wireMesh*/
-
         //Exception: Don't display the mesh if the thing we are displaying is already the output
-        if (GlobalVariables.currentMolecule.output.value != id) {
+        if (GlobalVariables.currentMolecule.uniqueID != id) {
           cad
-            .generateDisplayMesh(GlobalVariables.currentMolecule.output.value)
+            .generateDisplayMesh(GlobalVariables.currentMolecule.uniqueID)
             .then((w) => {
               setWireMesh(w);
               createPuppeteerDiv();


### PR DESCRIPTION
Ok. So... this seems to fix the issue, but I'm honestly a bit confused on why it wasn't like this before. I'm not 100% sure that this won't cause other issues when switching levels and such, because I have a feeling that the output was being used for a reason, but I can't seem to find anywhere where the output value was set since we moved away from values to ids a while ago. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the logic for updating visual elements to ensure they refresh based on a distinct identifier. This enhancement improves the consistency and accuracy of displayed visuals in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->