### PR TITLE
Gitsearch bug

### DIFF
--- a/src/components/main-routes/flowCanvas.jsx
+++ b/src/components/main-routes/flowCanvas.jsx
@@ -32,6 +32,7 @@ export default memo(function FlowCanvas({
 }) {
   /** State for github molecule search input */
   const [searchingGitHub, setSearchingGitHub] = useState(false);
+  const [gitRepos, setGitRepos] = useState([]);
 
   const canvasRef = useRef(null);
   const circleMenu = useRef(null);
@@ -218,6 +219,7 @@ export default memo(function FlowCanvas({
     } else {
       cmenu.hide();
       setSearchingGitHub(false);
+      setGitRepos([]);
 
       var clickHandledByMolecule = false;
       /*Run through all the atoms on the screen and decide if one was clicked*/
@@ -373,7 +375,9 @@ export default memo(function FlowCanvas({
       </div>
       <div>
         <div id="circle-menu1" className="cn-menu1" ref={circleMenu}></div>
-        <GitSearch {...{ searchingGitHub, setSearchingGitHub }} />
+        <GitSearch
+          {...{ searchingGitHub, setSearchingGitHub, gitRepos, setGitRepos }}
+        />
       </div>
     </>
   );

--- a/src/components/secondary/GitSearch.jsx
+++ b/src/components/secondary/GitSearch.jsx
@@ -2,9 +2,13 @@ import React, { useState, useRef } from "react";
 import GlobalVariables from "../../js/globalvariables.js";
 import topics from "../../js/maslowTopics.js";
 
-function GitSearch({ searchingGitHub, setSearchingGitHub }) {
+function GitSearch({
+  searchingGitHub,
+  setSearchingGitHub,
+  gitRepos,
+  setGitRepos,
+}) {
   let searchBarValue = "";
-  var [gitRepos, setGitRepos] = useState([]);
   var [loadingGit, setLoadingGit] = useState(false);
   const [lastKey, setLastKey] = useState("");
   const [yearShow, setYearShow] = useState("2024");
@@ -101,15 +105,16 @@ function GitSearch({ searchingGitHub, setSearchingGitHub }) {
             style={{
               top: GlobalVariables.lastClick
                 ? GlobalVariables.lastClick[1] + "px"
-                : "25%",
-              left: GlobalVariables.lastClick
+                : "37%",
+              right: GlobalVariables.lastClick
                 ? GlobalVariables.lastClick[0] + "px"
-                : "50%",
+                : "1%",
             }}
           >
             <input
               type="text"
               id="menuInput"
+              autoFocus
               //onBlur="value=''"
               onKeyDown={handleKeyDown}
               onChange={handleChange}
@@ -123,8 +128,13 @@ function GitSearch({ searchingGitHub, setSearchingGitHub }) {
             <div
               className="GitProjectInfoPanel"
               style={{
-                top: GlobalVariables.lastClick[1] - 50 + "px",
-                left: GlobalVariables.lastClick[0] - 375 + "px",
+                position: "absolute",
+                top: GlobalVariables.lastClick
+                  ? GlobalVariables.lastClick[1] + "px"
+                  : "35%",
+                left: GlobalVariables.lastClick
+                  ? GlobalVariables.lastClick[0] - 375 + "px"
+                  : "50%",
               }}
             >
               <div className="GitInfoLeft">

--- a/src/components/secondary/NewProjectPopUp.jsx
+++ b/src/components/secondary/NewProjectPopUp.jsx
@@ -319,13 +319,12 @@ const NewProjectPopUp = ({ setExportPopUp, authorizedUserOcto, exporting }) => {
       <div className="login-page export-div">
         <div className="form animate fadeInUp one">
           <button
-            style={{ width: "3%", display: "block" }}
             onClick={() => {
               setExportPopUp(false);
             }}
             className="closeButton"
           >
-            <img></img>
+            X
           </button>
           <form
             className="new-project-form"

--- a/src/molecules/molecule.js
+++ b/src/molecules/molecule.js
@@ -794,11 +794,18 @@ export default class Molecule extends Atom {
             ioValues: oldObject.ioValues,
           };
         } else {
+          let xPos = 0.5;
+          let yPos = 0.6;
+          //If there's no last click default to middle of screen
+          if (GlobalVariables.lastClick) {
+            xPos = GlobalVariables.pixelsToWidth(GlobalVariables.lastClick[0]);
+            yPos = GlobalVariables.pixelsToHeight(GlobalVariables.lastClick[1]);
+          }
           valuesToOverwriteInLoadedVersion = {
             uniqueID: newMoleculeUniqueID,
             parentRepo: item,
-            x: GlobalVariables.pixelsToWidth(GlobalVariables.lastClick[0]),
-            y: GlobalVariables.pixelsToHeight(GlobalVariables.lastClick[1]),
+            x: xPos,
+            y: yPos,
             topLevel: false,
           };
         }

--- a/src/styles/login.css
+++ b/src/styles/login.css
@@ -410,13 +410,11 @@
   position: absolute;
   top: 5px;
   right: 15px;
-  border: none;
   height: 1.5em;
   background-color: var(--settingsPopup-closeButton);
   font: 0.75em sans-serif;
-  cursor: pointer;
   margin-top: 3px;
-  border-color: var(--settingsPopup-text);
+  border-color: white;
   border-radius: 30px;
   padding: 0 15px 0 15px;
   color: var(--settingsPopup-text);

--- a/src/styles/maslowCreate.css
+++ b/src/styles/maslowCreate.css
@@ -233,12 +233,12 @@ canvas {
 .GitProjectInfoPanel {
   padding: 10px;
   display: flex;
+  position: absolute;
   background-color: var(--gitsearch-Panel-background);
   border: 2px solid #c4a3d5;
   color: rgb(10, 9, 10);
   width: 340px;
-  position: absolute;
-  left: 0px;
+  right: 360px;
   top: 100px;
   z-index: 10;
   gap: 20px;


### PR DESCRIPTION
- Changes positioning and fixes bug with github search from shortcuts 
- Clears gitlist even if no atom is placed
- Autofocus on input if gitsearch is open 
- fix new project close button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved handling of GitHub repository search results, allowing repository data to persist and be managed more effectively across components.

- **Style**
  - Updated the positioning and alignment of the GitHub search input and project info panel for a more consistent and user-friendly interface.
  - The search input now automatically focuses when opened.
  - Adjusted close button appearance in popups for clearer visual cues.
  - Modified close button styling on the login screen for improved contrast.

- **Bug Fixes**
  - Enhanced fallback positioning for loaded GitHub molecules, ensuring they appear in a sensible location even when no prior click is recorded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->