### PR TITLE
Copy maintain connectors + new cmmd + m move to molecule feature

### DIFF
--- a/src/components/main-routes/flowCanvas.jsx
+++ b/src/components/main-routes/flowCanvas.jsx
@@ -167,7 +167,6 @@ export default memo(function FlowCanvas({
       // Trigger GitSearch when Shift is pressed
       setSearchingGitHub(true);
       setIsShortcutTriggered(true); // Set the shortcut flag
-      GlobalVariables.ctrlDown = false;
     }
 
     if (GlobalVariables.ctrlDown && shortCuts.hasOwnProperty([e.key])) {
@@ -231,7 +230,7 @@ export default memo(function FlowCanvas({
 
           // Place atoms first
           const atomPromises = [];
-          if (remappedData && remappedData.allAtoms) {
+          if (remappedData?.allAtoms) {
             remappedData.allAtoms.forEach((atomData) => {
               const promise = GlobalVariables.currentMolecule.placeAtom(
                 atomData,
@@ -243,7 +242,7 @@ export default memo(function FlowCanvas({
 
           // Wait for all atoms to be placed, then place connectors
           Promise.all(atomPromises).then(() => {
-            if (remappedData && remappedData.allConnectors) {
+            if (remappedData?.allConnectors) {
               remappedData.allConnectors.forEach((connectorData) => {
                 GlobalVariables.currentMolecule.placeConnector(connectorData);
               });

--- a/src/molecules/molecule.js
+++ b/src/molecules/molecule.js
@@ -503,7 +503,7 @@ export default class Molecule extends Atom {
     const remappedData = targetMolecule.remapIDs(moleculeData);
 
     // Place atoms in target molecule
-    if (remappedData && remappedData.allAtoms) {
+    if (remappedData?.allAtoms) {
       const atomPromises = [];
       remappedData.allAtoms.forEach((atomData) => {
         const promise = targetMolecule.placeAtom(atomData, true);


### PR DESCRIPTION
This pull request introduces enhancements to the copy method allowing for copying to maintain connectors intact. It also introduces CMMD+M as a new feature which allows for selected atoms to be dropped into a new molecule.

- Added copyWithConnectors method to allow copying atoms along with their internal connectors.
- Improved the moveSelectedAtomsToMolecule method to support moving selected atoms and their connectors into a new or existing molecule.
- Enhanced placeConnector to handle connector placement more robustly.
- Added support for enhanced copy (Ctrl+C) and paste (Ctrl+V) operations, including connectors.
Introduced a shortcut (Ctrl+M) to move selected atoms into a new molecule.

-Fixes #476 
-Disables box selection behavior which will be reenabled in following PR. 
- Still displays minor errors when an atom with multiple connectors like assembly is copied 

