### PR TITLE
Input - expand/unexpand bug fix 

### DIFF
--- a/src/molecules/input.js
+++ b/src/molecules/input.js
@@ -86,18 +86,19 @@ export default class Input extends Atom {
      * The x position of the atom
      * @type {number}
      */
-    this.x = 0.04;
+    this.x = GlobalVariables.atomSize * 1.65;
     this.radius = GlobalVariables.atomSize * 1.3;
 
     let xInPixels = GlobalVariables.widthToPixels(this.x);
     let yInPixels = GlobalVariables.heightToPixels(this.y);
     let radiusInPixels = GlobalVariables.widthToPixels(this.radius);
+
     /**
      * Relates height to radius
      * @type {number}
      */
     this.height = radiusInPixels;
-    this.width = this.height * 2.5;
+    this.width = radiusInPixels * 2.5;
     //Check if the name has been updated
     if (this.name != this.oldName) {
       this.updateParentName();
@@ -125,17 +126,17 @@ export default class Input extends Atom {
       this.color = this.defaultColor;
       this.strokeColor = this.selectedColor;
     }
-    
+
     // Draw the inputs
     this.inputs.forEach((input) => {
       input.draw();
     });
-    
+
     // Draw the output
     if (this.output) {
       this.output.draw();
     }
-    
+
     GlobalVariables.c.beginPath();
     GlobalVariables.c.moveTo(0, yInPixels + this.height / 2);
     GlobalVariables.c.lineTo(this.width, yInPixels + this.height / 2);

--- a/src/prototypes/attachmentpoint.js
+++ b/src/prototypes/attachmentpoint.js
@@ -302,7 +302,11 @@ export default class AttachmentPoint {
     if (this.type == "input") {
       this.x = this.parentMolecule.x - this.parentMolecule.radius;
     } else {
-      this.x = this.parentMolecule.x + this.parentMolecule.radius;
+      if (this.parentMolecule.atomType == "Input") {
+        this.x = GlobalVariables.atomSize * 3.5;
+      } else {
+        this.x = this.parentMolecule.x + this.parentMolecule.radius;
+      }
     }
     [this.x, this.y] = GlobalVariables.constrainToCanvasBorders(this.x, this.y);
   }

--- a/src/prototypes/attachmentpoint.js
+++ b/src/prototypes/attachmentpoint.js
@@ -319,7 +319,6 @@ export default class AttachmentPoint {
     );
 
     if (this.type == "output") {
-      console.log(this.parentMolecule);
       if (this.parentMolecule.atomType == "Input") {
         return [GlobalVariables.atomSize * 4, this.parentMolecule.y];
       } else {


### PR DESCRIPTION
This should fix #333 by relating the x of the input atom to the variable size of the atoms which can be changed by the user.
Input is a special case for attachment point since it's shape is rectangular and not circular and such needs a different expand and retract radius than other outputs.