### PR TITLE
Import leva menu update

### DIFF
--- a/src/components/secondary/ParameterEditor.jsx
+++ b/src/components/secondary/ParameterEditor.jsx
@@ -89,7 +89,6 @@ export default (function ParamsEditor({
           set({
             [activeAtom.uniqueID + "Loaded File"]: fileName,
           });
-          // Perform additional actions after the file is loaded
         }
       );
     });

--- a/src/components/secondary/ParameterEditor.jsx
+++ b/src/components/secondary/ParameterEditor.jsx
@@ -80,6 +80,25 @@ export default (function ParamsEditor({
       disabled: true,
     };
   }
+  if (activeAtom.atomType == "Import") {
+    inputParamsConfig["Load File"] = button(() => {
+      activeAtom.loadFile(
+        activeAtom.importOptions[activeAtom.importIndex],
+        (fileName) => {
+          console.log(`File loaded successfully: ${fileName}`);
+          set({
+            [activeAtom.uniqueID + "Loaded File"]: fileName,
+          });
+          // Perform additional actions after the file is loaded
+        }
+      );
+    });
+    inputParamsConfig[activeAtom.uniqueID + "Loaded File"] = {
+      value: "", //href to the file
+      label: "Loaded File",
+      disabled: true,
+    };
+  }
 
   /** Creates Leva panel with parameters from active atom inputs */
 

--- a/src/components/secondary/ParameterEditor.jsx
+++ b/src/components/secondary/ParameterEditor.jsx
@@ -94,7 +94,7 @@ export default (function ParamsEditor({
       );
     });
     inputParamsConfig[activeAtom.uniqueID + "Loaded File"] = {
-      value: "", //href to the file
+      value: activeAtom.fileName ? activeAtom.fileName : "", //href to the file
       label: "Loaded File",
       disabled: true,
     };

--- a/src/molecules/import.js
+++ b/src/molecules/import.js
@@ -57,6 +57,10 @@ export default class Import extends Atom {
 
     this.addIO("output", "geometry", this, "geometry", "");
 
+    this.importOptions = ["SVG", "STL", "STEP"];
+
+    this.importIndex = 0;
+
     this.setValues(values);
   }
 
@@ -173,19 +177,16 @@ export default class Import extends Atom {
   createLevaInputs() {
     let inputParams = {};
     if (this.fileName == null) {
-      const importOptions = ["STL", "SVG", "STEP"];
-      let importIndex = 0;
-
       inputParams[this.uniqueID + "file_ops"] = {
-        options: importOptions,
+        options: this.importOptions,
         label: "File Type",
         onChange: (value) => {
-          importIndex = importOptions.indexOf(value);
+          this.importIndex = this.importOptions.indexOf(value);
         },
       };
-      inputParams["Load File"] = button(() =>
+      /*inputParams["Load File"] = button(() =>
         this.loadFile(importOptions[importIndex])
-      );
+      );*/
     } else {
       if (this.type == "SVG") {
         inputParams["Width"] = {
@@ -198,23 +199,26 @@ export default class Import extends Atom {
           },
         };
       }
-      inputParams["Loaded File"] = {
-        value: this.fileName, //href to the file
-        label: "Loaded File",
-        disabled: true,
-      };
     }
-
     return inputParams;
   }
   /**
    * Creates an input element to load a file and calls import function in CreateMode
    */
-  loadFile(type) {
+  loadFile(type, onLoadComplete) {
     var f = document.getElementById("fileLoaderInput");
     f.accept = "." + type.toLowerCase();
+    f.onchange = (event) => {
+      const file = event.target.files[0];
+      if (file) {
+        this.type = type;
+        this.fileName = file.name; // Set the filename
+        if (onLoadComplete) {
+          onLoadComplete(file.name); // Trigger the callback with the filename
+        }
+      }
+    };
     f.click();
-    this.type = type;
   }
 
   /**
@@ -231,6 +235,7 @@ export default class Import extends Atom {
    * Update the file, filename and sha of the atom
    */
   updateFile(file, sha) {
+    console.log("Updating file", file, sha);
     this.fileName = file.name;
     this.sha = sha;
     if (

--- a/src/molecules/import.js
+++ b/src/molecules/import.js
@@ -184,9 +184,6 @@ export default class Import extends Atom {
           this.importIndex = this.importOptions.indexOf(value);
         },
       };
-      /*inputParams["Load File"] = button(() =>
-        this.loadFile(importOptions[importIndex])
-      );*/
     } else {
       if (this.type == "SVG") {
         inputParams["Width"] = {

--- a/src/molecules/import.js
+++ b/src/molecules/import.js
@@ -235,7 +235,6 @@ export default class Import extends Atom {
    * Update the file, filename and sha of the atom
    */
   updateFile(file, sha) {
-    console.log("Updating file", file, sha);
     this.fileName = file.name;
     this.sha = sha;
     if (


### PR DESCRIPTION
This pull request takes care of updating the leva menu on the import atom if a file has been updated. It allows the user to immediately see the name of the file that has been uploaded and leaves the load button enabled allowing for a different upload to the atom. 
A subsequent pull request will address some issues with files not being deleted from the repo as well as user alerts letting them know the import has been deleted. 
Fixes #581 