### PR TITLE
Fix double click break

### DIFF
--- a/src/components/main-routes/flowCanvas.jsx
+++ b/src/components/main-routes/flowCanvas.jsx
@@ -186,7 +186,7 @@ export default memo(function FlowCanvas({
         GlobalVariables.currentMolecule.nodesOnTheScreen.forEach((atom) => {
           atom.selected = false;
         });
-        
+
         GlobalVariables.atomsSelected.forEach((item) => {
           let newAtomID = GlobalVariables.generateUniqueID();
           item.uniqueID = newAtomID;
@@ -313,7 +313,11 @@ export default memo(function FlowCanvas({
       var clickHandledByMolecule = false;
       /*Run through all the atoms on the screen and decide if one was clicked*/
       // Iterate in reverse order to give priority to newer atoms
-      for (let i = GlobalVariables.currentMolecule.nodesOnTheScreen.length - 1; i >= 0; i--) {
+      for (
+        let i = GlobalVariables.currentMolecule.nodesOnTheScreen.length - 1;
+        i >= 0;
+        i--
+      ) {
         const molecule = GlobalVariables.currentMolecule.nodesOnTheScreen[i];
         let atomClicked;
 
@@ -375,12 +379,13 @@ export default memo(function FlowCanvas({
     }
 
     // Iterate in reverse order to give priority to newer atoms
-    for (let i = GlobalVariables.currentMolecule.nodesOnTheScreen.length - 1; i >= 0; i--) {
+    for (
+      let i = GlobalVariables.currentMolecule.nodesOnTheScreen.length - 1;
+      i >= 0;
+      i--
+    ) {
       const molecule = GlobalVariables.currentMolecule.nodesOnTheScreen[i];
       const handled = molecule.doubleClick(event.clientX, event.clientY);
-      if (handled) {
-        break; // Stop processing once an atom handles the double click
-      }
     }
     setActiveAtom(GlobalVariables.currentMolecule);
   };


### PR DESCRIPTION
A break in double click was preventing molecules from being entered. Removing the break fixes the issue.