### PR TITLE
Shortcut-canvas prevent

### DIFF
--- a/src/components/main-routes/CreateMode.jsx
+++ b/src/components/main-routes/CreateMode.jsx
@@ -464,7 +464,7 @@ function CreateMode({
           ) : null}
           <ToggleRunCreate run={false} />
           {shortCutsOn ? (
-            <div id="shortcutDiv">
+            <div id="shortcutDiv" className="noselect">
               <li style={{ fontSize: "14px" }}>(CTRL +)</li>
               {Object.entries(shortCuts).map(([key, value]) => {
                 return (

--- a/src/styles/maslowCreate.css
+++ b/src/styles/maslowCreate.css
@@ -807,3 +807,14 @@ Sidebar navigation
     background-color: var(--dialog-border);
   }
 }
+
+.noselect {
+  pointer-events: none;
+  -webkit-touch-callout: none; /* iOS Safari */
+  -webkit-user-select: none; /* Safari */
+  -khtml-user-select: none; /* Konqueror HTML */
+  -moz-user-select: none; /* Old versions of Firefox */
+  -ms-user-select: none; /* Internet Explorer/Edge */
+  user-select: none; /* Non-prefixed version, currently
+                                  supported by Chrome, Edge, Opera and Firefox */
+}


### PR DESCRIPTION
Prevent interaction between the shortcut element and the canvas element when shortcuts are turned on and atoms are plance over the element

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the appearance of the keyboard shortcut list by preventing text selection and user interaction when shortcuts are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->