### PR TITLE
Extract tag bug

### DIFF
--- a/src/molecules/extracttag.js
+++ b/src/molecules/extracttag.js
@@ -88,7 +88,7 @@ export default class ExtractTag extends Atom {
 
   createLevaInputs(setInputChanged) {
     var inputID = this.findIOValue("geometry");
-    GlobalVariables.cad.extractAllTags(inputID).then((result) => {
+    GlobalVariables.cad.extractAllTags(inputID, this.tag).then((result) => {
       if (!this.arraysEqual(this.tagList, result)) {
         this.tagList = result;
         setInputChanged(this.tagList);
@@ -97,12 +97,18 @@ export default class ExtractTag extends Atom {
     let tagList = this.tagList;
     let inputParams = {};
 
-    inputParams[this.uniqueID + "tag_ops"] = {
+    inputParams[this.uniqueID + "extracting"] = {
       value: this.tag,
+      label: "Tag",
+      disabled: true,
+    };
+
+    inputParams[this.uniqueID + "tag_ops"] = {
+      value: "Select Tag",
       options: tagList,
       label: "Extract Tag",
       onChange: (value) => {
-        if (this.tag != value) {
+        if (this.tag != value && value != "Select Tag") {
           this.tag = value;
           this.updateValue();
           //this.sendToRender();

--- a/src/molecules/extracttag.js
+++ b/src/molecules/extracttag.js
@@ -48,9 +48,9 @@ export default class ExtractTag extends Atom {
     /** Selected Tag
      * @type {string}
      */
-    this.tag = "Select Tag";
+    this.tag = "";
 
-    this.tagList = ["Select Tag"];
+    this.tagList = [];
 
     this.setValues(values);
   }
@@ -82,17 +82,24 @@ export default class ExtractTag extends Atom {
   }
 
   arraysEqual(arr1, arr2) {
+    if (!arr1 || !arr2) return false;
     if (arr1.length !== arr2.length) return false;
-    return arr1.every((value, index) => value === arr2[index]);
+    for (let i = 0; i < arr1.length; i++) {
+      if (arr1[i] !== arr2[i]) return false;
+    }
+    return true;
   }
 
   createLevaInputs(setInputChanged) {
     var inputID = this.findIOValue("geometry");
+    this.processing = true;
     GlobalVariables.cad.extractAllTags(inputID, this.tag).then((result) => {
       if (!this.arraysEqual(this.tagList, result)) {
+        this.processing = true;
         this.tagList = result;
         setInputChanged(this.tagList);
       }
+      this.processing = false;
     });
     let tagList = this.tagList;
     let inputParams = {};
@@ -108,6 +115,7 @@ export default class ExtractTag extends Atom {
       options: tagList,
       label: "Extract Tag",
       onChange: (value) => {
+        setInputChanged(value);
         if (this.tag != value && value != "Select Tag") {
           this.tag = value;
           this.updateValue();

--- a/src/worker.js
+++ b/src/worker.js
@@ -393,7 +393,7 @@ function tag(targetID, inputID, TAG) {
   });
 }
 
-function extractAllTags(inputID) {
+function extractAllTags(inputID, tag) {
   return started.then(() => {
     // Recursive helper function to collect tags
     function collectTags(geometry) {
@@ -417,7 +417,10 @@ function extractAllTags(inputID) {
     }
 
     const allTags = collectTags(inputGeometry);
-    return Array.from(allTags); // Convert the Set to an array
+    let returningArray = Array.from(allTags); // Convert the Set to an array
+
+    returningArray = [...new Set(returningArray)];
+    return returningArray;
   });
 }
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -419,7 +419,7 @@ function extractAllTags(inputID, tag) {
     const allTags = collectTags(inputGeometry);
     let returningArray = Array.from(allTags); // Convert the Set to an array
 
-    returningArray = [...new Set(returningArray)];
+    returningArray = ["Select Tag", ...new Set(returningArray)];
     return returningArray;
   });
 }


### PR DESCRIPTION
Ok. So the bug is fixed. It's not a totally perfect solution since what I ended up doing to circumvent the problem was just defaulting the dropdown to always select the placeholder "Select Tag". When something is selected the value of the extracted tag does change but the text displaying above the dropdown does not dynamically change to reflect this. I could see if instead of this disabled text input I can change the molecule name like we do with tag so that the current selection is reflected on the canvas even if it's not reflected on the dropdown. 

Let me know what you think or if you encounter any issues. 

<img width="1289" alt="Screenshot 2025-04-10 at 10 22 10 PM" src="https://github.com/user-attachments/assets/ca39b28a-457e-473f-a549-f6e18ce36c72" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the tag selection interface with a clear default option, ensuring users see an intuitive prompt.
  - Updated the extraction of tag options to present a consistent, duplicate-free list.

- **Refactor**
  - Optimized tag input handling and comparison logic for improved responsiveness and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->