### PR TITLE
Allow /Function Within Code Atom

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -618,7 +618,6 @@ function validateUserCode(code) {
     // TODO(tristan): we may not actually want to ban all of these.
     // but leaving them for now, until we have a way to warn and override
     /eval\s*\(/,
-    /Function\s*\(/,
     /import\s*\(/,
     /require\s*\(/,
     /process\s*\./,


### PR DESCRIPTION
It was not allowed as a dangerous pattern, but it doesn't seem that dangerous and it's very helpful or even necessary when interacting with replicad functions which call for a function pointer.