### PR TITLE
Delete Doubling File Import

### DIFF
--- a/src/molecules/import.js
+++ b/src/molecules/import.js
@@ -208,10 +208,20 @@ export default class Import extends Atom {
     f.onchange = (event) => {
       const file = event.target.files[0];
       if (file) {
+        // If a previous file exists, delete it
+        if (this.fileName && this.sha) {
+          console.log(`Deleting previous file: ${this.fileName}`);
+          const deleteInput = document.getElementById("fileDeleteInput");
+          deleteInput.value = this.fileName;
+          deleteInput.setAttribute("data-sha", this.sha);
+          deleteInput.click();
+        }
+
         this.type = type;
-        this.fileName = file.name; // Set the filename
+        this.fileName = file.name; // Set the new filename
+
         if (onLoadComplete) {
-          onLoadComplete(file.name); // Trigger the callback with the filename
+          onLoadComplete(file.name); // Trigger the callback with the new filename
         }
       }
     };


### PR DESCRIPTION
This PR adds logic to the fileupload in the import atom that deletes the previous file if a new file is uploaded to the same atom preventing stale files being left in the user's repository.