### PR TITLE
Fix return from run to create

### DIFF
--- a/src/components/main-routes/LoginMode.jsx
+++ b/src/components/main-routes/LoginMode.jsx
@@ -998,7 +998,9 @@ function LoginMode({
     >
       <div>
         {" "}
-        {GlobalVariables.currentRepo && isAuthenticated ? (
+        {GlobalVariables.currentRepo &&
+        GlobalVariables.currentRepo.owner == GlobalVariables.currentUser &&
+        isAuthenticated ? (
           <Link
             to={`/${GlobalVariables.currentRepo.owner}/${GlobalVariables.currentRepo.repoName}`}
           >


### PR DESCRIPTION
- Corrects link which accidentally allowed return to create mode from run even if a project wasn't owned 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the logic for displaying the "Return to project" link so it now only appears when the current user owns the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->