### PR TITLE
Fixes the "Upstream part too thick for material" bug

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -797,6 +797,7 @@ function extractKeepOut(inputGeometry) {
 function layout(
   targetID,
   inputID,
+  tag,
   progressCallback,
   placementsCallback,
   layoutConfig
@@ -835,7 +836,7 @@ function layout(
 /**
  * Lay the input geometry flat and apply the transformations to display it
  */
-function displayLayout(targetID, inputID, positions, layoutConfig) {
+function displayLayout(targetID, inputID, positions, tag, layoutConfig) {
   rotateForLayout(targetID, inputID, layoutConfig);
 
   applyLayout(targetID, inputID, positions, layoutConfig);


### PR DESCRIPTION
This was occurring for all cut layouts. There was a tag parameter in the calling code which Obob-ed all our arguments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced layout-related features to support an additional tag parameter, allowing for more flexible usage in layout operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->