### PR TITLE
Feature/remove material thickness

### DIFF
--- a/src/molecules/cutlayout.js
+++ b/src/molecules/cutlayout.js
@@ -170,7 +170,6 @@ export default class CutLayout extends Atom {
       var materialThickness = this.findIOValue("Material Thickness");
       var sheetWidth = this.findIOValue("Sheet Width");
       var sheetHeight = this.findIOValue("Sheet Height");
-      var sheetPadding = 0;//this.findIOValue("Sheet Padding"); //It's easier to just adjust the sheet size than to add padding
       var partPadding = this.findIOValue("Part Padding");
 
       if (!inputID) {
@@ -187,7 +186,6 @@ export default class CutLayout extends Atom {
             thickness: materialThickness,
             width: sheetWidth,
             height: sheetHeight,
-            sheetPadding: sheetPadding,
             partPadding: partPadding
           })
         .then((warning) => {
@@ -220,7 +218,6 @@ export default class CutLayout extends Atom {
       var materialThickness = this.findIOValue("Material Thickness");
       var sheetWidth = this.findIOValue("Sheet Width");
       var sheetHeight = this.findIOValue("Sheet Height");
-      var sheetPadding = 0;//this.findIOValue("Sheet Padding"); //It's easier to just adjust the sheet size than to add padding
       var partPadding = this.findIOValue("Part Padding");
 
       if (!inputID) {
@@ -243,7 +240,6 @@ export default class CutLayout extends Atom {
             thickness: materialThickness,
             width: sheetWidth,
             height: sheetHeight,
-            sheetPadding: sheetPadding,
             partPadding: partPadding
           })
         .then((warning) => {

--- a/src/molecules/cutlayout.js
+++ b/src/molecules/cutlayout.js
@@ -172,7 +172,6 @@ export default class CutLayout extends Atom {
       var sheetHeight = this.findIOValue("Sheet Height");
       var sheetPadding = 0;//this.findIOValue("Sheet Padding"); //It's easier to just adjust the sheet size than to add padding
       var partPadding = this.findIOValue("Part Padding");
-      var tag = "cutLayout";
 
       if (!inputID) {
         this.setAlert('"geometry" input is missing');
@@ -184,7 +183,6 @@ export default class CutLayout extends Atom {
           this.uniqueID,
           inputID,
           [this.placements],
-          tag,
           {
             thickness: materialThickness,
             width: sheetWidth,
@@ -224,7 +222,6 @@ export default class CutLayout extends Atom {
       var sheetHeight = this.findIOValue("Sheet Height");
       var sheetPadding = 0;//this.findIOValue("Sheet Padding"); //It's easier to just adjust the sheet size than to add padding
       var partPadding = this.findIOValue("Part Padding");
-      var tag = "cutLayout";
 
       if (!inputID) {
         this.setAlert('"geometry" input is missing');
@@ -235,7 +232,6 @@ export default class CutLayout extends Atom {
         .layout(
           this.uniqueID,
           inputID,
-          tag,
           proxy((progress, cancelationHandle) => {
             this.progress = progress;
             this.cancelationHandle = cancelationHandle;

--- a/src/molecules/cutlayout.js
+++ b/src/molecules/cutlayout.js
@@ -6,7 +6,16 @@ import { button, LevaInputs } from "leva";
 
 
 /**
- * The Cut Layout atom extracts a copy of each shape on the cutlist and places them optimally on a cut sheet.
+ * Rearrange all input geometries to fit on a sheet of material. Parts are packed
+ * as densely as possible while still respecting part padding. In general, all parts
+ * will be arranged to be as thin as possible, however there are some exceptions in
+ * order to fit into a sheet of stock with some uniform thickness.
+ * 
+ * Params:
+ * - geometry: The geometry or assembly to be arranged
+ * - width: The width of the sheet
+ * - height: The height of the sheet
+ * - partPadding: The padding between parts
  */
 export default class CutLayout extends Atom {
   /**
@@ -49,13 +58,6 @@ export default class CutLayout extends Atom {
 
     this.addIO("input", "geometry", this, "geometry", null);
 
-    this.addIO(
-      "input",
-      "Material Thickness",
-      this,
-      "number",
-      GlobalVariables.topLevelMolecule.unitsKey == "MM" ? 19 : 0.75
-    );
     this.addIO(
       "input",
       "Sheet Width",
@@ -167,7 +169,6 @@ export default class CutLayout extends Atom {
     if (this.inputs.every((x) => x.ready)) {
       this.processing = true;
       var inputID = this.findIOValue("geometry");
-      var materialThickness = this.findIOValue("Material Thickness");
       var sheetWidth = this.findIOValue("Sheet Width");
       var sheetHeight = this.findIOValue("Sheet Height");
       var partPadding = this.findIOValue("Part Padding");
@@ -183,10 +184,10 @@ export default class CutLayout extends Atom {
           inputID,
           [this.placements],
           {
-            thickness: materialThickness,
             width: sheetWidth,
             height: sheetHeight,
-            partPadding: partPadding
+            partPadding: partPadding,
+            units: GlobalVariables.topLevelMolecule.units[GlobalVariables.topLevelMolecule.unitsKey],
           })
         .then((warning) => {
           this.basicThreadValueProcessing();
@@ -215,7 +216,6 @@ export default class CutLayout extends Atom {
       }
       this.processing = true;
       var inputID = this.findIOValue("geometry");
-      var materialThickness = this.findIOValue("Material Thickness");
       var sheetWidth = this.findIOValue("Sheet Width");
       var sheetHeight = this.findIOValue("Sheet Height");
       var partPadding = this.findIOValue("Part Padding");
@@ -237,10 +237,10 @@ export default class CutLayout extends Atom {
             this.placements = placements[0];
           }),
           {
-            thickness: materialThickness,
             width: sheetWidth,
             height: sheetHeight,
-            partPadding: partPadding
+            partPadding: partPadding,
+            units: GlobalVariables.topLevelMolecule.units[GlobalVariables.topLevelMolecule.unitsKey],
           })
         .then((warning) => {
           this.basicThreadValueProcessing();

--- a/src/worker.js
+++ b/src/worker.js
@@ -791,7 +791,6 @@ function extractKeepOut(inputGeometry) {
  *    - thickness - thickness of the stock material
  *    - width
  *    - height - together with width specifies the demensions of the stock material
- *    - sheetPadding - space from the edge of the material where no parts will be placed
  *    - partPadding - space between parts in the resulting placement
  */
 function layout(
@@ -1030,7 +1029,7 @@ function computePositions(
   // include tolerance * 2 to ensure padding is the minimum spacing between parts.
   const configWithDefaults = nestingEngine.config({
     spacing: layoutConfig.partPadding + tolerance * 2,
-    binSpacing: layoutConfig.sheetPadding,
+    binSpacing: 0,
     populationSize: populationSize,
     exploreConcave: false, // we eventually want this to be true, but it's unsupported right now
   });


### PR DESCRIPTION
Warning: lightly tested.

Removes material thickness input from cut layout. Instead we follow 1 of 2 behaviors.

1. We can make a plausible guess at the material thickness, then run as we did before.
2. We're not sure what stock material the user might be planning for, just put every part as flat as possible.

These two vary only in how they deal with parts that are exactly the material thickness in 1 dimension and **thinner** than the material in the other. Eg: generally a skinny stick or shim. If we can guess the material thickness then it's preferable to arrange these items so that they are up on end and exactly match the material thickness.

our strategy for guessing material thickness is: arrange all parts as flatly as possible, if they'd all fit in to stock that's <= 1", then we assume the material is as thick as the thickest part when so arranged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved and expanded descriptions for layout functionality and parameters to enhance clarity for users.

- **Bug Fixes**
  - Removed the "Material Thickness" input and related options from the layout interface.
  - Adjusted part orientation and layout logic to better handle material thickness automatically, improving accuracy in part arrangement.
  - Eliminated unnecessary spacing between nested parts for more efficient sheet usage.

- **Refactor**
  - Streamlined the layout process by removing unused parameters and simplifying configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->