### PR TITLE
Code molecule

### DIFF
--- a/src/components/secondary/codeWindow.jsx
+++ b/src/components/secondary/codeWindow.jsx
@@ -52,6 +52,7 @@ export default function CodeWindow(props) {
       semi: "error",
       "callback-return": "off",
     },
+
   };
 
   return (
@@ -60,6 +61,17 @@ export default function CodeWindow(props) {
         width="100%"
         height="500px"
         extensions={[
+          keymap.of({
+            key: "Mod-s",
+            run: () => {
+              console.log("mod-s pressed, attempting to save code");
+              if (props.activeAtom != null) {
+                props.activeAtom.saveCode();
+              }
+              return true;
+            },
+            preventDefault: true,
+          }),
           langs.javascript(),
           linter(
             esLint(new eslint.Linter(), {

--- a/src/molecules/code.js
+++ b/src/molecules/code.js
@@ -250,6 +250,34 @@ export default class Code extends Atom {
    * This function reads the string of inputs the user specifies and adds them to the atom.
    */
   parseInputs(ready = true) {
+/*    try {
+      const sourceFile = ts.createSourceFile(
+        "temp.ts",
+        this.code,
+        ts.ScriptTarget.Latest,
+        true
+      );
+
+      const atomFuncArguments = [];
+
+      const visitNode = (node) => {
+        if (ts.isFunctionDeclaration(node) && node.name?.text === "AtomFunc") {
+          node.parameters.forEach((param) => {
+            const paramName = param.name.getText();
+            const paramType = param.type ? param.type.getText() : "any";
+            atomFuncArguments.push({ name: paramName, type: paramType });
+          });
+        }
+        ts.forEachChild(node, visitNode);
+      };
+
+      visitNode(sourceFile);
+
+      console.log("AtomFunc arguments:", atomFuncArguments);
+    } catch (err) {
+      console.error("Error parsing TypeScript code:", err.message);
+    }*/
+
     //Parse this.code for the line "\nmain(input1, input2....) and add those as inputs if needed
     var variables = /Inputs:\[\s*([^)]+?)\s*\]/.exec(this.code);
 
@@ -327,15 +355,15 @@ export default class Code extends Atom {
     const saveCodeButton = document.getElementById("save-code-button");
     saveCodeButton.click();
 
+   // CreateMode.saveProject(CreateMode.setSaveState, "Code Save");
     document.getElementById("");
+  }
 
-    loadFile(type) {
-      var f = document.getElementById("fileLoaderInput");
-      f.accept = "." + type.toLowerCase();
-      f.click();
-      this.type = type;
-    }
-  
+  loadFile(type) {
+    var f = document.getElementById("fileLoaderInput");
+    f.accept = "." + type.toLowerCase();
+    f.click();
+    this.type = type;
   }
 
   /**

--- a/src/molecules/code.js
+++ b/src/molecules/code.js
@@ -250,34 +250,6 @@ export default class Code extends Atom {
    * This function reads the string of inputs the user specifies and adds them to the atom.
    */
   parseInputs(ready = true) {
-/*    try {
-      const sourceFile = ts.createSourceFile(
-        "temp.ts",
-        this.code,
-        ts.ScriptTarget.Latest,
-        true
-      );
-
-      const atomFuncArguments = [];
-
-      const visitNode = (node) => {
-        if (ts.isFunctionDeclaration(node) && node.name?.text === "AtomFunc") {
-          node.parameters.forEach((param) => {
-            const paramName = param.name.getText();
-            const paramType = param.type ? param.type.getText() : "any";
-            atomFuncArguments.push({ name: paramName, type: paramType });
-          });
-        }
-        ts.forEachChild(node, visitNode);
-      };
-
-      visitNode(sourceFile);
-
-      console.log("AtomFunc arguments:", atomFuncArguments);
-    } catch (err) {
-      console.error("Error parsing TypeScript code:", err.message);
-    }*/
-
     //Parse this.code for the line "\nmain(input1, input2....) and add those as inputs if needed
     var variables = /Inputs:\[\s*([^)]+?)\s*\]/.exec(this.code);
 
@@ -354,9 +326,6 @@ export default class Code extends Atom {
   saveCode() {
     const saveCodeButton = document.getElementById("save-code-button");
     saveCodeButton.click();
-
-   // CreateMode.saveProject(CreateMode.setSaveState, "Code Save");
-    document.getElementById("");
   }
 
   loadFile(type) {

--- a/src/molecules/code.js
+++ b/src/molecules/code.js
@@ -63,7 +63,7 @@ export default class Code extends Atom {
       //We can also create a new shape from scratch\n\
       let createdRectangle = replicad.drawRectangle(5,7)\n\
       //This is the plane we are going to put our new shape on\n\
-      const newPlane = new Plane().pivot(0, 'Y');\n\
+      const newPlane = new replicad.Plane().pivot(0, 'Y');\n\
       //And we extrude the shape to make it 3D\n\
       let createdShape = createdRectangle.sketchOnPlane(newPlane).extrude(height)\n\
       \n\
@@ -326,6 +326,16 @@ export default class Code extends Atom {
   saveCode() {
     const saveCodeButton = document.getElementById("save-code-button");
     saveCodeButton.click();
+
+    document.getElementById("");
+
+    loadFile(type) {
+      var f = document.getElementById("fileLoaderInput");
+      f.accept = "." + type.toLowerCase();
+      f.click();
+      this.type = type;
+    }
+  
   }
 
   /**


### PR DESCRIPTION
Minor improvements for the code molecule. No longer use eval, instead use a supposedly safer approach of wrapping the code in a function def and executing that. Also adds some banned keywords to the code molecule. We probably want to reduce this list at some point (eg: it currently includes 'import' but we probably eventually want to allow users to import external libraries).

Ideally we'd have a user warning with override option whenever a banned keyword is found.

Only other change,
ctrl+s (or cmd+s) inside the editor now saves the code instead of opening a save-to-file prompt from the browser. Notably, this does not trigger a save of the project though it maybe should.