### PR TITLE
Correct gitsearch and panel position 

### DIFF
--- a/src/components/main-routes/flowCanvas.jsx
+++ b/src/components/main-routes/flowCanvas.jsx
@@ -34,6 +34,7 @@ export default memo(function FlowCanvas({
   const [searchingGitHub, setSearchingGitHub] = useState(false);
   const [isHovering, setIsHovering] = useState(false);
   const [search, setSearch] = useState("");
+  const [isShortcut, setIsShortcutTriggered] = useState(false);
 
   const canvasRef = useRef(null);
   const circleMenu = useRef(null);
@@ -172,11 +173,11 @@ export default memo(function FlowCanvas({
 
     if (GlobalVariables.ctrlDown && shortCuts.hasOwnProperty([e.key])) {
       e.preventDefault();
-      //Undo
+      // Undo
       if (e.key == "z") {
         GlobalVariables.currentMolecule.undo();
       }
-      //Copy & Paste
+      // Copy & Paste
       if (e.key == "c") {
         GlobalVariables.atomsSelected = [];
         GlobalVariables.currentMolecule.copy();
@@ -200,9 +201,10 @@ export default memo(function FlowCanvas({
         });
       }
 
-      //Opens menu to search for github molecule
+      // Opens menu to search for GitHub molecule
       if (e.key == "g") {
         setSearchingGitHub(true);
+        setIsShortcutTriggered(true); // Set the shortcut flag
         GlobalVariables.ctrlDown = false;
       } else {
         GlobalVariables.currentMolecule.placeAtom(
@@ -307,6 +309,7 @@ export default memo(function FlowCanvas({
     } else {
       cmenu.hide();
       setSearchingGitHub(false);
+      setIsShortcutTriggered(false);
       setIsHovering(false);
       setSearch("");
 
@@ -520,6 +523,8 @@ export default memo(function FlowCanvas({
             setSearchingGitHub,
             isHovering,
             setIsHovering,
+            isShortcut,
+            setIsShortcutTriggered,
           }}
         />
       </div>

--- a/src/components/secondary/GitSearch.jsx
+++ b/src/components/secondary/GitSearch.jsx
@@ -266,6 +266,33 @@ function GitSearch({
     };
   };
 
+  const calculateSearchPosition = () => {
+    if (!GlobalVariables.lastClick) {
+      return { left: "75%", top: "37%" };
+    }
+
+    const clickX = GlobalVariables.lastClick[0];
+    const clickY = GlobalVariables.lastClick[1];
+    const searchWidth = 210; // Width from CSS
+    const margin = 20; // Minimum margin between elements
+
+    // Get viewport width and calculate maximum allowed position
+    const viewportWidth = window.innerWidth;
+    const maxLeft = viewportWidth - searchWidth - margin;
+
+    // Calculate left position
+    let left = clickX;
+    if (left + searchWidth > viewportWidth - margin) {
+      left = maxLeft;
+    }
+    left = Math.max(left, margin);
+
+    return {
+      left: left + "px",
+      top: clickY + "px",
+    };
+  };
+
   const GitList = function () {
     const localAtoms = getFilteredLocalAtoms(debouncedSearchTerm);
     
@@ -367,12 +394,8 @@ function GitSearch({
           <div
             id="git_search"
             style={{
-              top: GlobalVariables.lastClick
-                ? GlobalVariables.lastClick[1] + "px"
-                : "37%",
-              left: GlobalVariables.lastClick
-                ? GlobalVariables.lastClick[0] + "px"
-                : "75%",
+              position: "absolute",
+              ...calculateSearchPosition(),
             }}
           >
             <input

--- a/src/components/secondary/GitSearch.jsx
+++ b/src/components/secondary/GitSearch.jsx
@@ -293,9 +293,8 @@ function GitSearch({
 
   const calculateSearchPosition = (isShortcut) => {
     if (isShortcut) {
-      console.log(GlobalVariables.canvas.current.height);
-      console.log("Shortcut activated, positioning search box at bottom right");
-      const margin = 20; // Minimum margin between elements
+      const marginLeft = 30; // Minimum margin between elements
+      const marginTop = 10; // Minimum margin between elements
       const searchWidth = 210; // Width from CSS
       const searchHeight = 50; // Approximate height of the search box
 
@@ -303,8 +302,8 @@ function GitSearch({
       const canvasHeight = GlobalVariables.canvas.current.height;
 
       return {
-        left: viewportWidth - searchWidth - margin + "px",
-        top: canvasHeight - searchHeight - margin + "px",
+        left: viewportWidth - searchWidth - marginLeft + "px",
+        top: canvasHeight - searchHeight - marginTop + "px",
       };
     }
 

--- a/src/components/secondary/GitSearch.jsx
+++ b/src/components/secondary/GitSearch.jsx
@@ -230,64 +230,34 @@ function GitSearch({
 
   // Calculate smart positioning for the info panel to avoid overlap
   const calculatePanelPosition = () => {
-    if (!GlobalVariables.lastClick) {
+    const gitSearchElement = document.getElementById("git_search");
+    if (!gitSearchElement) {
       return { left: "50%", top: "35%" };
     }
 
-    const clickX = GlobalVariables.lastClick[0];
-    const clickY = GlobalVariables.lastClick[1];
+    const searchRect = gitSearchElement.getBoundingClientRect();
     const panelWidth = 340; // Width from CSS
-    const searchInputWidth = 210; // Width from CSS
-    const margin = 20; // Minimum margin between elements
+    const margin = 30; // Minimum margin between elements
 
-    // Get viewport width and calculate maximum allowed panel position
     const viewportWidth = window.innerWidth;
     const maxPanelLeft = viewportWidth - panelWidth - margin;
 
-    // Calculate search input position (it's positioned at clickX)
-    const searchInputLeft = clickX;
-    const searchInputRight = searchInputLeft + searchInputWidth;
+    // Try to position panel to the right of the search box
+    let panelLeft = searchRect.right + margin;
 
-    // Try to position panel to the left first (original behavior)
-    let panelLeft = clickX - panelWidth - margin;
-
-    // Check if panel would go off the left edge or overlap with search input
-    if (panelLeft < margin) {
-      // Try positioning to the right of the search input
-      panelLeft = searchInputRight + margin;
-
-      // Check if it goes off the right edge
-      if (panelLeft + panelWidth > viewportWidth - margin) {
-        // Find the best available position
-        const leftSpace = searchInputLeft - margin;
-        const rightSpace = viewportWidth - searchInputRight - margin;
-
-        if (leftSpace >= panelWidth) {
-          // Fit on the left with proper spacing
-          panelLeft = margin;
-        } else if (rightSpace >= panelWidth) {
-          // Fit on the right with proper spacing
-          panelLeft = searchInputRight + margin;
-        } else {
-          // Choose the side with more space, but ensure we never exceed viewport
-          if (leftSpace >= rightSpace) {
-            // Position at the leftmost safe position
-            panelLeft = margin;
-          } else {
-            // Position as far right as possible without exceeding viewport
-            panelLeft = Math.min(searchInputRight + margin, maxPanelLeft);
-          }
-        }
-      }
+    // Check if it goes off the right edge
+    if (panelLeft + panelWidth > viewportWidth - margin) {
+      // Position to the left of the search box
+      panelLeft = searchRect.left - panelWidth - margin;
     }
 
-    // Final safety check: ensure panel never extends beyond viewport
+    // Ensure panel does not extend beyond viewport
     panelLeft = Math.min(panelLeft, maxPanelLeft);
     panelLeft = Math.max(panelLeft, margin);
 
     return {
       left: panelLeft + "px",
-      top: clickY + "px",
+      top: searchRect.top + "px",
     };
   };
 


### PR DESCRIPTION
Fixes #508 

- Makes github search determine whether the trigger was a shortcut and position accordingly.
- Prevents gitsearch from extending past canvas width
- Makes gitInfoPanel reference gitsearch div position instead of last click position. 