### PR TITLE
Atoms placed are selected by default

### DIFF
--- a/src/molecules/molecule.js
+++ b/src/molecules/molecule.js
@@ -958,6 +958,10 @@ export default class Molecule extends Atom {
 
             atom.updateValue();
             const flowCanvas = document.querySelector("#flow-canvas");
+            if (!flowCanvas) {
+              console.warn("Flow canvas element not found");
+              return;
+            }
             const mouseDownEvent = new MouseEvent("mousedown", {
               bubbles: true,
               cancelable: true,


### PR DESCRIPTION
Fixes #334 

This feels a bit hacky but what this PR does is simulate a click event for React to change the activeAtom state, so that the element is properly selected (including showing the correct menu) when it is placed. However, it does not focus the cursor on the menu.