### PR TITLE
Add a visual display for generated gcode tool paths

### DIFF
--- a/src/components/secondary/Kirimoto.js
+++ b/src/components/secondary/Kirimoto.js
@@ -22,7 +22,7 @@ export const initKiriMoto = () => {
 };
 
 //This is the main function which runs the Kiri:Moto engine
-export const runKirimoto = (stlUrl, toolSize, passes, speed) => {
+export const runKirimoto = (stlUrl, toolSize, passes, speed, gcodeCallback) => {
   if (!kiriEngine) {
     console.error("Kiri:Moto engine is not initialized yet.");
     return;
@@ -293,6 +293,7 @@ export const runKirimoto = (stlUrl, toolSize, passes, speed) => {
     .then((eng) => eng.prepare())
     .then((eng) => eng.export())
     .then((gcode) => {
+      gcodeCallback(gcode);
       const blob = new Blob([gcode], { type: "text/plain" });
       const fileName = "output.gcode";
       saveAs(blob, fileName); // Use FileSaver.js to save the GCode file
@@ -303,5 +304,6 @@ export const runKirimoto = (stlUrl, toolSize, passes, speed) => {
     .finally(() => {
       // Clean up the temporary URL after the file is saved
       setTimeout(() => URL.revokeObjectURL(stlUrl), 1000);
+      return "This returned";
     });
 };

--- a/src/molecules/gcode.js
+++ b/src/molecules/gcode.js
@@ -137,8 +137,7 @@ export default class Gcode extends Atom {
 
     //A callback function for once the gcode is generated
     const gcodeCallback = (gcode) => {
-      console.log("Gcode generated successfully");
-      console.log(gcode);
+      GlobalVariables.cad.visualizeGcode(this.uniqueID, gcode);
     };
 
     inputParams["Download Gcode"] = button(() => runKirimoto(this.stlURL, this.findIOValue("tool size"), this.findIOValue("passes"), this.findIOValue("speed"), gcodeCallback), {});

--- a/src/molecules/gcode.js
+++ b/src/molecules/gcode.js
@@ -93,10 +93,10 @@ export default class Gcode extends Atom {
       let inputID = this.findIOValue("geometry");
 
       GlobalVariables.cad
-        .visExport(this.uniqueID, inputID, "STL")
+        .visExport(this.uniqueID+1, inputID, "STL") //What a hack, we shouldn't be using uniqueID+1 here
         .then((result) => {
           GlobalVariables.cad
-            .downExport(this.uniqueID, "STL")
+            .downExport(this.uniqueID+1, "STL")
             .then((result) => {
               this.stlURL = URL.createObjectURL(result); // Store the STL URL
             });
@@ -135,7 +135,13 @@ export default class Gcode extends Atom {
       });
     }
 
-    inputParams["Download Gcode"] = button(() => runKirimoto(this.stlURL, this.findIOValue("tool size"), this.findIOValue("passes"), this.findIOValue("speed")), {});
+    //A callback function for once the gcode is generated
+    const gcodeCallback = (gcode) => {
+      console.log("Gcode generated successfully");
+      console.log(gcode);
+    };
+
+    inputParams["Download Gcode"] = button(() => runKirimoto(this.stlURL, this.findIOValue("tool size"), this.findIOValue("passes"), this.findIOValue("speed"), gcodeCallback), {});
 
     return inputParams;
   }

--- a/src/worker.js
+++ b/src/worker.js
@@ -623,11 +623,13 @@ function visExport(targetID, inputID, fileType) {
     } else {
       finalGeometry = [fusedGeometry];
     }
-    library[targetID] = {
-      geometry: finalGeometry,
-      color: displayColor,
-      plane: library[inputID].plane,
-    };
+    if(targetID){
+      library[targetID] = {
+        geometry: finalGeometry,
+        color: displayColor,
+        plane: library[inputID].plane,
+      };
+    }
     return true;
   });
 }

--- a/src/worker.js
+++ b/src/worker.js
@@ -715,9 +715,6 @@ async function importingSVG(targetID, svg, width) {
 
 //Visualize Gcode
 function visualizeGcode(targetID, gcode) {
-  console.log("Gcode got to visualizeGcode function");
-  console.log(gcode);
-
   let currentPosition = [0, 0, 0];
   let edges = [];
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -713,6 +713,45 @@ async function importingSVG(targetID, svg, width) {
   }
 }
 
+//Visualize Gcode
+function visualizeGcode(targetID, gcode) {
+  console.log("Gcode got to visualizeGcode function");
+  console.log(gcode);
+
+  let currentPosition = [0, 0, 0];
+  let edges = [];
+
+  // Split the gcode into lines
+  const lines = gcode.split("\n");
+  lines.forEach((line) => {
+    // Only process lines that start with G0 or G1
+    if (line.startsWith("G0") || line.startsWith("G1")) {
+      // Parse the line for X, Y, Z values
+      const xMatch = line.match(/X([\d.-]+)/);
+      const yMatch = line.match(/Y([\d.-]+)/);
+      const zMatch = line.match(/Z([\d.-]+)/);
+
+      // Update coordinates if found, otherwise keep the previous value
+      let x = xMatch ? Number(xMatch[1]) : currentPosition[0];
+      let y = yMatch ? Number(yMatch[1]) : currentPosition[1];
+      let z = zMatch ? Number(zMatch[1]) : currentPosition[2];
+
+      edges.push(replicad.makeLine(currentPosition, [x, y, z]));
+      currentPosition = [x, y, z];
+    }
+  });
+
+  // Create a wire from the edges
+  const wire = replicad.assembleWire(edges);
+  library[targetID] = {
+    geometry: [wire],
+    tags: [],
+    plane: new Plane().pivot(0, "Y"),
+    color: defaultColor,
+    bom: [],
+  };
+}
+
 const prettyProjection = (shape) => {
   const bbox = shape.boundingBox;
   const center = bbox.center;
@@ -1901,4 +1940,5 @@ expose({
   loftShapes,
   text,
   resetView,
+  visualizeGcode,
 });


### PR DESCRIPTION
It's a work in progress, but this adds basic visualization for generated gcode tool paths.

<img width="974" alt="image" src="https://github.com/user-attachments/assets/fc4dca13-0f3a-4f04-a3a8-c303f3c38b77" />

Right now they are not aligned with the original shape which is not ideal, and there are still issues with stock thickness and the number of passes.