### PR TITLE
Puppeteer import failure fix

### DIFF
--- a/Puppet/index.js
+++ b/Puppet/index.js
@@ -1,14 +1,11 @@
-//ENTER YOUR GITHUB CREDENTIALS TO TEST PUPPETEER AND CHANGE PROJECTS TO TEST TO PROJECTS THAT EXIST FOR THAT SPECIFIC USER
-
-//const envUserValue = "";
-//const envPassValue = "";
-
-const projectUser = "moatmaslow";
-
 import puppeteer from "puppeteer";
 import projects_to_test from "./projects_to_test.js";
-// Get the current date
+import path from "path";
+import { fileURLToPath } from "url";
+
+const projectUser = "moatmaslow";
 const currentDate = new Date().toISOString().split("T")[0];
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Launch the browser and open a new blank page
 //for each project in projects to test launch puppeteer
@@ -100,7 +97,6 @@ async function loadPuppeteerAndExec(browser, date) {
 
   // Navigate to main.html
   try {
-    const path = require("path");
     await page.goto(`file:${path.join(__dirname, "main.html")}`);
     console.log("navigated to: main.html");
     await page.screenshot({

--- a/Puppet/projects_to_test.js
+++ b/Puppet/projects_to_test.js
@@ -1,7 +1,3 @@
 const projects_to_test = ["Laundry-Shelf", "Wall-Anchor"];
 
-if (typeof module !== "undefined" && module.exports) {
-  module.exports = projects_to_test;
-} else {
-  window.projects_to_test = projects_to_test;
-}
+export default projects_to_test;


### PR DESCRIPTION
This pull request is trying to address this error appearing in run npm test. It is unclear to me why the tests were passing before and in the most recent PRs this error started appearing but hopefully changing the erring file to import ES Modules takes care of it.

`Run npm test

> replicad-app-example@0.14.6 test
> node Puppet/index.js

file:///home/runner/work/Abundance/Abundance/Puppet/index.js:8
const puppeteer = require("puppeteer");
                  ^

ReferenceError: require is not defined in ES module scope, you can use import instead
This file is being treated as an ES module because it has a '.js' file extension and '/home/runner/work/Abundance/Abundance/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
    at file:///home/runner/work/Abundance/Abundance/Puppet/index.js:8:19
    at ModuleJob.run (node:internal/modules/esm/module_job:263:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:540:24)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)

Node.js v20.19.3`