### PR TITLE
Move worker.js so it can start to be deomposed

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,7 +14,7 @@ import GlobalVariables from "./js/globalvariables.js";
 import LoginMode from "./components/main-routes/LoginMode.jsx";
 import RunMode from "./components/main-routes/RunMode.jsx";
 import CreateMode from "./components/main-routes/CreateMode.jsx";
-import cadWorker from "./worker.js?worker";
+import cadWorker from "./worker/worker.js?worker";
 import { button } from "leva";
 import { QueryClient, QueryClientProvider } from "react-query";
 import Callback from "./components/main-routes/CallBack.jsx";

--- a/src/prototypes/atom.js
+++ b/src/prototypes/atom.js
@@ -355,9 +355,9 @@ export default class Atom {
    * @returns
    */
   alertingErrorHandler() {
-    console.log("Error in atom: " + this.name);
     return (err) => {
       this.processing = false;
+      console.log("Error in atom: " + this.name);
       console.log(err);
       this.setError(err.message || "Unkown error occurred");
     };

--- a/src/worker/actions.js
+++ b/src/worker/actions.js
@@ -1,10 +1,11 @@
 import * as util from "./util.js";
 
 /**
- * Extrudes a 2D sketch to create a 3D geometry with the specified height and stores it in the library.
- * @param {string} toExtrude - An Assembly whose components will be extruded. Must contain only 2D sketches
- * @param {number} height - The height to extrude the sketch(es)
- * @returns {Promise<Object>} An Assembly containing the extruded geometries
+ * Methods in this file act on a single geometry and return a modified copy of it.
+ */
+
+/**
+ * Extrudes a 2D sketch to create a 3D geometry with the specified height and returns the result.
  */
 function extrude(toExtrude, height) {
   return util.actOnLeafs(toExtrude, (leaf) => {
@@ -23,12 +24,6 @@ function extrude(toExtrude, height) {
 /**
  * Moves a geometry by the specified x, y, and z distances. If the geometry is 2D, then it's plane
  * will be translated by the specified z distance.
- *
- * @param {Object} toMove - The assembly to be moved
- * @param {number} x - The distance to move along the x-axis
- * @param {number} y - The distance to move along the y-axis
- * @param {number} z - The distance to move along the z-axis
- * @returns {Promise<Object>} A promise that resolves to the moved geometry
  */
 function move(toMove, x, y, z) {
   if (util.is3D(toMove)) {
@@ -65,11 +60,6 @@ function move(toMove, x, y, z) {
 /**
  * Function to rotate a geometry around the x, y, and z axis. If toRotate is 2D, it's plane will be
  * rotated based on the x and y inputs, while it will be rotated within the plane according to the z input.
- * @param {Object} toRotate - The geometry to rotate
- * @param {number} x - The angle to rotate around the x axis
- * @param {number} y - The angle to rotate around the y axis
- * @param {number} z - The angle to rotate around the z axis
- * @returns {Promise<Object>} A promise that resolves to the rotated geometry
  **/
 async function rotate(toRotate, x, y, z) {
   if (util.is3D(toRotate)) {
@@ -102,10 +92,7 @@ async function rotate(toRotate, x, y, z) {
 }
 
 /**
- * Scales a geometry by the specified scale factor.
- * @param {Object} geom - The geometry to scale
- * @param {number} scaleFactor - The scale factor to apply (1.0 = no change, 2.0 = double size, 0.5 = half size)
- * @returns {Promise<Object>} A promise that resolves to the scaled geometry
+ * Scale geom by the given factor and return the resulting geometry.
  */
 async function scale(geom, scaleFactor) {
   if (util.is3D(geom)) {
@@ -140,10 +127,7 @@ async function scale(geom, scaleFactor) {
 }
 
 /**
- * Applies a fillet (rounded edge) to the input geometry.
- * @param {Object|string} geom - The geometry to fillet, or library ID for same
- * @param {number} radius - The radius of the fillet
- * @returns {Promise<Object>} A promise that resolves to the filleted geometry
+ * Rounds all edges in geom to radius and return the resulting geometry.
  */
 async function fillet(geom, radius) {
   if (util.is3D(geom)) {
@@ -178,10 +162,8 @@ async function fillet(geom, radius) {
 }
 
 /**
- * Applies a chamfer (beveled edge) to the input geometry.
- * @param {Object|string} geom - The geometry to chamfer, or library ID for same
- * @param {number} size - The size of the chamfer
- * @returns {Promise<Object>} A promise that resolves to the chamfered geometry
+ * Applies a chamfer (beveled edge) to all edges in geom. Chamfer is symmetric and specified by size.
+ * Returns the resulting geometry.
  */
 async function chamfer(geom, size) {
   if (util.is3D(geom)) {

--- a/src/worker/actions.js
+++ b/src/worker/actions.js
@@ -184,9 +184,6 @@ async function fillet(geom, radius) {
  * @returns {Promise<Object>} A promise that resolves to the chamfered geometry
  */
 async function chamfer(geom, size) {
-  await started;
-
-  geom = toGeometry(geom, "chamfer-geometry");
   if (util.is3D(geom)) {
     return util.actOnLeafs(
       geom,

--- a/src/worker/actions.js
+++ b/src/worker/actions.js
@@ -1,0 +1,221 @@
+import * as util from "./util.js";
+
+/**
+ * Extrudes a 2D sketch to create a 3D geometry with the specified height and stores it in the library.
+ * @param {string} toExtrude - An Assembly whose components will be extruded. Must contain only 2D sketches
+ * @param {number} height - The height to extrude the sketch(es)
+ * @returns {Promise<Object>} An Assembly containing the extruded geometries
+ */
+function extrude(toExtrude, height) {
+  return util.actOnLeafs(toExtrude, (leaf) => {
+    return {
+      geometry: [
+        leaf.geometry[0].clone().sketchOnPlane(leaf.plane).extrude(height),
+      ],
+      tags: leaf.tags,
+      plane: leaf.plane,
+      color: leaf.color,
+      bom: leaf.bom,
+    };
+  });
+}
+
+/**
+ * Moves a geometry by the specified x, y, and z distances. If the geometry is 2D, then it's plane
+ * will be translated by the specified z distance.
+ *
+ * @param {Object} toMove - The assembly to be moved
+ * @param {number} x - The distance to move along the x-axis
+ * @param {number} y - The distance to move along the y-axis
+ * @param {number} z - The distance to move along the z-axis
+ * @returns {Promise<Object>} A promise that resolves to the moved geometry
+ */
+function move(toMove, x, y, z) {
+  if (util.is3D(toMove)) {
+    return util.actOnLeafs(
+      toMove,
+      (leaf) => {
+        return {
+          geometry: [leaf.geometry[0].clone().translate(x, y, z)],
+          plane: leaf.plane,
+          tags: leaf.tags,
+          color: leaf.color,
+          bom: leaf.bom,
+        };
+      },
+      toMove.plane
+    );
+  } else {
+    return util.actOnLeafs(
+      toMove,
+      (leaf) => {
+        return {
+          geometry: [leaf.geometry[0].clone().translate([x, y])],
+          tags: leaf.tags,
+          plane: leaf.plane.translate([0, 0, z]),
+          color: leaf.color,
+          bom: leaf.bom,
+        };
+      },
+      toMove.plane.translate([0, 0, z])
+    );
+  }
+}
+
+/**
+ * Function to rotate a geometry around the x, y, and z axis. If toRotate is 2D, it's plane will be
+ * rotated based on the x and y inputs, while it will be rotated within the plane according to the z input.
+ * @param {Object} toRotate - The geometry to rotate
+ * @param {number} x - The angle to rotate around the x axis
+ * @param {number} y - The angle to rotate around the y axis
+ * @param {number} z - The angle to rotate around the z axis
+ * @returns {Promise<Object>} A promise that resolves to the rotated geometry
+ **/
+async function rotate(toRotate, x, y, z) {
+  if (util.is3D(toRotate)) {
+    return util.actOnLeafs(toRotate, (leaf) => {
+      return {
+        geometry: [
+          leaf.geometry[0]
+            .clone()
+            .rotate(x, [0, 0, 0], [1, 0, 0])
+            .rotate(y, [0, 0, 0], [0, 1, 0])
+            .rotate(z, [0, 0, 0], [0, 0, 1]),
+        ],
+        tags: leaf.tags,
+        plane: leaf.plane,
+        color: leaf.color,
+        bom: leaf.bom,
+      };
+    });
+  } else {
+    return util.actOnLeafs(input, (leaf) => {
+      return {
+        geometry: [leaf.geometry[0].clone().rotate(z, [0, 0, 0], [0, 0, 1])],
+        tags: leaf.tags,
+        plane: leaf.plane.pivot(x, "X").pivot(y, "Y"),
+        color: leaf.color,
+        bom: leaf.bom,
+      };
+    });
+  }
+}
+
+/**
+ * Scales a geometry by the specified scale factor.
+ * @param {Object} geom - The geometry to scale
+ * @param {number} scaleFactor - The scale factor to apply (1.0 = no change, 2.0 = double size, 0.5 = half size)
+ * @returns {Promise<Object>} A promise that resolves to the scaled geometry
+ */
+async function scale(geom, scaleFactor) {
+  if (util.is3D(geom)) {
+    return util.actOnLeafs(
+      geom,
+      (leaf) => {
+        return {
+          geometry: [leaf.geometry[0].clone().scale(scaleFactor)],
+          plane: leaf.plane,
+          tags: leaf.tags,
+          color: leaf.color,
+          bom: leaf.bom,
+        };
+      },
+      geom.plane
+    );
+  } else {
+    return util.actOnLeafs(
+      geom,
+      (leaf) => {
+        return {
+          geometry: [leaf.geometry[0].clone().scale(scaleFactor)],
+          tags: leaf.tags,
+          plane: leaf.plane,
+          color: leaf.color,
+          bom: leaf.bom,
+        };
+      },
+      geom.plane
+    );
+  }
+}
+
+/**
+ * Applies a fillet (rounded edge) to the input geometry.
+ * @param {Object|string} geom - The geometry to fillet, or library ID for same
+ * @param {number} radius - The radius of the fillet
+ * @returns {Promise<Object>} A promise that resolves to the filleted geometry
+ */
+async function fillet(geom, radius) {
+  if (util.is3D(geom)) {
+    return util.actOnLeafs(
+      geom,
+      (leaf) => {
+        return {
+          geometry: [leaf.geometry[0].clone().fillet(radius)],
+          plane: leaf.plane,
+          tags: leaf.tags,
+          color: leaf.color,
+          bom: leaf.bom,
+        };
+      },
+      geom.plane
+    );
+  } else {
+    return util.actOnLeafs(
+      geom,
+      (leaf) => {
+        return {
+          geometry: [leaf.geometry[0].clone().fillet(radius)],
+          tags: leaf.tags,
+          plane: leaf.plane,
+          color: leaf.color,
+          bom: leaf.bom,
+        };
+      },
+      geom.plane
+    );
+  }
+}
+
+/**
+ * Applies a chamfer (beveled edge) to the input geometry.
+ * @param {Object|string} geom - The geometry to chamfer, or library ID for same
+ * @param {number} size - The size of the chamfer
+ * @returns {Promise<Object>} A promise that resolves to the chamfered geometry
+ */
+async function chamfer(geom, size) {
+  await started;
+
+  geom = toGeometry(geom, "chamfer-geometry");
+  if (util.is3D(geom)) {
+    return util.actOnLeafs(
+      geom,
+      (leaf) => {
+        return {
+          geometry: [leaf.geometry[0].clone().chamfer(size)],
+          plane: leaf.plane,
+          tags: leaf.tags,
+          color: leaf.color,
+          bom: leaf.bom,
+        };
+      },
+      geom.plane
+    );
+  } else {
+    return util.actOnLeafs(
+      geom,
+      (leaf) => {
+        return {
+          geometry: [leaf.geometry[0].clone().chamfer(size)],
+          tags: leaf.tags,
+          plane: leaf.plane,
+          color: leaf.color,
+          bom: leaf.bom,
+        };
+      },
+      geom.plane
+    );
+  }
+}
+
+export { extrude, move, rotate, scale, fillet, chamfer };

--- a/src/worker/actions.js
+++ b/src/worker/actions.js
@@ -89,7 +89,7 @@ async function rotate(toRotate, x, y, z) {
       };
     });
   } else {
-    return util.actOnLeafs(input, (leaf) => {
+    return util.actOnLeafs(toRotate, (leaf) => {
       return {
         geometry: [leaf.geometry[0].clone().rotate(z, [0, 0, 0], [0, 0, 1])],
         tags: leaf.tags,

--- a/src/worker/code.js
+++ b/src/worker/code.js
@@ -1,0 +1,229 @@
+import * as util from "./util.js";
+
+/**
+ * Validates that user-provided code doesn't contain dangerous patterns
+ * @param {string} code - The JavaScript code string to validate
+ * @returns {boolean} True if code appears safe, throws error if dangerous patterns detected
+ */
+function validateUserCode(code) {
+  const dangerousPatterns = [
+    /eval\s*\(/,
+    /import\s*\(/,
+    /require\s*\(/,
+    /process\s*\./,
+    /global\s*\./,
+    /window\s*\./,
+    /document\s*\./,
+    /XMLHttpRequest/,
+    /fetch\s*\(/,
+    /localStorage/,
+    /sessionStorage/,
+    /IndexedDB/,
+    /WebSocket/,
+    /Worker\s*\(/,
+    /setTimeout\s*\(/,
+    /setInterval\s*\(/,
+    /__proto__/,
+    /constructor/,
+    /prototype/,
+  ];
+
+  for (const pattern of dangerousPatterns) {
+    if (pattern.test(code)) {
+      throw new Error(
+        `Code contains potentially dangerous pattern: ${pattern.source}`
+      );
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Executes user-provided code in the worker thread with access to predefined geometry functions.
+ * @param {string} targetID - The unique identifier to store the code execution result in the library
+ * @param {string} code - The JavaScript code string to execute
+ * @param {Object} argumentsArray - Object containing key-value pairs of additional variables to make available to the code
+ * @returns {Promise<boolean|number>} A promise that resolves to the result value if it's a number, or true otherwise
+ * @note Uses eval() for code execution - consider security implications in production environments
+ */
+async function executeCode(targetID, code, argumentsArray) {
+  await started;
+  try {
+    // Validate input parameters
+    if (typeof code !== "string") {
+      throw new Error("Code must be a string");
+    }
+    if (code.length > 50000) {
+      throw new Error("Code too long (maximum 50,000 characters)");
+    }
+
+    // Validate code for dangerous patterns
+    // TODO: we probably want to allow some of these but still need to warn about them before executing
+    // the code molecule.
+    validateUserCode(code);
+
+    let keys1 = [
+      "Rotate",
+      "Move",
+      "Scale",
+      "Assembly",
+      "Intersect",
+      "CutAssembly",
+      "AssemblyMap",
+      "AssemblyAsIterable",
+      "GetBounds",
+      "Fillet",
+      "Chamfer",
+      "library",
+      "replicad",
+    ];
+    let inputValues = [
+      // TODO: TRISTAN we need all of these to be imported
+      rotate,
+      move,
+      scale,
+      assembly,
+      intersect,
+      cutAssembly,
+      assemblyMap,
+      assemblyAsIterable,
+      getBounds,
+      fillet,
+      chamfer,
+      library,
+      util.replicad,
+    ];
+    for (const [key, value] of Object.entries(argumentsArray)) {
+      // Sanitize parameter names to prevent injection
+      if (!/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(key)) {
+        throw new Error(`Invalid parameter name: ${key}`);
+      }
+      keys1.push(key);
+      inputValues.push(value);
+    }
+
+    // Use Function constructor instead of eval - still allows code execution but safer than eval
+    const userFunction = new Function(
+      ...keys1,
+      `return (async () => { ${code} })();`
+    );
+
+    // Execute with timeout protection
+    const timeoutPromise = new Promise((_, reject) => {
+      setTimeout(() => reject(new Error("Code execution timed out")), 60000); // 1 min timeout
+    });
+
+    const result = await Promise.race([
+      userFunction(...inputValues),
+      timeoutPromise,
+    ]);
+
+    library[targetID] = result;
+    // If the type of the result is a number return the number so it can be passed to the next atom
+    if (typeof result === "number") {
+      return result;
+    } else {
+      return true;
+    }
+  } catch (error) {
+    console.error("Code execution error:", error);
+    throw new Error(`Code execution failed: ${error.message}`);
+  }
+}
+
+/**
+ * AssemblyMap
+ *
+ * Maps the given callbackFn to each leaf in the specified assembly. And returns
+ * a new assembly of the same structure and metadata, but with transformed leafs.
+ * If the provided assembly is a single entity, returns a transformed singular entity.
+ *
+ * @param {*} assemblyId
+ * @param {*} callbackFn - A function that takes a leaf and returns a new leaf.
+ * @returns a new assembly with the same structure and metadata as assemblyId,
+ * but where each leaf is the result of applying callbackFn to the
+ * corresponding leaf in the input assembly.
+ */
+async function assemblyMap(assemblyId, callbackFn) {
+  try {
+    const assembly = toGeometry(assemblyId);
+
+    // Helper function to process nodes recursively
+    async function processNode(node, depth) {
+      // If this is a leaf node
+      if (
+        node.geometry.length === 1 &&
+        node.geometry[0].geometry === undefined
+      ) {
+        // Apply callback and return result
+        let result = await callbackFn(node, depth);
+        return result;
+      }
+      // This is a branch node (an assembly)
+      else {
+        const newGeometry = await Promise.all(
+          node.geometry.map(async (child) => {
+            return await processNode(child, depth + 1);
+          })
+        );
+
+        // Filter out any undefined results (in case callbackFn filters some nodes)
+        const filteredGeometry = newGeometry.filter(
+          (item) => item !== undefined
+        );
+
+        // Return a new node with the same metadata but transformed children
+        return {
+          geometry: filteredGeometry,
+          tags: node.tags || [],
+          color: node.color,
+          plane: node.plane,
+          bom: node.bom || [],
+        };
+      }
+    }
+
+    // Start processing from the root
+    const result = await processNode(assembly, 0);
+    return result;
+  } catch (error) {
+    logError(error, "AssemblyMap");
+    throw error;
+  }
+}
+
+async function assemblyAsIterable(assemblyId) {
+  const result = [];
+  util.actOnLeafs(toGeometry(assemblyId), (leaf) => {
+    result.push(leaf);
+  });
+  // TODO: when we typescriptify things, this should be a read-only list.
+  return result;
+}
+
+function logError(error, context) {
+  console.warn("error from context: ", context);
+  if (error instanceof SyntaxError) {
+    console.error("SyntaxError encountered:", error.message);
+  } else if (error instanceof ReferenceError) {
+    console.error("ReferenceError encountered:", error.message);
+  } else {
+    console.error("An error occurred:", error.message);
+  }
+
+  // Log additional error details if available
+  if (error.stack) {
+    console.error("Stack trace:", error.stack);
+  }
+  if (error.lineNumber) {
+    console.error("Line number:", error.lineNumber);
+  }
+  if (error.columnNumber) {
+    console.error("Column number:", error.columnNumber);
+  }
+  console.log("full error:");
+  console.log(error);
+}
+
+export { executeCode };

--- a/src/worker/code.js
+++ b/src/worker/code.js
@@ -48,7 +48,6 @@ function validateUserCode(code) {
  * @note Uses eval() for code execution - consider security implications in production environments
  */
 async function executeCode(targetID, code, argumentsArray) {
-  await started;
   try {
     // Validate input parameters
     if (typeof code !== "string") {

--- a/src/worker/code.js
+++ b/src/worker/code.js
@@ -1,4 +1,6 @@
 import * as util from "./util.js";
+import { rotate, move, scale, fillet, chamfer } from "./actions.js";
+import { intersect, assembly, cutAssembly } from "./interaction.js";
 
 /**
  * Validates that user-provided code doesn't contain dangerous patterns
@@ -47,7 +49,7 @@ function validateUserCode(code) {
  * @returns {Promise<boolean|number>} A promise that resolves to the result value if it's a number, or true otherwise
  * @note Uses eval() for code execution - consider security implications in production environments
  */
-async function executeCode(targetID, code, argumentsArray) {
+async function executeCode(code, argumentsArray, library) {
   try {
     // Validate input parameters
     if (typeof code !== "string") {
@@ -87,10 +89,10 @@ async function executeCode(targetID, code, argumentsArray) {
       cutAssembly,
       assemblyMap,
       assemblyAsIterable,
-      getBounds,
+      util.getBounds,
       fillet,
       chamfer,
-      library,
+      library, // TODO(tristan): I think we should deprecate this
       util.replicad,
     ];
     for (const [key, value] of Object.entries(argumentsArray)) {

--- a/src/worker/code.js
+++ b/src/worker/code.js
@@ -80,7 +80,6 @@ async function executeCode(code, argumentsArray, library) {
       "replicad",
     ];
     let inputValues = [
-      // TODO: TRISTAN we need all of these to be imported
       rotate,
       move,
       scale,
@@ -92,7 +91,7 @@ async function executeCode(code, argumentsArray, library) {
       util.getBounds,
       fillet,
       chamfer,
-      library, // TODO(tristan): I think we should deprecate this
+      library, // TODO(tristan): I think we should deprecate this but it'll require passing the actual geom.
       util.replicad,
     ];
     for (const [key, value] of Object.entries(argumentsArray)) {
@@ -115,18 +114,7 @@ async function executeCode(code, argumentsArray, library) {
       setTimeout(() => reject(new Error("Code execution timed out")), 60000); // 1 min timeout
     });
 
-    const result = await Promise.race([
-      userFunction(...inputValues),
-      timeoutPromise,
-    ]);
-
-    library[targetID] = result;
-    // If the type of the result is a number return the number so it can be passed to the next atom
-    if (typeof result === "number") {
-      return result;
-    } else {
-      return true;
-    }
+    return await Promise.race([userFunction(...inputValues), timeoutPromise]);
   } catch (error) {
     console.error("Code execution error:", error);
     throw new Error(`Code execution failed: ${error.message}`);
@@ -146,10 +134,8 @@ async function executeCode(code, argumentsArray, library) {
  * but where each leaf is the result of applying callbackFn to the
  * corresponding leaf in the input assembly.
  */
-async function assemblyMap(assemblyId, callbackFn) {
+async function assemblyMap(assembly, callbackFn) {
   try {
-    const assembly = toGeometry(assemblyId);
-
     // Helper function to process nodes recursively
     async function processNode(node, depth) {
       // If this is a leaf node
@@ -194,9 +180,9 @@ async function assemblyMap(assemblyId, callbackFn) {
   }
 }
 
-async function assemblyAsIterable(assemblyId) {
+async function assemblyAsIterable(assembly) {
   const result = [];
-  util.actOnLeafs(toGeometry(assemblyId), (leaf) => {
+  util.actOnLeafs(assembly, (leaf) => {
     result.push(leaf);
   });
   // TODO: when we typescriptify things, this should be a read-only list.

--- a/src/worker/code.js
+++ b/src/worker/code.js
@@ -3,7 +3,7 @@ import { rotate, move, scale, fillet, chamfer } from "./actions.js";
 import { intersect, assembly, cutAssembly } from "./interaction.js";
 
 /**
- * Validates that user-provided code doesn't contain dangerous patterns
+ * A best-effort check for exploits in user provided code. Checks for a series of known bad patterns.
  * @param {string} code - The JavaScript code string to validate
  * @returns {boolean} True if code appears safe, throws error if dangerous patterns detected
  */
@@ -42,12 +42,9 @@ function validateUserCode(code) {
 }
 
 /**
- * Executes user-provided code in the worker thread with access to predefined geometry functions.
- * @param {string} targetID - The unique identifier to store the code execution result in the library
- * @param {string} code - The JavaScript code string to execute
- * @param {Object} argumentsArray - Object containing key-value pairs of additional variables to make available to the code
- * @returns {Promise<boolean|number>} A promise that resolves to the result value if it's a number, or true otherwise
- * @note Uses eval() for code execution - consider security implications in production environments
+ * Executes the given code with the provided arguments list.
+ * 
+ * Unusually this function requires library as context since the source code may reference library.
  */
 async function executeCode(code, argumentsArray, library) {
   try {

--- a/src/worker/cutlayout.js
+++ b/src/worker/cutlayout.js
@@ -1,0 +1,685 @@
+import { PolygonPacker, PlacementWrapper } from "polygon-packer";
+import { Plane, Solid, Wire } from "replicad";
+import * as util from "./util.js";
+import { proxy } from "comlink"; // TODO: this should ideally be moved to worker somehow
+
+/**
+ * @param progressCallback - a function which takes two parameters:
+ *    - progress - 0 to 1 inclusive
+ *    - cancelationHandle - a callable which cancels this task.
+ * @param {*} layoutConfig - dictionary with keys:
+ *    - thickness - thickness of the stock material
+ *    - width
+ *    - height - together with width specifies the demensions of the stock material
+ *    - partPadding - space between parts in the resulting placement
+ * @param {*} previousPlacements - optional array of previous placements to use as starting point
+ */
+function layout(
+  assembly,
+  progressCallback,
+  warningCallback,
+  placementsCallback,
+  layoutConfig,
+  previousPlacements = null
+) {
+  var [rotatedAssembly, shapesForLayout] = rotateForLayout(
+    assembly,
+    layoutConfig,
+    warningCallback
+  );
+
+  let positionsPromise = computePositions(
+    shapesForLayout,
+    progressCallback,
+    placementsCallback,
+    layoutConfig,
+    previousPlacements
+  );
+  return positionsPromise.then((positions) => {
+    //This does the actual layout of the parts.
+    const layedOutAssembly = applyLayout(rotatedAssembly, positions, layoutConfig);
+
+    if (positions.length == 0) {
+      throw new Error(
+        "Failed to place any parts. Are sheet dimensions right?"
+      );
+    } else {
+      let unplacedParts = shapesForLayout.length - positions.flat().length;
+      if (unplacedParts > 0) {
+        const warning =
+          unplacedParts +
+          " parts are too big to fit on this sheet size. Failed layout for " +
+          unplacedParts +
+          " part(s)";
+        warningCallback(warning);
+      }
+    }
+
+    return [layedOutAssembly, positions];
+  });
+}
+
+/**
+ * Lay the input geometry flat and apply the transformations to display it
+ */
+function displayLayout(
+  assembly,
+  positions,
+  warningCallback,
+  layoutConfig
+) {
+
+  const [rotatedAssembly, shapesForLayout] = rotateForLayout(assembly, layoutConfig, warningCallback);
+
+  return applyLayout(rotatedAssembly, positions, layoutConfig);
+}
+
+/**
+ * Rotates and moves all leafs into an orientation which can be fed into
+ * the nesting algorithm.
+ *
+ * Specific criteria of this pre-layout step are as follows:
+ * 1) rotate the part such that the best possible face is aligned with the XY plane.
+ *    Criteria for the best face are as follows (in order):
+ *    a) face must be flat (eg: not the edge of a cylinder)
+ *    b) face must have no protrusions below the XY plane
+ *    c) face must be within the (inferred) thickness of the material
+ *    d) face should have minimal number of interior voids and have the largest bounding box
+ */
+function rotateForLayout(assembly, layoutConfig, warningCallback) {
+  var THICKNESS_TOLLERANCE = 0.001;
+
+  function equalThickness(a, b) {
+    return Math.abs(a - b) < THICKNESS_TOLLERANCE;
+  }
+
+  // Get geometry and remove any empty leafs.
+  let geometryToLayout = util.actOnLeafs(assembly, (leaf) => {
+    if (leaf.geometry.length > 0 && leaf.geometry[0].faces.length > 0) {
+      return leaf;
+    } else {
+      return undefined;
+    }
+  });
+
+  let localId = 0;
+  let shapesForLayout = [];
+
+  // Algo overview:
+  // collect all prospective orientations for all parts
+  // come up with a best-guess material thickness or n/a
+  // select among candidates for each part based on either good fit to the
+  //    estimated material thickness, or just take thinnest orientation.
+
+  // get candidates as {leaf_id: "abc", [candidate 1, candidate 2 etc]}
+  const all_candidates = {};
+  const intermediate = util.actOnLeafs(geometryToLayout, (leaf) => {
+    // For each face, consider it as the underside of the shape on the CNC bed.
+    // In order to be considered, a face must be...
+    //  1) a flat PLANE, not a cylinder, or sphere or other curved face type.
+    //  2) there must be no parts of the shape which protrude "below" this face
+    const candidates = [];
+    let faceIndex = 0;
+    leaf.geometry[0].faces.forEach((face) => {
+      let prospectiveGoem = moveFaceToCuttingPlane(leaf.geometry[0], face);
+      let offset = 0;
+      if (
+        prospectiveGoem.boundingBox.bounds[0][2] <
+        -1 * THICKNESS_TOLLERANCE
+      ) {
+        // this face causes protrusions below the XY plane, move the prospective geometry so that
+        // all points are above the XY plane. Record this movement, since it's a red flag for
+        // this candidate.
+        offset = -1 * prospectiveGoem.boundingBox.bounds[0][2];
+        prospectiveGoem = prospectiveGoem.translate(0, 0, offset);
+      }
+      candidates.push({
+        face: face,
+        offset: offset,
+        geom: prospectiveGoem,
+        faceIndex: faceIndex,
+        thickness: prospectiveGoem.boundingBox.depth,
+      });
+      faceIndex++;
+    });
+
+    all_candidates[localId] = candidates;
+    const newLeaf = {
+      geometry: leaf.geometry,
+      id: localId,
+      tags: leaf.tags,
+      color: leaf.color,
+      plane: leaf.plane,
+      bom: leaf.bom,
+    };
+    localId++;
+    return newLeaf;
+  });
+
+  // Heuristic here is... for each part get it's minimum thickness. If the largest of these is
+  // <= 1" then it's credibly the size of stock being used, so set that as our material
+  // thickness and select among candidates for each part.
+
+  let material_thickness = -1;
+  if (layoutConfig.units) {
+    const LARGEST_PLAUSIBLE_STOCK = layoutConfig.units == "MM" ? 25.4 : 1;
+    const min_thickness_per_part = Object.values(all_candidates).map((s) =>
+      Math.min(...s.map((c) => c.thickness))
+    );
+    if (
+      Math.max(...min_thickness_per_part) <=
+      LARGEST_PLAUSIBLE_STOCK + THICKNESS_TOLLERANCE
+    ) {
+      material_thickness = Math.max(...min_thickness_per_part);
+    }
+  }
+
+  const layoutWarnList = [];
+
+  const rotatedAssembly = util.actOnLeafs(intermediate, (leaf) => {
+    let candidates = all_candidates[leaf.id];
+    if (candidates == undefined || candidates.length == 0) {
+      // This should be impossible.
+      throw new Error("Failed to filter unplacable part. id: " + leaf.id);
+    }
+    let selected;
+    if (candidates.length == 1) {
+      selected = candidates[0];
+    } else {
+      // For each candidate generate a descriptive struct with the properties we care about.
+      // namely:
+      //  - is planar face
+      //  - offset (how much the of the object is below the face)
+      //  - thickness
+      //  - area (approx)
+      //  - number of interior wires (if any)
+      const scores = candidates.map((c, index) => {
+        return {
+          candidate_index: index,
+          is_planar: c.face.geomType == "PLANE",
+          offset: c.offset,
+          thickness: c.thickness,
+          area: areaApprox(c.face.UVBounds),
+          interiorWires: c.face.clone().innerWires().length,
+        };
+      });
+
+      // Sort in order of preference (scores[0] being best).
+      scores.sort((a, b) => {
+        // Planar faces are preferred because typical cnc machines won't be able to reach the
+        // underside face to make cuts.
+        if (a.is_planar != b.is_planar) {
+          return a.is_planar ? -1 : 1; // prefer planar faces
+        }
+
+        // offset == 0 is preferred since it means our face is flush with the xy plane.
+        if (a.offset != b.offset) {
+          return a.offset - b.offset; // prefer candidates with no offset
+        }
+
+        // Next, prefer thickness that matches material if possible, else pick thinnest
+        // orientation. Or defer if thickness is equal.
+        if (!equalThickness(a.thickness, b.thickness)) {
+          // Candidates with thickness exactly equal to material thickness always win.
+          if (equalThickness(a.thickness, material_thickness)) {
+            return -1;
+          } else if (equalThickness(b.thickness, material_thickness)) {
+            return 1;
+          } else {
+            // Neither candidate is equal to material thickness. Prefer thinnest
+            // candidate.
+            return a.thickness - b.thickness;
+          }
+        }
+
+        // Tie brakes for candidates of equal thickness.
+
+        // First, look for interior wires, if unequal we prefer candidates with fewer since
+        // interior wires *might* indicate carve-outs which are unreachable on the underside of the sheet.
+        if (a.interiorWires != b.interiorWires) {
+          return a.interiorWires - b.interiorWires;
+        }
+
+        // Second (finally), prefer candidates with larger area.
+        if (Math.abs(a.area - b.area) > THICKNESS_TOLLERANCE) {
+          return b.area - a.area;
+        }
+
+        return 0; // we can't decide.
+      });
+      selected = candidates[scores[0].candidate_index];
+    }
+    if (
+      selected.face.geomType != "PLANE" ||
+      selected.offset > THICKNESS_TOLLERANCE
+    ) {
+      layoutWarnList.push(leaf.id);
+    }
+    // move so center of face is at (0, 0, 0)
+    const newGeom = selected.geom
+      .clone()
+      .translate(-1 * selected.face.center.x, -1 * selected.face.center.y, 0);
+
+    let newLeaf = {
+      geometry: [newGeom],
+      id: leaf.id,
+      referencePoint: selected.face.center,
+      tags: leaf.tags,
+      color: leaf.color,
+      plane: leaf.plane,
+      bom: leaf.bom,
+    };
+    // Retrieve face from the re-positioned shape so that we get the shape of the face after
+    // it's been moved to the xy cutting plane. Otherwise we can get weird skewed projections
+    // of the face shape.
+    shapesForLayout.push({
+      id: leaf.id,
+      shape: newLeaf.geometry[0].faces[selected.faceIndex],
+    });
+
+    return newLeaf;
+  });
+
+  // If we have a warning, pass it to the callback
+  if (layoutWarnList.length > 0 && warningCallback) {
+    warningCallback(
+      `Part(s) ${layoutWarnList.join(
+        ", "
+      )} have no orientation suitable for layout.`
+    );
+  }
+
+  return [rotatedAssembly, shapesForLayout];
+}
+
+
+
+/**
+ * Apply the transformations to the geometry to apply the layout
+ */
+function applyLayout(rotatedAssembly, positions, layoutConfig) {
+  console.log("Applying layout");
+  console.log(positions);
+  return util.actOnLeafs(rotatedAssembly, (leaf) => {
+    let transform, index;
+    for (var i = 0; i < positions.length; i++) {
+      let candidates = positions[i].filter(
+        (transform) => transform.id == leaf.id
+      );
+      if (candidates.length == 1) {
+        transform = candidates[0];
+        index = i;
+        break;
+      } else if (candidates.length > 1) {
+        console.warn("Found more than one transformation for same id");
+      }
+    }
+    if (transform == undefined) {
+      console.log("didn't find transform for id: " + leaf.id);
+      return undefined;
+    }
+    // apply rotation first. All rotations are around (0, 0, 0)
+    // Additionally, shift by sheet-index * sheet height so that multiple
+    // sheet layouts are spaced out from one another.
+    let newGeom = leaf.geometry[0]
+      .clone()
+      .rotate(
+        transform.rotate,
+        new util.replicad.Vector([0, 0, 0]),
+        new util.replicad.Vector([0, 0, 1])
+      )
+      .translate(
+        transform.translate.x,
+        transform.translate.y + i * layoutConfig.height,
+        0
+      );
+
+    return {
+      geometry: [newGeom],
+      tags: leaf.tags,
+      color: leaf.color,
+      plane: leaf.plane,
+      bom: leaf.bom,
+      id: leaf.id,
+    };
+  });
+}
+
+/**
+ * Converts a shape array of {x, y} points to a Float64Array format for polygon packing.
+ * @param {Array} shape - Array of point objects with x and y properties
+ * @returns {Float64Array} Float64Array containing points as [x1, y1, x2, y2, ...] with the polygon closed
+ * @throws {Error} Throws an error if any points contain NaN values
+ */
+function asFloat64(shape) {
+  const points = new Float64Array(shape.length * 2 + 2);
+  let i = 0;
+  shape.forEach((point) => {
+    points[i] = point.x;
+    points[i + 1] = point.y;
+    i += 2;
+  });
+  points[i] = shape[0].x;
+  points[i + 1] = shape[0].y; // close the polygon
+
+  if (points.filter((c) => !Number.isFinite(c)).length > 0) {
+    throw new Error(
+      "NaN points in Float64Array from: " + JSON.stringify(shape)
+    );
+  }
+
+  return points;
+}
+
+/**
+ * Use the packing engine, this is potentially time consuming step.
+ */
+function computePositions(
+  shapesForLayout,
+  progressCallback,
+  placementsCallback,
+  layoutConfig,
+  previousPlacements = null
+) {
+  console.log("Starting to compute positions for shapes: ");
+  console.log(shapesForLayout);
+  
+  const tolerance = 0.2;
+  const runtimeMs = 120000;
+  const config = {
+    curveTolerance: 0.1,
+    spacing: layoutConfig.partPadding + tolerance * 2,
+    rotations: 12, // TODO: this should be higher, like at least 8? idk
+    populationSize: 8,
+    mutationRate: 50,
+    useHoles: false,
+  };
+  // from the mesh format of [x1, y1, z1, x2, y2, z2, ...] to FloatPolygon friendly format of
+  // [{x: x1, y: y1}, {x: x2, y: y2}...]
+  const polygons = shapesForLayout.map((shape, index) => {
+    let face = shape.shape;
+    const mesh = face
+      .clone()
+      .outerWire()
+      .meshEdges({ tolerance: tolerance, angularTolerance: 0.5 }); //The tolerance here is described in the conversation here https://github.com/BarbourSmith/Abundance/pull/173
+
+    const prepared = preparePoints(mesh, tolerance / 100);
+    const result = asFloat64(prepared);
+    return result;
+  });
+
+  // Clockwise winding direction appears to matter here for the current packing algo.
+  const bin = asFloat64([
+    { x: 0, y: 0 },
+    { x: 0, y: layoutConfig.height },
+    { x: layoutConfig.width, y: layoutConfig.height },
+    { x: layoutConfig.width, y: 0 },
+  ]);
+
+  const packer = new PolygonPacker();
+
+  let progressCallbackCounter = 0;
+  const callbackFunction = (num) => {
+    // Forward to the UI thread along with a cancelation handle.
+    // Expect a call every 0.1 seconds for this method.
+    // Unclear what the num argument is supposed to represent
+    progressCallbackCounter++;
+    progressCallback(
+      0.1 + 0.9 * ((progressCallbackCounter * 100) / runtimeMs),
+      proxy(() => {
+        packer.stop(false);
+      })
+    );
+  };
+
+  const result = new Promise((resolve, reject) => {
+    // See https://github.com/yuriilychak/SVGnest/blob/6ed19cf44cb458b11d7ae4abf1868a513c53420a/packages/polygon-packer/src/types.ts#L31
+    let callbackCounter = 0;
+    let bestPlacement = null;
+    const displayCallback = (
+      placementsData,
+      placementPercentage,
+      placedParts,
+      partCount
+    ) => {
+      callbackCounter++;
+      if (placedParts > 0) {
+        let placements = translatePlacements(
+          placementsData,
+          placedParts,
+          partCount
+        );
+
+        placementsCallback(placements);
+        bestPlacement = placements;
+      }
+    };
+
+    try {
+      packer.start(config, polygons, bin, callbackFunction, displayCallback, previousPlacements);
+
+      setTimeout(() => {
+        console.log("Timeout reached. Stopping packer.");
+        if (bestPlacement != null) {
+          packer.stop(true);
+          resolve(bestPlacement);
+        } else {
+          packer.stop(true);
+          reject(new Error("Failed to find placements within the time limit."));
+        }
+      }, runtimeMs);
+    } catch (err) {
+      console.log("error in nesting engine: " + err);
+      packer.stop(true);
+      reject(err);
+    }
+  });
+  return result;
+}
+
+/**
+ *
+ * @param {} placement
+ * @returns List of placements as expected by applyLayout
+ *  ie. a list of list of transforms, where each entry in the outer list is for 1 sheet's worth of placement
+ *  Each transform follows the structure: {id: "part_id", rotate: degrees, translate: {x: x, y: y}}
+ */
+
+function translatePlacements(placement, placedParts, partCount) {
+  const placements = new PlacementWrapper(
+    placement.placementsData,
+    placement.angleSplit
+  );
+  console.log(
+    "new placement received. " +
+      placedParts +
+      " of " +
+      partCount +
+      " parts placed. score: " +
+      placement.placementsData[0]
+  );
+
+  const result = [];
+  for (let i = 0; i < placements.placementCount; i++) {
+    const sheet = [];
+    placements.bindPlacement(i);
+    for (let j = 0; j < placements.size; j++) {
+      placements.bindData(j);
+      sheet.push({
+        id: placements.id,
+        rotate: placements.rotation,
+        translate: { x: placements.x, y: placements.y },
+      });
+    }
+    result.push(sheet);
+  }
+
+  return result;
+}
+
+/**
+ * Converts mesh edge data to a polygon-friendly format with proper winding order.
+ * @param {Object} mesh - The mesh object containing edge groups and line data
+ * @param {number} tolerance - The tolerance for determining if points are equal
+ * @returns {Array} Array of {x, y} points in proper winding order
+ * @throws {Error} Throws an error if geometry has inconsistent edge continuations
+ */
+function preparePoints(mesh, tolerance) {
+  // Unfortunately the "edges" of this mesh aren't always in sequential order. Here we re-sort them so we can
+  // provide them in a winding order, ie, starting at one point and winding around the perimeter of the shape.
+
+  // create structure for lookup of line segments by start point or end point
+  let edgeStarts = [];
+  mesh.edgeGroups.forEach((edge) => {
+    edgeStarts.push({
+      startPoint: {
+        x: mesh.lines[edge.start * 3],
+        y: mesh.lines[edge.start * 3 + 1],
+      },
+      start: edge.start * 3,
+      len: edge.count,
+      edgeId: edge.edgeId,
+    });
+    const endIndex = (edge.start + edge.count - 1) * 3;
+    edgeStarts.push({
+      startPoint: { x: mesh.lines[endIndex], y: mesh.lines[endIndex + 1] },
+      start: endIndex,
+      len: -1 * edge.count,
+      edgeId: edge.edgeId,
+    });
+  });
+
+  const almostEqual = (p1, p2, t = tolerance) => {
+    const x = Math.abs(p1.x - p2.x) < t;
+    const y = Math.abs(p1.y - p2.y) < t;
+    return x && y;
+  };
+
+  const result = [];
+  let currentEdge = edgeStarts[0];
+  while (edgeStarts.length > 0) {
+    // add currentEdge to result. Remember, it could be reverse direction if we matched
+    // an endpoint.
+    for (var i = 1; i < Math.abs(currentEdge.len); i++) {
+      // skip start point
+      let offset = i * 3;
+      if (currentEdge.len < 0) {
+        offset = -1 * offset;
+      }
+      const index = currentEdge.start + offset;
+      const nextPoint = { x: mesh.lines[index], y: mesh.lines[index + 1] };
+      if (
+        result.length == 0 ||
+        !almostEqual(result[result.length - 1], nextPoint)
+      ) {
+        result.push(nextPoint);
+      }
+    }
+
+    // Remove this edge and it's inverse from the lookup table.
+    edgeStarts = edgeStarts.filter((edge) => {
+      return edge.edgeId != currentEdge.edgeId;
+    });
+    if (edgeStarts.length == 0) {
+      break;
+    }
+
+    // else find next edge which starts where current result ends.
+    const nextEdges = edgeStarts.filter((edge) => {
+      return almostEqual(result[result.length - 1], edge.startPoint);
+    });
+    if (nextEdges.length == 0) {
+      throw new Error(
+        "Found a discontinuity in the perimeter of an input part."
+      );
+    } else if (nextEdges.length == 1) {
+      currentEdge = nextEdges[0];
+    } else {
+      // nextEdges.length > 1
+      console.warn("Multiple edges starting at seemingly the same point.");
+      nextEdges.sort((a, b) => {
+        const p1 = result[result.length - 1];
+        const p2 = a.startPoint;
+        const p3 = b.startPoint;
+        const distA = Math.sqrt(
+          Math.pow(p1.x - p2.x, 2) + Math.pow(p1.y - p2.y, 2)
+        );
+        const distB = Math.sqrt(
+          Math.pow(p1.x - p3.x, 2) + Math.pow(p1.y - p3.y, 2)
+        );
+        return distA - distB;
+      });
+      currentEdge = nextEdges[0];
+    }
+  }
+
+  if (result.length < 3) {
+    throw new Error(
+      "Part perimiter has less than 3 points: " + JSON.stringify(result)
+    );
+  }
+  return result;
+}
+
+/**
+ * Moves a face to the cutting plane by rotating and translating the geometry.
+ * @param {Object} geom - The geometry to transform
+ * @param {Object} face - The face to align with the cutting plane
+ * @returns {Object} The transformed geometry with the face aligned to the XY cutting plane
+ */
+function moveFaceToCuttingPlane(geom, face) {
+  // There's a broken edge case in the clipper lib which gets triggered if one of the perimeter lines is
+  // co-incident with the X or Y axis. Here use the center of the face to ensure the origin isn't aligned with
+  // any perimeter edge of this face.
+  // Try removing this once https://github.com/BarbourSmith/Abundance/issues/572 is resolved.
+  let center = {
+    x: (face.UVBounds.uMin + face.UVBounds.uMax) / 2,
+    y: (face.UVBounds.vMin + face.UVBounds.vMax) / 2,
+  };
+
+  let pointOnSurface = face.pointOnSurface(center.x, center.y);
+  let faceNormal = face.normalAt();
+
+  // Always use "XY" plane as the cutting surface. Attempt to reorient
+  // the given face so it's normal vector points down the Z axis. Down because
+  // the normal vector points out of the surface of our 3d shape, and the interior
+  // of the 3D shape should be placed above the XY plane.
+  let targetOrientation = new util.replicad.Vector([0, 0, -1]);
+
+  let rotationAxis = faceNormal.cross(targetOrientation);
+  if (rotationAxis.Length == 0) {
+    if (faceNormal.dot(targetOrientation) < 0) {
+      // Face points upward but is otherwise parallel to cut plane. flip 180 around x axis.
+      geom = geom
+        .clone()
+        .rotate(180, pointOnSurface, new util.replicad.Vector([1, 0, 0]));
+    }
+
+    // Face already parallel to cut plane and on underside of the shape.
+    return geom.clone().translate(0, 0, -1 * pointOnSurface.z);
+  }
+
+  let rotationDegrees =
+    (Math.acos(
+      faceNormal.dot(targetOrientation) /
+        (targetOrientation.Length * faceNormal.Length)
+    ) *
+      360) /
+    (2 * Math.PI);
+
+  return geom
+    .clone()
+    .rotate(rotationDegrees, pointOnSurface, rotationAxis)
+    .translate(0, 0, -1 * pointOnSurface.z);
+}
+
+/**
+ * Calculates an approximate area from UV bounds.
+ * @param {Object} bounds - The bounds object containing uMin, uMax, vMin, vMax properties
+ * @returns {number} The approximate area calculated from the bounds
+ */
+function areaApprox(bounds) {
+  return (bounds.uMax - bounds.uMin) * (bounds.vMax - bounds.vMin);
+}
+
+export { layout, displayLayout };

--- a/src/worker/cutlayout.js
+++ b/src/worker/cutlayout.js
@@ -3,17 +3,6 @@ import { Plane, Solid, Wire } from "replicad";
 import * as util from "./util.js";
 import { proxy } from "comlink"; // TODO: this should ideally be moved to worker somehow
 
-/**
- * @param progressCallback - a function which takes two parameters:
- *    - progress - 0 to 1 inclusive
- *    - cancelationHandle - a callable which cancels this task.
- * @param {*} layoutConfig - dictionary with keys:
- *    - thickness - thickness of the stock material
- *    - width
- *    - height - together with width specifies the demensions of the stock material
- *    - partPadding - space between parts in the resulting placement
- * @param {*} previousPlacements - optional array of previous placements to use as starting point
- */
 function layout(
   assembly,
   progressCallback,

--- a/src/worker/cutlayout.js
+++ b/src/worker/cutlayout.js
@@ -37,12 +37,14 @@ function layout(
   );
   return positionsPromise.then((positions) => {
     //This does the actual layout of the parts.
-    const layedOutAssembly = applyLayout(rotatedAssembly, positions, layoutConfig);
+    const layedOutAssembly = applyLayout(
+      rotatedAssembly,
+      positions,
+      layoutConfig
+    );
 
     if (positions.length == 0) {
-      throw new Error(
-        "Failed to place any parts. Are sheet dimensions right?"
-      );
+      throw new Error("Failed to place any parts. Are sheet dimensions right?");
     } else {
       let unplacedParts = shapesForLayout.length - positions.flat().length;
       if (unplacedParts > 0) {
@@ -62,14 +64,12 @@ function layout(
 /**
  * Lay the input geometry flat and apply the transformations to display it
  */
-function displayLayout(
-  assembly,
-  positions,
-  warningCallback,
-  layoutConfig
-) {
-
-  const [rotatedAssembly, shapesForLayout] = rotateForLayout(assembly, layoutConfig, warningCallback);
+function displayLayout(assembly, positions, warningCallback, layoutConfig) {
+  const [rotatedAssembly, shapesForLayout] = rotateForLayout(
+    assembly,
+    layoutConfig,
+    warningCallback
+  );
 
   return applyLayout(rotatedAssembly, positions, layoutConfig);
 }
@@ -292,8 +292,6 @@ function rotateForLayout(assembly, layoutConfig, warningCallback) {
   return [rotatedAssembly, shapesForLayout];
 }
 
-
-
 /**
  * Apply the transformations to the geometry to apply the layout
  */
@@ -383,13 +381,13 @@ function computePositions(
 ) {
   console.log("Starting to compute positions for shapes: ");
   console.log(shapesForLayout);
-  
+
   const tolerance = 0.2;
   const runtimeMs = 120000;
   const config = {
     curveTolerance: 0.1,
     spacing: layoutConfig.partPadding + tolerance * 2,
-    rotations: 12, // TODO: this should be higher, like at least 8? idk
+    rotations: 12,
     populationSize: 8,
     mutationRate: 50,
     useHoles: false,
@@ -456,7 +454,14 @@ function computePositions(
     };
 
     try {
-      packer.start(config, polygons, bin, callbackFunction, displayCallback, previousPlacements);
+      packer.start(
+        config,
+        polygons,
+        bin,
+        callbackFunction,
+        displayCallback,
+        previousPlacements
+      );
 
       setTimeout(() => {
         console.log("Timeout reached. Stopping packer.");

--- a/src/worker/interaction.js
+++ b/src/worker/interaction.js
@@ -411,4 +411,5 @@ export {
   fusion,
   assembly,
   digFuse,
+  cutAssembly,
 };

--- a/src/worker/interaction.js
+++ b/src/worker/interaction.js
@@ -3,10 +3,15 @@ import shrinkWrap from "replicad-shrink-wrap";
 import { Plane, Solid } from "replicad";
 
 /**
- * Creates a loft shape by blending between multiple 2D sketches.
- * @param {Object[]} sketches - Array of sketch assemblies to be lofted
- * @returns {Promise<Object>} A promise of an Assembly containing the lofted geometry
- * @throws {Error} Throws an error if input parts are not sketches or contain interior geometries
+ * All methods in this file take multiple geometries and combine them in some way.
+ *
+ * Most methods return a singular new geometry which is the intersection/difference/fusion etc
+ * of the inputs. The one notable exception is `assembly`, which returns a grouping of multiple
+ * geometries which can later be separated (eg: with tags, BOM, or cut layout)
+ */
+
+/**
+ * Create and return a lofted shape which blends between multiple 2D profile sketches.
  */
 function loftShapes(sketches) {
   let arrayOfSketchedGeometry = [];
@@ -38,15 +43,6 @@ function loftShapes(sketches) {
 /**
  * Performs a boolean difference operation between two geometries.
  * This function subtracts the second geometry (cutter) from the first geometry (target).
- *
- * @param {string} input1ID - The ID of the base geometry from which material will be removed
- * @param {string} input2ID - The ID of the cutting geometry that will be subtracted
- * @returns {Promise<Object>} - A promise that resolves to the resulting geometry after the operation
- * @throws {Error} - If the input geometries are not of the same type (both must be either 3D or 2D)
- *
- * The function maintains all metadata from the base geometry including tags, color, plane, and BOM.
- * If the base geometry is an assembly, the cut operation is applied to each leaf independently.
- * Uses bounding box checks to avoid processing cuts for non-overlapping geometries.
  */
 function difference(target, cutter) {
   if (
@@ -76,9 +72,6 @@ function difference(target, cutter) {
 
 /**
  * Creates a shrink-wrapped boundary around multiple 2D sketches and stores it in the library.
- * @param {string[]} inputIDs - Array of library IDs containing 2D sketches to be shrink-wrapped
- * @returns {Promise<boolean>} A promise that resolves to true when the shrink wrapping is completed successfully
- * @throws {Error} Throws an error if inputs are not all sketches or if sketches have interior geometries
  */
 function shrinkWrapSketches(sketches) {
   let BOM = [];
@@ -107,11 +100,7 @@ function shrinkWrapSketches(sketches) {
 }
 
 /**
- * Performs a boolean intersection operation between two geometries.
- * @param {string|Object} input1ID - The ID of the first geometry or the geometry object itself
- * @param {string|Object} input2ID - The ID of the second geometry or the geometry object itself
- * @param {string|null} targetID - The ID to store the result in the library. If null, the result is returned
- * @returns {Promise<boolean|Object>} A promise that resolves to true if targetID is provided, or the intersected geometry if targetID is null
+ * Return the intersection between shape1 and shape2.
  */
 function intersect(shape1, shape2) {
   return util.actOnLeafs(shape1, (leaf) => {
@@ -128,11 +117,7 @@ function intersect(shape1, shape2) {
 }
 
 /**
- * Performs a boolean fusion (union) operation on multiple geometries and stores the result in the library.
- * @param {string} targetID - The unique identifier to store the fused geometry in the library
- * @param {string[]} inputIDs - Array of library IDs containing geometries to be fused together
- * @returns {Promise<boolean>} A promise that resolves to true when the fusion is completed successfully
- * @throws {Error} Throws an error if inputs are mixed between 2D and 3D geometries
+ * Return the boolean union between all entries in shapes.
  */
 function fusion(shapes) {
   let fusedGeometry = [];

--- a/src/worker/interaction.js
+++ b/src/worker/interaction.js
@@ -226,7 +226,8 @@ function chainFuse(chain) {
     }
     return fused;
   } catch (e) {
-    throw new Error("Fusion failed");
+    console.log(e);
+    throw new Error("Fusion failed", e);
   }
 }
 

--- a/src/worker/interaction.js
+++ b/src/worker/interaction.js
@@ -122,16 +122,16 @@ function intersect(shape1, shape2) {
 function fusion(shapes) {
   let fusedGeometry = [];
   let bomAssembly = [];
+  const all2D = shapes.every((shape) => !util.is3D(shape));
+  const all3D = shapes.every((shape) => util.is3D(shape));
+  if (!all2D && !all3D) {
+    throw new Error(
+      "Fusion must be composed from only sketches OR only solids"
+    );
+  }
+
   shapes.forEach((shape) => {
-    if (shapes.every((shape) => util.is3D(shape))) {
-      fusedGeometry.push(digFuse(shape));
-    } else if (shapes.every((shape) => !util.is3D(shape))) {
-      fusedGeometry.push(digFuse(shape));
-    } else {
-      throw new Error(
-        "Fusion must be composed from only sketches OR only solids"
-      );
-    }
+    fusedGeometry.push(digFuse(shape));
     if (shape.bom.length > 0) {
       bomAssembly.push(...shape.bom);
     }

--- a/src/worker/interaction.js
+++ b/src/worker/interaction.js
@@ -1,6 +1,6 @@
 import * as util from "./util.js";
 import shrinkWrap from "replicad-shrink-wrap";
-import { Plane } from "replicad";
+import { Plane, Solid } from "replicad";
 
 /**
  * Creates a loft shape by blending between multiple 2D sketches.
@@ -9,32 +9,30 @@ import { Plane } from "replicad";
  * @throws {Error} Throws an error if input parts are not sketches or contain interior geometries
  */
 function loftShapes(sketches) {
-  return started.then(() => {
-    let arrayOfSketchedGeometry = [];
+  let arrayOfSketchedGeometry = [];
 
-    sketches.forEach((sketch) => {
-      if (util.is3D(sketch)) {
-        throw new Error("Parts to be lofted must be sketches");
-      }
-      let partToLoft = digFuse(sketch);
-      let sketchedpart = partToLoft.sketchOnPlane(sketch.plane);
-      if (!sketchedpart.sketches) {
-        arrayOfSketchedGeometry.push(sketchedpart);
-      } else {
-        throw new Error("Sketches to be lofted can't have interior geometries");
-      }
-    });
-    let startGeometry = arrayOfSketchedGeometry.shift();
-    const newPlane = new Plane().pivot(0, "Y");
-
-    return {
-      geometry: [startGeometry.loftWith([...arrayOfSketchedGeometry])],
-      tags: [],
-      plane: newPlane,
-      color: util.defaultColor,
-      bom: [],
-    };
+  sketches.forEach((sketch) => {
+    if (util.is3D(sketch)) {
+      throw new Error("Parts to be lofted must be sketches");
+    }
+    let partToLoft = digFuse(sketch);
+    let sketchedpart = partToLoft.sketchOnPlane(sketch.plane);
+    if (!sketchedpart.sketches) {
+      arrayOfSketchedGeometry.push(sketchedpart);
+    } else {
+      throw new Error("Sketches to be lofted can't have interior geometries");
+    }
   });
+  let startGeometry = arrayOfSketchedGeometry.shift();
+  const newPlane = new Plane().pivot(0, "Y");
+
+  return {
+    geometry: [startGeometry.loftWith([...arrayOfSketchedGeometry])],
+    tags: [],
+    plane: newPlane,
+    color: util.defaultColor,
+    bom: [],
+  };
 }
 
 /**
@@ -183,7 +181,7 @@ async function assembly(geometries) {
     if (all3D || all2D) {
       for (let i = 0; i < geometries.length; i++) {
         const geometry = geometries[i];
-        assembly.push(cutAssembly(geometry, geometries.slice(i + 1), targetID));
+        assembly.push(cutAssembly(geometry, geometries.slice(i + 1)));
         if (geometry.bom.length > 0) {
           bomAssembly.push(...geometry.bom);
         }
@@ -274,7 +272,7 @@ function digFuse(assembly) {
 function cutAssembly(partToCut, cuttingParts) {
   try {
     //If the partToCut is an assembly pass each part back into cutAssembly function to be cut separately
-    if (isAssembly(partToCut)) {
+    if (util.isAssembly(partToCut)) {
       let assemblyToCut = partToCut.geometry;
       let assemblyCut = [];
       assemblyToCut.forEach((part) => {
@@ -282,18 +280,17 @@ function cutAssembly(partToCut, cuttingParts) {
         assemblyCut.push(cutAssembly(part, cuttingParts));
       });
 
-      let subID = generateUniqueID();
       //returns new assembly that has been cut
-      library[subID] = {
-        //This feels like a hack, we shouldn't be using the library internally like this
+      const newAssembly = {
+        //TODO(tristan): Shouldn't we be copying color and plane here?
         geometry: assemblyCut,
         tags: partToCut.tags,
         bom: partToCut.bom,
       };
-      return library[subID];
+      return newAssembly;
     } else {
       // if part to cut is wire geometry, return it unchanged (wires should pass through assemblies)
-      if (isWireGeometry(partToCut)) {
+      if (util.isWireGeometry(partToCut)) {
         return partToCut;
       }
 
@@ -324,29 +321,23 @@ function cutAssembly(partToCut, cuttingParts) {
             });
           });
           // return new cut part
-          let newID = generateUniqueID();
-          library[newID] = {
+          return {
             geometry: newAssembly,
             tags: partToCut.tags,
             color: partToCut.color,
             bom: partToCut.bom,
             plane: partToCut.plane,
           };
-
-          return library[newID];
         }
       }
       // return new cut part
-      let newID = generateUniqueID();
-      library[newID] = {
+      return {
         geometry: [partCutCopy],
         tags: partToCut.tags,
         color: partToCut.color,
         bom: partToCut.bom,
         plane: partToCut.plane,
       };
-
-      return library[newID];
     }
   } catch (e) {
     console.log(e);

--- a/src/worker/interaction.js
+++ b/src/worker/interaction.js
@@ -1,0 +1,423 @@
+import * as util from "./util.js";
+import shrinkWrap from "replicad-shrink-wrap";
+import { Plane } from "replicad";
+
+/**
+ * Creates a loft shape by blending between multiple 2D sketches.
+ * @param {Object[]} sketches - Array of sketch assemblies to be lofted
+ * @returns {Promise<Object>} A promise of an Assembly containing the lofted geometry
+ * @throws {Error} Throws an error if input parts are not sketches or contain interior geometries
+ */
+function loftShapes(sketches) {
+  return started.then(() => {
+    let arrayOfSketchedGeometry = [];
+
+    sketches.forEach((sketch) => {
+      if (util.is3D(sketch)) {
+        throw new Error("Parts to be lofted must be sketches");
+      }
+      let partToLoft = digFuse(sketch);
+      let sketchedpart = partToLoft.sketchOnPlane(sketch.plane);
+      if (!sketchedpart.sketches) {
+        arrayOfSketchedGeometry.push(sketchedpart);
+      } else {
+        throw new Error("Sketches to be lofted can't have interior geometries");
+      }
+    });
+    let startGeometry = arrayOfSketchedGeometry.shift();
+    const newPlane = new Plane().pivot(0, "Y");
+
+    return {
+      geometry: [startGeometry.loftWith([...arrayOfSketchedGeometry])],
+      tags: [],
+      plane: newPlane,
+      color: util.defaultColor,
+      bom: [],
+    };
+  });
+}
+
+/**
+ * Performs a boolean difference operation between two geometries.
+ * This function subtracts the second geometry (cutter) from the first geometry (target).
+ *
+ * @param {string} input1ID - The ID of the base geometry from which material will be removed
+ * @param {string} input2ID - The ID of the cutting geometry that will be subtracted
+ * @returns {Promise<Object>} - A promise that resolves to the resulting geometry after the operation
+ * @throws {Error} - If the input geometries are not of the same type (both must be either 3D or 2D)
+ *
+ * The function maintains all metadata from the base geometry including tags, color, plane, and BOM.
+ * If the base geometry is an assembly, the cut operation is applied to each leaf independently.
+ * Uses bounding box checks to avoid processing cuts for non-overlapping geometries.
+ */
+function difference(target, cutter) {
+  if (
+    (util.is3D(target) && util.is3D(cutter)) ||
+    (!util.is3D(target) && !util.is3D(cutter))
+  ) {
+    // Process each leaf of target independently
+    return util.actOnLeafs(target, (leaf) => {
+      // Start with a clone of the original geometry
+      let resultGeometry = leaf.geometry[0].clone();
+
+      // Apply cuts recursively from cutter, checking bounding boxes
+      resultGeometry = recursiveCut(resultGeometry, cutter);
+
+      return {
+        geometry: [resultGeometry],
+        tags: leaf.tags,
+        color: leaf.color,
+        plane: leaf.plane,
+        bom: leaf.bom,
+      };
+    });
+  } else {
+    throw new Error("Both inputs must be either 3D or 2D");
+  }
+}
+
+/**
+ * Creates a shrink-wrapped boundary around multiple 2D sketches and stores it in the library.
+ * @param {string[]} inputIDs - Array of library IDs containing 2D sketches to be shrink-wrapped
+ * @returns {Promise<boolean>} A promise that resolves to true when the shrink wrapping is completed successfully
+ * @throws {Error} Throws an error if inputs are not all sketches or if sketches have interior geometries
+ */
+function shrinkWrapSketches(sketches) {
+  let BOM = [];
+  if (sketches.every((sketch) => !util.is3D(sketch))) {
+    let inputsToFuse = [];
+    sketches.forEach((sketch) => {
+      let fusedInput = digFuse(sketch);
+      inputsToFuse.push(fusedInput);
+      if (fusedInput.innerShape.blueprints) {
+        throw new Error("Sketches to be lofted can't have interior geometries");
+      }
+      BOM.push(fusedInput.bom);
+    });
+    let geometryToWrap = chainFuse(inputsToFuse);
+    const newPlane = new Plane().pivot(0, "Y");
+    return {
+      geometry: [shrinkWrap(geometryToWrap, 50)],
+      tags: [],
+      color: util.defaultColor,
+      plane: newPlane,
+      bom: BOM,
+    };
+  } else {
+    throw new Error("All inputs must be sketches");
+  }
+}
+
+/**
+ * Performs a boolean intersection operation between two geometries.
+ * @param {string|Object} input1ID - The ID of the first geometry or the geometry object itself
+ * @param {string|Object} input2ID - The ID of the second geometry or the geometry object itself
+ * @param {string|null} targetID - The ID to store the result in the library. If null, the result is returned
+ * @returns {Promise<boolean|Object>} A promise that resolves to true if targetID is provided, or the intersected geometry if targetID is null
+ */
+function intersect(shape1, shape2) {
+  return util.actOnLeafs(shape1, (leaf) => {
+    const shapeToIntersectWith = digFuse(shape2);
+    const newGeom = leaf.geometry[0].clone().intersect(shapeToIntersectWith);
+    return {
+      geometry: [newGeom],
+      tags: leaf.tags,
+      color: leaf.color,
+      plane: leaf.plane,
+      bom: leaf.bom,
+    };
+  });
+}
+
+/**
+ * Performs a boolean fusion (union) operation on multiple geometries and stores the result in the library.
+ * @param {string} targetID - The unique identifier to store the fused geometry in the library
+ * @param {string[]} inputIDs - Array of library IDs containing geometries to be fused together
+ * @returns {Promise<boolean>} A promise that resolves to true when the fusion is completed successfully
+ * @throws {Error} Throws an error if inputs are mixed between 2D and 3D geometries
+ */
+function fusion(shapes) {
+  let fusedGeometry = [];
+  let bomAssembly = [];
+  shapes.forEach((shape) => {
+    if (shapes.every((shape) => util.is3D(shape))) {
+      fusedGeometry.push(digFuse(shape));
+    } else if (shapes.every((shape) => !util.is3D(shape))) {
+      fusedGeometry.push(digFuse(shape));
+    } else {
+      throw new Error(
+        "Fusion must be composed from only sketches OR only solids"
+      );
+    }
+    if (shape.bom.length > 0) {
+      bomAssembly.push(...shape.bom);
+    }
+  });
+  const newPlane = new Plane().pivot(0, "Y");
+  return {
+    geometry: [chainFuse(fusedGeometry)],
+    tags: [],
+    bom: bomAssembly,
+    plane: newPlane,
+    color: util.defaultColor,
+  };
+}
+
+/**
+ * A function which takes in an array of target geometries and forms them into an assembly
+ * Geometries will cut all geometries below them in the list to make sure that no parts intersect
+ * If the targetID is defined, the assembly will be stored in the library under that ID, otherwise it will be returned
+ */
+async function assembly(geometries) {
+  if (!Array.isArray(geometries) || geometries.length === 0) {
+    throw new Error("inputIDs must be a non-empty array");
+  }
+
+  let assembly = [];
+  let bomAssembly = [];
+
+  if (geometries.length > 1) {
+    const all3D = geometries.every((geom) => util.is3D(geom));
+    const all2D = geometries.every((geom) => !util.is3D(geom));
+
+    if (all3D || all2D) {
+      for (let i = 0; i < geometries.length; i++) {
+        const geometry = geometries[i];
+        assembly.push(cutAssembly(geometry, geometries.slice(i + 1), targetID));
+        if (geometry.bom.length > 0) {
+          bomAssembly.push(...geometry.bom);
+        }
+      }
+    } else {
+      console.trace("assembly error. inputs: " + geometries);
+      throw new Error(
+        "Assemblies must be composed from only sketches OR only solids"
+      );
+    }
+  } else {
+    const geometry = geometries[0];
+    assembly.push(geometry);
+    if (geometry.bom.length > 0) {
+      bomAssembly.push(...geometry.bom);
+    }
+  }
+
+  const newPlane = new Plane().pivot(0, "Y");
+  // TODO(tristan): color isn't defined at the top level here. is that a problem?
+  return {
+    geometry: assembly,
+    plane: newPlane,
+    tags: [],
+    bom: bomAssembly,
+  };
+}
+
+//// Helper Functions ////
+
+/**
+ * Performs a chain fusion operation on an array of geometries.
+ * @param {Array} chain - Array of geometry objects to fuse together sequentially
+ * @returns {Object} The resulting fused geometry
+ * @throws {Error} Throws an error if the fusion operation fails
+ */
+function chainFuse(chain) {
+  try {
+    let fused = chain[0].clone();
+    for (let i = 1; i < chain.length; i++) {
+      fused = fused.fuse(chain[i]);
+    }
+    return fused;
+  } catch (e) {
+    throw new Error("Fusion failed");
+  }
+}
+
+/**
+ * Recursively digs through an assembly and fuses all leaf geometries into a single geometry.
+ * @param {Object} assembly - The assembly or leaf geometry to process
+ * @returns {Object} A single fused geometry combining all leaves in the assembly
+ */
+function digFuse(assembly) {
+  var flattened = [];
+
+  if (util.isAssembly(assembly)) {
+    assembly.geometry.forEach((subAssembly) => {
+      if (!util.isAssembly(subAssembly)) {
+        //if it's not an assembly hold on add it to the fusion list
+        flattened.push(subAssembly.geometry[0]);
+      } else {
+        // if it is an assembly keep digging
+        // add the fused things in
+        flattened.push(digFuse(subAssembly));
+      }
+    });
+    return chainFuse(flattened);
+  } else {
+    return assembly.geometry[0];
+  }
+}
+
+/**
+ * Performs a boolean cut operation on an assembly or part with one or more cutting geometries.
+ *
+ * @param {Object} partToCut - The library object (part or assembly) that will be cut
+ * @param {Object[]} cuttingParts - Array of geometries that will cut the part
+ * @returns {Object} - A new object containing either a single cut part or an assembly of cut parts
+ *
+ * This function handles cutting operations on complex hierarchical structures:
+ * - If partToCut is a simple part, it applies all cutting geometries to it sequentially
+ * - If partToCut is an assembly, it recursively processes each leaf in the assembly tree
+ * - Maintains the original hierarchy, tags, colors, and metadata
+ * - Avoids unnecessary operations by checking bounding box intersections
+ * - Preserves the original assembly structure while applying cuts
+ */
+function cutAssembly(partToCut, cuttingParts) {
+  try {
+    //If the partToCut is an assembly pass each part back into cutAssembly function to be cut separately
+    if (isAssembly(partToCut)) {
+      let assemblyToCut = partToCut.geometry;
+      let assemblyCut = [];
+      assemblyToCut.forEach((part) => {
+        // make new assembly from cut parts
+        assemblyCut.push(cutAssembly(part, cuttingParts));
+      });
+
+      let subID = generateUniqueID();
+      //returns new assembly that has been cut
+      library[subID] = {
+        //This feels like a hack, we shouldn't be using the library internally like this
+        geometry: assemblyCut,
+        tags: partToCut.tags,
+        bom: partToCut.bom,
+      };
+      return library[subID];
+    } else {
+      // if part to cut is wire geometry, return it unchanged (wires should pass through assemblies)
+      if (isWireGeometry(partToCut)) {
+        return partToCut;
+      }
+
+      // if part to cut is a single part send to cutting function with cutting parts
+      var partCutCopy = partToCut.geometry[0];
+      cuttingParts.forEach((cuttingPart) => {
+        // for each cutting part cut the part
+        partCutCopy = recursiveCut(partCutCopy, cuttingPart);
+      });
+      /*   if the part is a compound return each solid as a new assembly */
+      function getSolids(compound) {
+        return Array.from(
+          util.replicad.iterTopo(compound.wrapped, "solid"),
+          (s) => new Solid(s)
+        );
+      }
+      if (partCutCopy.wrapped) {
+        let solids = getSolids(partCutCopy);
+        if (solids.length > 1) {
+          let newAssembly = [];
+          solids.forEach((solid) => {
+            newAssembly.push({
+              geometry: [solid],
+              tags: partToCut.tags,
+              color: partToCut.color,
+              bom: partToCut.bom,
+              plane: partToCut.plane,
+            });
+          });
+          // return new cut part
+          let newID = generateUniqueID();
+          library[newID] = {
+            geometry: newAssembly,
+            tags: partToCut.tags,
+            color: partToCut.color,
+            bom: partToCut.bom,
+            plane: partToCut.plane,
+          };
+
+          return library[newID];
+        }
+      }
+      // return new cut part
+      let newID = generateUniqueID();
+      library[newID] = {
+        geometry: [partCutCopy],
+        tags: partToCut.tags,
+        color: partToCut.color,
+        bom: partToCut.bom,
+        plane: partToCut.plane,
+      };
+
+      return library[newID];
+    }
+  } catch (e) {
+    console.log(e);
+    throw new Error("Cut Assembly failed", e);
+  }
+}
+
+/**
+ * Recursively applies boolean cutting operations between geometries with optimization.
+ *
+ * @param {Object} partToCut - The geometry object to be cut
+ * @param {Object} cuttingPart - The library object (may be assembly) used to cut the part
+ * @returns {Object} - The resulting geometry after all applicable cuts have been performed
+ *
+ * This function:
+ * - Recursively processes assemblies, applying cuts only when necessary
+ * - Performs bounding box intersection checks to skip non-intersecting geometries
+ * - Handles nested assemblies by traversing the entire tree of cutting geometries
+ * - Optimizes performance by avoiding cuts with geometries that cannot intersect
+ * - Preserves the structure of both the target and cutting geometries
+ *
+ * The function is a core part of the boolean difference system and is designed
+ * to efficiently handle complex hierarchical structures.
+ */
+function recursiveCut(partToCut, cuttingPart) {
+  try {
+    let cutGeometry = partToCut;
+
+    // Wire geometry should not participate in cutting operations
+    if (util.isWireGeometry({ geometry: [partToCut] })) {
+      return partToCut; // Wire parts should pass through unchanged
+    }
+
+    // if cutting part is an assembly pass back into the function to be cut by each part in that assembly
+    if (util.isAssembly(cuttingPart)) {
+      for (let i = 0; i < cuttingPart.geometry.length; i++) {
+        // Skip cutting with wire geometry
+        if (!util.isWireGeometry(cuttingPart.geometry[i])) {
+          cutGeometry = recursiveCut(cutGeometry, cuttingPart.geometry[i]);
+        }
+      }
+      return cutGeometry;
+    } else {
+      // Skip cutting if the cutting part is wire geometry
+      if (util.isWireGeometry(cuttingPart)) {
+        return partToCut;
+      }
+
+      //If the shapes don't overlap, we don't need to cut them
+      if (partToCut.boundingBox.isOut(cuttingPart.geometry[0].boundingBox)) {
+        return partToCut;
+      }
+      // cut and return part
+      else {
+        let cutPart;
+        cutPart = partToCut.cut(cuttingPart.geometry[0]);
+        return cutPart;
+      }
+    }
+  } catch (e) {
+    console.log(e);
+    throw new Error("Recursive Cut failed", e);
+  }
+}
+
+export {
+  loftShapes,
+  difference,
+  shrinkWrapSketches,
+  intersect,
+  fusion,
+  assembly,
+  digFuse,
+};

--- a/src/worker/shapes.js
+++ b/src/worker/shapes.js
@@ -3,6 +3,12 @@ import Fonts from "../js/fonts.js";
 import { Plane } from "replicad";
 
 /**
+ * Methods in this file create a new geometry from non-geometric inputs. Eg:
+ * create a circle from a diameter. Almost all projects will start with
+ * these methods.
+ */
+
+/**
  * Creates a circle geometry with the specified diameter and stores it in the library.
  * @param {number} diameter - The diameter of the circle
  * @returns Assembly containing a circle on the XY plane

--- a/src/worker/shapes.js
+++ b/src/worker/shapes.js
@@ -1,0 +1,106 @@
+import * as util from "./util.js";
+import Fonts from "../js/fonts.js";
+import { Plane } from "replicad";
+
+/**
+ * Creates a circle geometry with the specified diameter and stores it in the library.
+ * @param {number} diameter - The diameter of the circle
+ * @returns Assembly containing a circle on the XY plane
+ */
+function circle(diameter) {
+  const newPlane = new Plane().pivot(0, "Y");
+  return {
+    geometry: [util.replicad.drawCircle(diameter / 2)],
+    tags: [],
+    plane: newPlane,
+    color: util.defaultColor,
+    bom: [],
+  };
+}
+
+/**
+ * Creates a rectangle geometry with the specified dimensions and stores it in the library.
+ * @param {number} x - The width of the rectangle
+ * @param {number} y - The height of the rectangle
+ * @returns Assembly containing a rectangle on the XY plane
+ */
+function rectangle(x, y) {
+  const newPlane = new Plane().pivot(0, "Y");
+  return {
+    geometry: [util.replicad.drawRectangle(x, y)],
+    tags: [],
+    plane: newPlane,
+    color: util.defaultColor,
+    bom: [],
+  };
+}
+
+/**
+ * Creates a regular polygon geometry with the specified radius and number of sides, and stores it in the library.
+ * @param {number} radius - The radius of the polygon (distance from center to vertex)
+ * @param {number} numberOfSides - The number of sides of the polygon
+ * @returns Assembly containing a regular polygon on the XY plane
+ */
+function regularPolygon(radius, numberOfSides) {
+  const newPlane = new Plane().pivot(0, "Y");
+  return {
+    geometry: [util.replicad.drawPolysides(radius, numberOfSides)],
+    tags: [],
+    plane: newPlane,
+    color: util.defaultColor,
+    bom: [],
+  };
+}
+
+/**
+ * Creates text geometry with the specified text, font size, and font family, and stores it in the library.
+ * @param {string} text - The text content to be rendered
+ * @param {number} fontSize - The size of the font
+ * @param {string} fontFamily - The font family to use for rendering the text
+ * @returns {Promise<Object>} Promise of an Assembly containing text geometry on the XY plane
+ * @throws {Error} Throws an error if the font fails to load
+ */
+async function text(text, fontSize, fontFamily) {
+  return util.replicad
+    .loadFont(Fonts[fontFamily])
+    .then(() => {
+      const newPlane = new Plane().pivot(0, "Y");
+
+      const textGeometry = util.replicad.drawText(text, {
+        startX: 0,
+        startY: 0,
+        fontSize: fontSize,
+        font: fontFamily,
+      });
+      return {
+        geometry: [textGeometry],
+        tags: [],
+        plane: newPlane,
+        color: util.defaultColor,
+        bom: [],
+      };
+    })
+    .catch((err) => {
+      throw new Error("Error loading font: ", err);
+    });
+}
+
+/**
+ * Copies a geometry from one library location to another, typically used for molecule connections.
+ * @param {string} targetID - The unique identifier to store the molecule geometry in the library
+ * @param {string} inputID - The library ID of the geometry to copy for the molecule
+ * @returns {Promise<boolean>} A promise that resolves to true when the molecule operation is completed successfully
+ * @throws {Error} Throws an error if the output ID is undefined
+ */
+function molecule(targetID, inputID) {
+  return started.then(() => {
+    if (library[inputID] != undefined) {
+      library[targetID] = library[inputID];
+    } else {
+      throw new Error("output ID is undefined");
+    }
+    return true;
+  });
+}
+
+export { circle, rectangle, regularPolygon, text, molecule };

--- a/src/worker/tags.js
+++ b/src/worker/tags.js
@@ -73,7 +73,7 @@ function extractBomList(assembly) {
 function extractTag(geometry, TAG) {
   let taggedGeometry = extractTags(geometry, TAG);
   if (taggedGeometry != false) {
-    library[targetID] = {
+    return {
       bom: taggedGeometry.bom,
       geometry: taggedGeometry.geometry,
       tags: taggedGeometry.tags,
@@ -114,6 +114,7 @@ function extractAllTags(geom) {
 
 // Recursively extract geometries with the specified tag.
 function extractTags(inputGeometry, TAG) {
+  // TODO(tristan): this destroys the "plane" property.
   if (inputGeometry.tags.includes(TAG)) {
     return inputGeometry;
   } else if (isAssembly(inputGeometry)) {
@@ -126,13 +127,12 @@ function extractTags(inputGeometry, TAG) {
       }
     });
     if (geometryWithTags.length > 0) {
-      let thethingtoreturn = {
+      return {
         geometry: geometryWithTags,
         tags: inputGeometry.tags,
         color: inputGeometry.color,
         bom: inputGeometry.bom,
       };
-      return thethingtoreturn;
     } else {
       return false;
     }

--- a/src/worker/tags.js
+++ b/src/worker/tags.js
@@ -1,0 +1,185 @@
+/**
+ * Adds tags to a geometry and stores the tagged geometry in the library.
+ * @param {string} targetID - The unique identifier to store the tagged geometry in the library
+ * @param {string} inputID - The library ID of the geometry to tag
+ * @param {string[]} TAG - Array of tags to add to the geometry
+ * @returns {Promise<boolean>} A promise that resolves to true when the tagging is completed successfully
+ */
+function tag(geom, TAG) {
+  return {
+    geometry: geom.geometry,
+    bom: geom.bom,
+    tags: [...TAG, ...geom.tags],
+    color: geom.color,
+    plane: geom.plane,
+  };
+}
+
+/**
+ * Applies a color to a geometry and stores the colored geometry in the library.
+ * @param {string} targetID - The unique identifier to store the colored geometry in the library
+ * @param {string} inputID - The library ID of the geometry to color
+ * @param {string} color - The color to apply to the geometry (hex color code)
+ * @returns {Promise} A promise that resolves when the coloring operation is completed
+ * @note If the color is "#D9544D", a "keepout" tag is automatically added to the geometry
+ */
+function color(geom, color) {
+  return util.actOnLeafs(geom, (leaf) => {
+    // keep out color add tag
+    if (color == "#D9544D") {
+      leaf.tags.push("keepout");
+    }
+    return {
+      geometry: leaf.geometry,
+      tags: [...leaf.tags],
+      color: color,
+      bom: leaf.bom,
+      plane: leaf.plane,
+    };
+  });
+}
+
+/**
+ * Return new assembly with BOM attached.
+ */
+function bom(geom, BOM) {
+  if (geom.bom != []) {
+    BOM = [...geom.bom, BOM];
+  }
+  // TODO(tristan): this drops "plane"
+  return {
+    geometry: geom.geometry,
+    tags: [...geom.tags],
+    bom: BOM,
+    color: geom.color,
+  };
+}
+
+/**
+ * Gets bom list for the given assembly
+ */
+function extractBomList(assembly) {
+  if (assembly.bom !== undefined) {
+    return assembly.bom;
+  } else {
+    // TODO(tristan): shouldn't this walk the assembly tree? Shouldn't our default be an empty list?
+    return false;
+  }
+}
+
+/**
+ * Extracts and returns all assembly components with the given tag.
+ */
+function extractTag(geometry, TAG) {
+  let taggedGeometry = extractTags(geometry, TAG);
+  if (taggedGeometry != false) {
+    library[targetID] = {
+      bom: taggedGeometry.bom,
+      geometry: taggedGeometry.geometry,
+      tags: taggedGeometry.tags,
+      color: taggedGeometry.color,
+    };
+  } else {
+    throw new Error("Tag not found");
+  }
+}
+
+/**
+ * List all tags in the given assembly.
+ */
+function extractAllTags(geom) {
+  // Recursive helper function to collect tags
+  function collectTags(geometry) {
+    let tags = new Set(geometry.tags || []); // Use a Set to ensure uniqueness
+
+    // If the geometry is an assembly, recursively collect tags from subassemblies
+    if (isAssembly(geometry)) {
+      geometry.geometry.forEach((subAssembly) => {
+        const subTags = collectTags(subAssembly);
+        subTags.forEach((tag) => tags.add(tag)); // Add tags from subassemblies
+      });
+    }
+
+    return tags;
+  }
+
+  const allTags = collectTags(geom);
+  let returningArray = Array.from(allTags); // Convert the Set to an array
+
+  returningArray = ["Select Tag", ...new Set(returningArray)];
+  return returningArray;
+}
+
+///// Helper functions /////
+
+// Recursively extract geometries with the specified tag.
+function extractTags(inputGeometry, TAG) {
+  if (inputGeometry.tags.includes(TAG)) {
+    return inputGeometry;
+  } else if (isAssembly(inputGeometry)) {
+    let geometryWithTags = [];
+    inputGeometry.geometry.forEach((subAssembly) => {
+      let extractedGeometry = extractTags(subAssembly, TAG);
+
+      if (extractedGeometry != false) {
+        geometryWithTags.push(extractedGeometry);
+      }
+    });
+    if (geometryWithTags.length > 0) {
+      let thethingtoreturn = {
+        geometry: geometryWithTags,
+        tags: inputGeometry.tags,
+        color: inputGeometry.color,
+        bom: inputGeometry.bom,
+      };
+      return thethingtoreturn;
+    } else {
+      return false;
+    }
+  } else {
+    return false;
+  }
+}
+
+/**
+ * Recursively extracts geometry that does NOT have "keepout" tags from an assembly or single geometry.
+ * @param {Object} inputGeometry - The geometry object to filter keepout tags from
+ * @returns {Object|boolean} The geometry without keepout tags, or false if all geometry has keepout tags
+ */
+function extractKeepOut(inputGeometry) {
+  if (inputGeometry.tags.includes("keepout")) {
+    return false;
+  } else if (isAssembly(inputGeometry)) {
+    let geometryNoKeepOut = [];
+    inputGeometry.geometry.forEach((subAssembly) => {
+      let extractedGeometry = extractKeepOut(subAssembly, "keepout");
+
+      if (extractedGeometry != false) {
+        geometryNoKeepOut.push(extractedGeometry);
+      }
+    });
+    if (geometryNoKeepOut.length > 0) {
+      let thethingtoreturn = {
+        geometry: geometryNoKeepOut,
+        tags: inputGeometry.tags,
+        color: inputGeometry.color,
+        bom: inputGeometry.bom,
+      };
+      return thethingtoreturn;
+    } else {
+      return false;
+    }
+  } else {
+    return inputGeometry;
+  }
+}
+
+export {
+  extractAllTags,
+  tag,
+  color,
+  bom,
+  extractTag,
+  extractBomList,
+  extractKeepOut,
+};

--- a/src/worker/tags.js
+++ b/src/worker/tags.js
@@ -1,10 +1,12 @@
 import { isAssembly, actOnLeafs } from "./util";
 
 /**
- * Adds tags to a geometry and stores the tagged geometry in the library.
- * @param {string} targetID - The unique identifier to store the tagged geometry in the library
- * @param {string} inputID - The library ID of the geometry to tag
- * @param {string[]} TAG - Array of tags to add to the geometry
+ * Methods in this file act on the metadata of a geometry or assembly,
+ * either adding new metadata properties or filtering by existing ones.
+ */
+
+/**
+ * Return a copy of `geom` with the specified tag(s)
  */
 function tag(geom, TAG) {
   return {
@@ -17,10 +19,7 @@ function tag(geom, TAG) {
 }
 
 /**
- * Applies a color to a geometry and stores the colored geometry in the library.
- * @param {string} targetID - The unique identifier to store the colored geometry in the library
- * @param {string} inputID - The library ID of the geometry to color
- * @param {string} color - The color to apply to the geometry (hex color code)
+ * Return a copy of `geom` with the specified color.
  * @note If the color is "#D9544D", a "keepout" tag is automatically added to the geometry
  */
 function color(geom, color) {

--- a/src/worker/tags.js
+++ b/src/worker/tags.js
@@ -1,3 +1,5 @@
+import { isAssembly, actOnLeafs } from "./util";
+
 /**
  * Adds tags to a geometry and stores the tagged geometry in the library.
  * @param {string} targetID - The unique identifier to store the tagged geometry in the library
@@ -24,7 +26,7 @@ function tag(geom, TAG) {
  * @note If the color is "#D9544D", a "keepout" tag is automatically added to the geometry
  */
 function color(geom, color) {
-  return util.actOnLeafs(geom, (leaf) => {
+  return actOnLeafs(geom, (leaf) => {
     // keep out color add tag
     if (color == "#D9544D") {
       leaf.tags.push("keepout");

--- a/src/worker/tags.js
+++ b/src/worker/tags.js
@@ -5,7 +5,6 @@ import { isAssembly, actOnLeafs } from "./util";
  * @param {string} targetID - The unique identifier to store the tagged geometry in the library
  * @param {string} inputID - The library ID of the geometry to tag
  * @param {string[]} TAG - Array of tags to add to the geometry
- * @returns {Promise<boolean>} A promise that resolves to true when the tagging is completed successfully
  */
 function tag(geom, TAG) {
   return {
@@ -22,7 +21,6 @@ function tag(geom, TAG) {
  * @param {string} targetID - The unique identifier to store the colored geometry in the library
  * @param {string} inputID - The library ID of the geometry to color
  * @param {string} color - The color to apply to the geometry (hex color code)
- * @returns {Promise} A promise that resolves when the coloring operation is completed
  * @note If the color is "#D9544D", a "keepout" tag is automatically added to the geometry
  */
 function color(geom, color) {

--- a/src/worker/util.js
+++ b/src/worker/util.js
@@ -93,7 +93,7 @@ function generateUniqueID() {
 function isWireGeometry(inputs) {
   if (isAssembly(inputs)) {
     return inputs.geometry.some((input) => isWireGeometry(input));
-  } else if (inputs.geometry && inputs.geometry[0] instanceof Wire) {
+  } else if (inputs.geometry && inputs.geometry[0] instanceof replicad.Wire) {
     return true;
   } else {
     return false;
@@ -120,4 +120,12 @@ function isAssembly(part) {
   }
 }
 
-export { init, actOnLeafs, replicad, is3D, isWireGeometry, isAssembly };
+export {
+  init,
+  actOnLeafs,
+  replicad,
+  is3D,
+  isWireGeometry,
+  isAssembly,
+  generateUniqueID,
+};

--- a/src/worker/util.js
+++ b/src/worker/util.js
@@ -44,10 +44,8 @@ function is3D(inputs) {
  * @param {*} input - Can be a library ID, util.replicad geometry, or assembly
  * @returns {Object} The bounds object with min and max arrays
  */
-function getBounds(input) {
+function getBounds(geometry) {
   try {
-    const geometry = toGeometry(input);
-
     let minX = Infinity,
       minY = Infinity,
       minZ = Infinity;
@@ -55,9 +53,9 @@ function getBounds(input) {
       maxY = -Infinity,
       maxZ = -Infinity;
 
-    if (util.isAssembly(geometry)) {
+    if (isAssembly(geometry)) {
       // Handle assembly by iterating through all parts
-      util.actOnLeafs(geometry, (leaf) => {
+      actOnLeafs(geometry, (leaf) => {
         if (leaf.geometry && leaf.geometry[0] && leaf.geometry[0].boundingBox) {
           const bbox = leaf.geometry[0].boundingBox.bounds;
           minX = Math.min(minX, bbox[0][0]);

--- a/src/worker/util.js
+++ b/src/worker/util.js
@@ -1,0 +1,60 @@
+import opencascade from "replicad-opencascadejs/src/replicad_single.js";
+import opencascadeWasm from "replicad-opencascadejs/src/replicad_single.wasm?url";
+import * as replicad from "replicad";
+
+let loaded = false;
+const init = async () => {
+  if (loaded) return Promise.resolve(true);
+
+  const OC = await opencascade({
+    locateFile: () => opencascadeWasm,
+  });
+
+  loaded = true;
+  replicad.setOC(OC);
+  console.log(replicad);
+
+  return true;
+};
+
+
+/**
+ * Recursively applies an action function to all leaf geometries in an assembly tree.
+ * @param {Object} assembly - The assembly or leaf geometry to process
+ * @param {Function} action - The function to apply to each leaf geometry. Should return the transformed leaf or undefined to remove it
+ * @param {Object} plane - Optional plane to use for the resulting assembly
+ * @returns {Object} The transformed assembly with the action applied to all leaves
+ */
+function actOnLeafs(assembly, action, plane) {
+  plane = plane || assembly.plane;
+  //This is a leaf
+  if (assembly.geometry == undefined) {
+    console.log("empty geometry found:");
+    console.log(assembly);
+  }
+
+  if (
+    assembly.geometry.length == 1 &&
+    assembly.geometry[0].geometry == undefined
+  ) {
+    return action(assembly);
+  }
+  //This is a branch
+  else {
+    let transformedAssembly = [];
+    assembly.geometry.forEach((subAssembly) => {
+      const result = actOnLeafs(subAssembly, action);
+      if (result != undefined) {
+        transformedAssembly.push(result);
+      }
+    });
+    return {
+      geometry: transformedAssembly,
+      tags: assembly.tags,
+      bom: assembly.bom,
+      plane: plane,
+    };
+  }
+}
+
+export { init, actOnLeafs, replicad };

--- a/src/worker/util.js
+++ b/src/worker/util.js
@@ -185,4 +185,5 @@ export {
   isAssembly,
   generateUniqueID,
   getBounds,
+  defaultColor,
 };

--- a/src/worker/util.js
+++ b/src/worker/util.js
@@ -40,6 +40,64 @@ function is3D(inputs) {
 }
 
 /**
+ * Gets the bounds of the input geometry or assembly.
+ * @param {*} input - Can be a library ID, util.replicad geometry, or assembly
+ * @returns {Object} The bounds object with min and max arrays
+ */
+function getBounds(input) {
+  try {
+    const geometry = toGeometry(input);
+
+    let minX = Infinity,
+      minY = Infinity,
+      minZ = Infinity;
+    let maxX = -Infinity,
+      maxY = -Infinity,
+      maxZ = -Infinity;
+
+    if (util.isAssembly(geometry)) {
+      // Handle assembly by iterating through all parts
+      util.actOnLeafs(geometry, (leaf) => {
+        if (leaf.geometry && leaf.geometry[0] && leaf.geometry[0].boundingBox) {
+          const bbox = leaf.geometry[0].boundingBox.bounds;
+          minX = Math.min(minX, bbox[0][0]);
+          minY = Math.min(minY, bbox[0][1]);
+          minZ = Math.min(minZ, bbox[0][2]);
+          maxX = Math.max(maxX, bbox[1][0]);
+          maxY = Math.max(maxY, bbox[1][1]);
+          maxZ = Math.max(maxZ, bbox[1][2]);
+        }
+      });
+    } else {
+      // Handle single geometry
+      if (
+        geometry.geometry &&
+        geometry.geometry[0] &&
+        geometry.geometry[0].boundingBox
+      ) {
+        const bbox = geometry.geometry[0].boundingBox.bounds;
+        minX = bbox[0][0];
+        minY = bbox[0][1];
+        minZ = bbox[0][2];
+        maxX = bbox[1][0];
+        maxY = bbox[1][1];
+        maxZ = bbox[1][2];
+      } else {
+        throw new Error("Invalid geometry: missing boundingBox");
+      }
+    }
+
+    return {
+      min: [minX, minY, minZ],
+      max: [maxX, maxY, maxZ],
+    };
+  } catch (error) {
+    console.error("GetBounds error:", error);
+    throw new Error(`GetBounds failed: ${error.message}`);
+  }
+}
+
+/**
  * Recursively applies an action function to all leaf geometries in an assembly tree.
  * @param {Object} assembly - The assembly or leaf geometry to process
  * @param {Function} action - The function to apply to each leaf geometry. Should return the transformed leaf or undefined to remove it
@@ -128,4 +186,5 @@ export {
   isWireGeometry,
   isAssembly,
   generateUniqueID,
+  getBounds,
 };

--- a/src/worker/util.js
+++ b/src/worker/util.js
@@ -1,7 +1,9 @@
 import opencascade from "replicad-opencascadejs/src/replicad_single.js";
 import opencascadeWasm from "replicad-opencascadejs/src/replicad_single.wasm?url";
 import * as replicad from "replicad";
+import { v4 as uuidv4 } from "uuid";
 
+let defaultColor = "#aad7f2";
 let loaded = false;
 const init = async () => {
   if (loaded) return Promise.resolve(true);
@@ -12,11 +14,30 @@ const init = async () => {
 
   loaded = true;
   replicad.setOC(OC);
+  console.log("loaded replicad");
   console.log(replicad);
 
   return true;
 };
 
+/**
+ * Checks if the input geometry is 3D (has a mesh) or 2D (sketch).
+ * @param {Object} inputs - The geometry object to check
+ * @returns {boolean} True if the geometry is 3D, false if it's a 2D sketch
+ */
+function is3D(inputs) {
+  // if it's an assembly assume it's 3d since our assemblies don't work for drawings right now
+  if (isAssembly(inputs)) {
+    return inputs.geometry.some((input) => is3D(input));
+  } else if (
+    inputs.geometry[0].mesh !== undefined ||
+    inputs.geometry[0] instanceof replicad.Wire
+  ) {
+    return true;
+  } else {
+    return false;
+  }
+}
 
 /**
  * Recursively applies an action function to all leaf geometries in an assembly tree.
@@ -57,4 +78,46 @@ function actOnLeafs(assembly, action, plane) {
   }
 }
 
-export { init, actOnLeafs, replicad };
+/**
+ * A function to generate a unique ID value.
+ */
+function generateUniqueID() {
+  return uuidv4();
+}
+
+/**
+ * Checks if the input geometry is wire geometry (like from G-code).
+ * @param {Object} inputs - The geometry object to check
+ * @returns {boolean} True if the geometry is wire geometry, false otherwise
+ */
+function isWireGeometry(inputs) {
+  if (isAssembly(inputs)) {
+    return inputs.geometry.some((input) => isWireGeometry(input));
+  } else if (inputs.geometry && inputs.geometry[0] instanceof Wire) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+/**
+ * Checks if a part is an assembly (contains sub-geometries) or a single part.
+ * @param {Object} part - The part object to check
+ * @returns {boolean} True if the part is an assembly, false if it's a single part
+ */
+function isAssembly(part) {
+  if (part == undefined || part.geometry == undefined) {
+    return false;
+  }
+  if (part.geometry.length > 0) {
+    if (part.geometry[0].geometry) {
+      return true;
+    } else {
+      return false;
+    }
+  } else {
+    return false;
+  }
+}
+
+export { init, actOnLeafs, replicad, is3D, isWireGeometry, isAssembly };

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -170,7 +170,7 @@ async function regularPolygon(id, radius, numberOfSides) {
  * @param {string} text - The text content to be rendered
  * @param {number} fontSize - The size of the font
  * @param {string} fontFamily - The font family to use for rendering the text
- * @returns {Promise<boolean>} A promise that resolves to true when the text is created successfully
+ * @returns {Promise<Object>} A promise that resolves to the created text geometry object
  * @throws {Error} Throws an error if the font fails to load
  */
 async function text(id, text, fontSize, fontFamily) {
@@ -219,7 +219,7 @@ async function extrude(targetID, inputID, height) {
  * @param {number} y - The distance to move along the y-axis
  * @param {number} z - The distance to move along the z-axis
  * @param {string|null} targetID - The ID to store the result in the library. If null, the result is returned
- * @returns {Promise<Object>} A promise that resolves to the moved geometry
+ * @returns {Promise<boolean|Object>} A promise that resolves to the moved geometry, or true if targetID is provided
  */
 async function move(geom, x, y, z, targetID = null) {
   await started;
@@ -240,7 +240,7 @@ async function move(geom, x, y, z, targetID = null) {
  * @param {number} y - The angle to rotate around the y axis
  * @param {number} z - The angle to rotate around the z axis
  * @param {string} targetID - The ID to store the result in. If it undefined the result will be returned instead
- * @returns {Promise<Object>} A promise that resolves to the rotated geometry
+ * @returns {Promise<boolean|Object>} A promise that resolves to the rotated geometry or true if targetID is provided
  **/
 async function rotate(geom, x, y, z, targetID = null) {
   await started;
@@ -249,6 +249,7 @@ async function rotate(geom, x, y, z, targetID = null) {
   const result = await actions.rotate(asGeom, x, y, z);
   if (targetID) {
     library[targetID] = result;
+    return true;
   } else {
     return result;
   }
@@ -259,7 +260,7 @@ async function rotate(geom, x, y, z, targetID = null) {
  * @param {Object|string} geom - The geometry to scale, or library ID for same
  * @param {number} scaleFactor - The scale factor to apply (1.0 = no change, 2.0 = double size, 0.5 = half size)
  * @param {string|null} targetID - The ID to store the result in the library. If null, the result is returned
- * @returns {Promise<Object>} A promise that resolves to the scaled geometry
+ * @returns {Promise<boolean|Object>} A promise that resolves to the scaled geometry, or true if targetID is provided
  */
 async function scale(geom, scaleFactor, targetID = null) {
   await started;
@@ -268,6 +269,7 @@ async function scale(geom, scaleFactor, targetID = null) {
   const result = await actions.scale(geom, scaleFactor);
   if (targetID) {
     library[targetID] = result;
+    return true;
   } else {
     return result;
   }
@@ -278,7 +280,7 @@ async function scale(geom, scaleFactor, targetID = null) {
  * @param {Object|string} geom - The geometry to fillet, or library ID for same
  * @param {number} radius - The radius of the fillet
  * @param {string|null} targetID - The ID to store the result in the library. If null, the result is returned
- * @returns {Promise<Object>} A promise that resolves to the filleted geometry
+ * @returns {Promise<boolean|Object>} A promise that resolves to the filleted geometry or true if targetID is provided
  */
 async function fillet(geom, radius, targetID = null) {
   await started;
@@ -289,6 +291,7 @@ async function fillet(geom, radius, targetID = null) {
   );
   if (targetID) {
     library[targetID] = result;
+    return true;
   } else {
     return result;
   }
@@ -299,7 +302,7 @@ async function fillet(geom, radius, targetID = null) {
  * @param {Object|string} geom - The geometry to chamfer, or library ID for same
  * @param {number} size - The size of the chamfer
  * @param {string|null} targetID - The ID to store the result in the library. If null, the result is returned
- * @returns {Promise<Object>} A promise that resolves to the chamfered geometry
+ * @returns {Promise<boolean|Object>} A promise that resolves to the chamfered geometry or true if targetID is provided
  */
 async function chamfer(geom, size, targetID = null) {
   await started;
@@ -310,6 +313,7 @@ async function chamfer(geom, size, targetID = null) {
   );
   if (targetID) {
     library[targetID] = result;
+    return true;
   } else {
     return result;
   }
@@ -450,21 +454,11 @@ function bom(targetID, inputID, BOM) {
  * @returns {Promise<boolean>} A promise that resolves to true when the extraction is completed successfully
  * @throws {Error} Throws an error if the specified tag is not found in the geometry
  */
-function extractTag(targetID, inputID, TAG) {
-  return started.then(() => {
-    let taggedGeometry = extractTags(library[inputID], TAG);
-    if (taggedGeometry != false) {
-      library[targetID] = {
-        bom: taggedGeometry.bom,
-        geometry: taggedGeometry.geometry,
-        tags: taggedGeometry.tags,
-        color: taggedGeometry.color,
-      };
-    } else {
-      throw new Error("Tag not found");
-    }
-    return true;
-  });
+async function extractTag(targetID, inputID, TAG) {
+  await started;
+  assertInLibrary(inputID);
+  library[targetID] = tags.extractTag(library[inputID], TAG);
+  return true;
 }
 
 /**
@@ -762,6 +756,7 @@ function generateThumbnail(inputID) {
  */
 
 function getBoundingBox(inputID) {
+  // TODO(tristan): this is redundant with util.getBounds I think.
   let minX = Infinity,
     minY = Infinity,
     minZ = Infinity;

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -21,7 +21,7 @@ function assertInLibrary(id) {
 
 async function code(targetID, codeText, argumentsArray) {
   await started;
-  const result = codeLib.executeCode(codeText, argumentsArray);
+  const result = await codeLib.executeCode(codeText, argumentsArray, library);
   library[targetID] = result;
   return true;
 }
@@ -66,7 +66,7 @@ async function displayLayout(
   await started;
   assertInLibrary(inputID);
 
-  library[targetID] = cutlayout.displayLayout(
+  library[targetID] = await cutlayout.displayLayout(
     library[inputID],
     placements,
     warningCallback,
@@ -132,11 +132,10 @@ function createMesh(thickness) {
  * @param {number} diameter - The diameter of the circle
  * @returns {Promise<boolean>} A promise that resolves to true when the circle is created successfully
  */
-function circle(id, diameter) {
-  return started.then(() => {
-    library[id] = shapes.circle(diameter);
-    return true;
-  });
+async function circle(id, diameter) {
+  await started;
+  library[id] = await shapes.circle(diameter);
+  return true;
 }
 
 /**
@@ -146,11 +145,10 @@ function circle(id, diameter) {
  * @param {number} y - The height of the rectangle
  * @returns {Promise<boolean>} A promise that resolves to true when the rectangle is created successfully
  */
-function rectangle(id, x, y) {
-  return started.then(() => {
-    library[id] = shapes.rectangle(x, y);
-    return true;
-  });
+async function rectangle(id, x, y) {
+  await started;
+  library[id] = await shapes.rectangle(x, y);
+  return true;
 }
 
 /**
@@ -160,11 +158,10 @@ function rectangle(id, x, y) {
  * @param {number} numberOfSides - The number of sides of the polygon
  * @returns {Promise<boolean>} A promise that resolves to true when the polygon is created successfully
  */
-function regularPolygon(id, radius, numberOfSides) {
-  return started.then(() => {
-    library[id] = shapes.regularPolygon(radius, numberOfSides);
-    return true;
-  });
+async function regularPolygon(id, radius, numberOfSides) {
+  await started;
+  library[id] = await shapes.regularPolygon(radius, numberOfSides);
+  return true;
 }
 
 /**
@@ -191,16 +188,15 @@ async function text(id, text, fontSize, fontFamily) {
  * @returns {Promise<boolean>} A promise that resolves to true when the loft is created successfully
  * @throws {Error} Throws an error if input parts are not sketches or contain interior geometries
  */
-function loftShapes(targetID, inputsIDs) {
-  return started.then(() => {
-    library[targetID] = interaction.loftShapes(
-      (inputsIDs || []).map((id) => {
-        assertInLibrary(id);
-        return library[id];
-      })
-    );
-    return true;
-  });
+async function loftShapes(targetID, inputsIDs) {
+  await started;
+  library[targetID] = await interaction.loftShapes(
+    (inputsIDs || []).map((id) => {
+      assertInLibrary(id);
+      return library[id];
+    })
+  );
+  return true;
 }
 
 /**
@@ -210,11 +206,10 @@ function loftShapes(targetID, inputsIDs) {
  * @param {number} height - The height to extrude the sketch
  * @returns {Promise<boolean>} A promise that resolves to true when the extrusion is completed successfully
  */
-function extrude(targetID, inputID, height) {
-  return started.then(() => {
-    library[targetID] = actions.extrude(library[inputID], height);
-    return true;
-  });
+async function extrude(targetID, inputID, height) {
+  await started;
+  library[targetID] = await actions.extrude(library[inputID], height);
+  return true;
 }
 
 /**
@@ -229,7 +224,7 @@ function extrude(targetID, inputID, height) {
 async function move(geom, x, y, z, targetID = null) {
   await started;
 
-  const result = actions.move(geom, x, y, z);
+  const result = await actions.move(toGeometry(geom, "move-geometry"), x, y, z);
   if (targetID) {
     library[targetID] = result;
   } else {
@@ -250,7 +245,7 @@ async function rotate(geom, x, y, z, targetID = null) {
   await started;
 
   const asGeom = toGeometry(geom, "rotate-geometry"); // TODO(tristan): I'd love to deprecate use of this method here.
-  const result = actions.rotate(asGeom, x, y, z);
+  const result = await actions.rotate(asGeom, x, y, z);
   if (targetID) {
     library[targetID] = result;
   } else {
@@ -269,7 +264,7 @@ async function scale(geom, scaleFactor, targetID = null) {
   await started;
 
   geom = toGeometry(geom, "scale-geometry");
-  const result = actions.scale(geom, scaleFactor);
+  const result = await actions.scale(geom, scaleFactor);
   if (targetID) {
     library[targetID] = result;
   } else {
@@ -287,7 +282,10 @@ async function scale(geom, scaleFactor, targetID = null) {
 async function fillet(geom, radius, targetID = null) {
   await started;
 
-  const result = actions.fillet(toGeometry(geom, "fillet-geometry"), radius);
+  const result = await actions.fillet(
+    toGeometry(geom, "fillet-geometry"),
+    radius
+  );
   if (targetID) {
     library[targetID] = result;
   } else {
@@ -305,7 +303,10 @@ async function fillet(geom, radius, targetID = null) {
 async function chamfer(geom, size, targetID = null) {
   await started;
 
-  const result = actions.chamfer(toGeometry(geom, "chamfer-geometry"), size);
+  const result = awaitactions.chamfer(
+    toGeometry(geom, "chamfer-geometry"),
+    size
+  );
   if (targetID) {
     library[targetID] = result;
   } else {
@@ -328,10 +329,10 @@ async function chamfer(geom, size, targetID = null) {
  * Uses bounding box checks to avoid processing cuts for non-overlapping geometries.
  */
 function difference(targetID, input1ID, input2ID) {
-  return started.then(() => {
+  return started.then(async () => {
     assertInLibrary(input1ID);
     assertInLibrary(input2ID);
-    library[targetID] = interaction.difference(
+    library[targetID] = await interaction.difference(
       library[input1ID],
       library[input2ID]
     );
@@ -347,8 +348,8 @@ function difference(targetID, input1ID, input2ID) {
  * @throws {Error} Throws an error if inputs are not all sketches or if sketches have interior geometries
  */
 function shrinkWrapSketches(targetID, inputIDs) {
-  return started.then(() => {
-    library[targetID] = interaction.shrinkWrapSketches(
+  return started.then(async () => {
+    library[targetID] = await interaction.shrinkWrapSketches(
       inputIDs.map((id) => {
         assertInLibrary(id);
         return library[id];
@@ -366,11 +367,11 @@ function shrinkWrapSketches(targetID, inputIDs) {
  * @returns {Promise<boolean|Object>} A promise that resolves to true if targetID is provided, or the intersected geometry if targetID is null
  */
 function intersect(input1ID, input2ID, targetID = null) {
-  return started.then(() => {
+  return started.then(async () => {
     assertInLibrary(input1ID);
     assertInLibrary(input2ID);
 
-    const result = interaction.intersect(input1ID, input2ID);
+    const result = await interaction.intersect(input1ID, input2ID);
     if (targetID) {
       library[targetID] = result;
       return true;
@@ -784,71 +785,13 @@ function getBoundingBox(inputID) {
 }
 
 /**
- * Gets the bounds of the input geometry or assembly.
- * @param {*} input - Can be a library ID, util.replicad geometry, or assembly
- * @returns {Object} The bounds object with min and max arrays
- */
-function getBounds(input) {
-  try {
-    const geometry = toGeometry(input);
-
-    let minX = Infinity,
-      minY = Infinity,
-      minZ = Infinity;
-    let maxX = -Infinity,
-      maxY = -Infinity,
-      maxZ = -Infinity;
-
-    if (util.isAssembly(geometry)) {
-      // Handle assembly by iterating through all parts
-      util.actOnLeafs(geometry, (leaf) => {
-        if (leaf.geometry && leaf.geometry[0] && leaf.geometry[0].boundingBox) {
-          const bbox = leaf.geometry[0].boundingBox.bounds;
-          minX = Math.min(minX, bbox[0][0]);
-          minY = Math.min(minY, bbox[0][1]);
-          minZ = Math.min(minZ, bbox[0][2]);
-          maxX = Math.max(maxX, bbox[1][0]);
-          maxY = Math.max(maxY, bbox[1][1]);
-          maxZ = Math.max(maxZ, bbox[1][2]);
-        }
-      });
-    } else {
-      // Handle single geometry
-      if (
-        geometry.geometry &&
-        geometry.geometry[0] &&
-        geometry.geometry[0].boundingBox
-      ) {
-        const bbox = geometry.geometry[0].boundingBox.bounds;
-        minX = bbox[0][0];
-        minY = bbox[0][1];
-        minZ = bbox[0][2];
-        maxX = bbox[1][0];
-        maxY = bbox[1][1];
-        maxZ = bbox[1][2];
-      } else {
-        throw new Error("Invalid geometry: missing boundingBox");
-      }
-    }
-
-    return {
-      min: [minX, minY, minZ],
-      max: [maxX, maxY, maxZ],
-    };
-  } catch (error) {
-    console.error("GetBounds error:", error);
-    throw new Error(`GetBounds failed: ${error.message}`);
-  }
-}
-
-/**
  * A function which takes in an array of target geometries and forms them into an assembly
  * Geometries will cut all geometries below them in the list to make sure that no parts intersect
  * If the targetID is defined, the assembly will be stored in the library under that ID, otherwise it will be returned
  */
 async function assembly(geometries, targetID = null) {
   await started;
-  const result = interaction.assembly(
+  const result = await interaction.assembly(
     geometries.map((id) => {
       assertInLibrary(id);
       return library[id];
@@ -871,7 +814,9 @@ async function assembly(geometries, targetID = null) {
  */
 function fusion(targetID, inputIDs) {
   return started.then(() => {
-    library[targetID] = intersection.fusion(
+    console.log("fusion with inputs: " + inputIDs.length);
+    console.log(inputIDs);
+    library[targetID] = interaction.fusion(
       inputIDs.map((id) => {
         assertInLibrary(id);
         return library[id];
@@ -1173,7 +1118,6 @@ if (
     resetView,
     visualizeGcode,
     getBoundingBox,
-    getBounds,
   });
 }
 
@@ -1212,7 +1156,6 @@ export {
   text,
   visualizeGcode,
   getBoundingBox,
-  getBounds,
   generateThumbnail,
   visExport,
   downExport,

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -1,33 +1,72 @@
-import opencascade from "replicad-opencascadejs/src/replicad_single.js";
-import opencascadeWasm from "replicad-opencascadejs/src/replicad_single.wasm?url";
 import * as replicad from "replicad";
 import { expose, proxy } from "comlink";
 import { Plane, Solid, Wire } from "replicad";
 import shrinkWrap from "replicad-shrink-wrap";
 import { drawSVG } from "replicad-decorate";
 import { v4 as uuidv4 } from "uuid";
-import Fonts from "./js/fonts.js";
-import { PolygonPacker, PlacementWrapper } from "polygon-packer";
+import Fonts from "../js/fonts.js";
+import * as cutlayout from "./cutlayout.js";
+import * as util from "./util.js";
 
 var library = {};
 let defaultColor = "#aad7f2";
 
-// This is the logic to load the web assembly code into replicad
-let loaded = false;
-const init = async () => {
-  if (loaded) return Promise.resolve(true);
+const started = util.init();
 
-  const OC = await opencascade({
-    locateFile: () => opencascadeWasm,
-  });
+function assertInLibrary(id) {
+  if (!library[id]) {
+    throw new Error(`Library ID ${id} does not exist.`);
+  }
+}
 
-  loaded = true;
-  replicad.setOC(OC);
-  console.log(replicad);
+// Wrap layout and manage library accesses
+async function layout(
+  targetID,
+  inputID,
+  progressCallback,
+  warningCallback,
+  placementCallback,
+  layoutConfig,
+  priorPlacements
+) {
+  await started;
+  assertInLibrary(inputID);
 
-  return true;
-};
-const started = init();
+  // TODO: check inputID exists in library.
+  return cutlayout
+    .layout(
+      library[inputID],
+      progressCallback,
+      warningCallback,
+      placementCallback,
+      layoutConfig,
+      priorPlacements
+    )
+    .then((resultArray) => {
+      const [layedOutAssembly, positions] = resultArray;
+      library[targetID] = layedOutAssembly;
+      return positions;
+    });
+}
+
+// Wrap displayLayout and manage library accesses
+async function displayLayout(
+  targetID,
+  inputID,
+  placements,
+  warningCallback,
+  layoutConfig
+) {
+  await started;
+  assertInLibrary(inputID);
+
+  library[targetID] = cutlayout.displayLayout(
+    library[inputID],
+    placements,
+    warningCallback,
+    layoutConfig
+  );
+}
 
 /**
  * A function which converts any input into Abundance style geometry. Input can be a library ID, an abundance object, or a single geometry object.
@@ -98,7 +137,7 @@ function circle(id, diameter) {
   return started.then(() => {
     const newPlane = new Plane().pivot(0, "Y");
     library[id] = {
-      geometry: [replicad.drawCircle(diameter / 2)],
+      geometry: [util.replicad.drawCircle(diameter / 2)],
       tags: [],
       plane: newPlane,
       color: defaultColor,
@@ -119,7 +158,7 @@ function rectangle(id, x, y) {
   return started.then(() => {
     const newPlane = new Plane().pivot(0, "Y");
     library[id] = {
-      geometry: [replicad.drawRectangle(x, y)],
+      geometry: [util.replicad.drawRectangle(x, y)],
       tags: [],
       plane: newPlane,
       color: defaultColor,
@@ -140,7 +179,7 @@ function regularPolygon(id, radius, numberOfSides) {
   return started.then(() => {
     const newPlane = new Plane().pivot(0, "Y");
     library[id] = {
-      geometry: [replicad.drawPolysides(radius, numberOfSides)],
+      geometry: [util.replicad.drawPolysides(radius, numberOfSides)],
       tags: [],
       plane: newPlane,
       color: defaultColor,
@@ -159,14 +198,14 @@ function regularPolygon(id, radius, numberOfSides) {
  * @throws {Error} Throws an error if the font fails to load
  */
 async function text(id, text, fontSize, fontFamily) {
-  await replicad
+  await util.replicad
     .loadFont(Fonts[fontFamily])
     .then(() => {
       console.log("Font loaded");
       return started.then(() => {
         const newPlane = new Plane().pivot(0, "Y");
 
-        const textGeometry = replicad.drawText(text, {
+        const textGeometry = util.replicad.drawText(text, {
           startX: 0,
           startY: 0,
           fontSize: fontSize,
@@ -233,7 +272,7 @@ function loftShapes(targetID, inputsIDs) {
  */
 function extrude(targetID, inputID, height) {
   return started.then(() => {
-    library[targetID] = actOnLeafs(library[inputID], (leaf) => {
+    library[targetID] = util.actOnLeafs(library[inputID], (leaf) => {
       return {
         geometry: [
           leaf.geometry[0].clone().sketchOnPlane(leaf.plane).extrude(height),
@@ -296,7 +335,7 @@ async function move(geom, x, y, z, targetID = null) {
 
   geom = toGeometry(geom, "move-geometry");
   if (is3D(geom)) {
-    let result = actOnLeafs(
+    let result = util.actOnLeafs(
       geom,
       (leaf) => {
         return {
@@ -315,7 +354,7 @@ async function move(geom, x, y, z, targetID = null) {
       return result;
     }
   } else {
-    let result = actOnLeafs(
+    let result = util.actOnLeafs(
       geom,
       (leaf) => {
         return {
@@ -351,7 +390,7 @@ async function rotate(geom, x, y, z, targetID = null) {
   await started;
 
   if (is3D(input)) {
-    let result = actOnLeafs(input, (leaf) => {
+    let result = util.actOnLeafs(input, (leaf) => {
       return {
         geometry: [
           leaf.geometry[0]
@@ -372,7 +411,7 @@ async function rotate(geom, x, y, z, targetID = null) {
       return result;
     }
   } else {
-    let result = actOnLeafs(input, (leaf) => {
+    let result = util.actOnLeafs(input, (leaf) => {
       return {
         geometry: [leaf.geometry[0].clone().rotate(z, [0, 0, 0], [0, 0, 1])],
         tags: leaf.tags,
@@ -403,7 +442,7 @@ async function scale(geom, scaleFactor, targetID = null) {
 
   geom = toGeometry(geom, "scale-geometry");
   if (is3D(geom)) {
-    let result = actOnLeafs(
+    let result = util.actOnLeafs(
       geom,
       (leaf) => {
         return {
@@ -422,7 +461,7 @@ async function scale(geom, scaleFactor, targetID = null) {
       return result;
     }
   } else {
-    let result = actOnLeafs(
+    let result = util.actOnLeafs(
       geom,
       (leaf) => {
         return {
@@ -456,7 +495,7 @@ async function fillet(geom, radius, targetID = null) {
 
   geom = toGeometry(geom, "fillet-geometry");
   if (is3D(geom)) {
-    let result = actOnLeafs(
+    let result = util.actOnLeafs(
       geom,
       (leaf) => {
         return {
@@ -475,7 +514,7 @@ async function fillet(geom, radius, targetID = null) {
       return result;
     }
   } else {
-    let result = actOnLeafs(
+    let result = util.actOnLeafs(
       geom,
       (leaf) => {
         return {
@@ -509,7 +548,7 @@ async function chamfer(geom, size, targetID = null) {
 
   geom = toGeometry(geom, "chamfer-geometry");
   if (is3D(geom)) {
-    let result = actOnLeafs(
+    let result = util.actOnLeafs(
       geom,
       (leaf) => {
         return {
@@ -528,7 +567,7 @@ async function chamfer(geom, size, targetID = null) {
       return result;
     }
   } else {
-    let result = actOnLeafs(
+    let result = util.actOnLeafs(
       geom,
       (leaf) => {
         return {
@@ -571,7 +610,7 @@ function difference(targetID, input1ID, input2ID) {
       (!is3D(library[input1ID]) && !is3D(library[input2ID]))
     ) {
       // Process each leaf of input1ID independently
-      library[targetID] = actOnLeafs(library[input1ID], (leaf) => {
+      library[targetID] = util.actOnLeafs(library[input1ID], (leaf) => {
         // Start with a clone of the original geometry
         let resultGeometry = leaf.geometry[0].clone();
 
@@ -642,7 +681,7 @@ function intersect(input1ID, input2ID, targetID = null) {
   let inputGeometry1 = toGeometry(input1ID, "geometry1");
   let inputGeometry2 = toGeometry(input2ID, "geometry2");
   return started.then(() => {
-    let generatedAssembly = actOnLeafs(inputGeometry1, (leaf) => {
+    let generatedAssembly = util.actOnLeafs(inputGeometry1, (leaf) => {
       const shapeToIntersectWith = digFuse(inputGeometry2);
       const newGeom = leaf.geometry[0].clone().intersect(shapeToIntersectWith);
       return {
@@ -785,7 +824,7 @@ async function assemblyMap(assemblyId, callbackFn) {
 
 async function assemblyAsIterable(assemblyId) {
   const result = [];
-  actOnLeafs(toGeometry(assemblyId), (leaf) => {
+  util.actOnLeafs(toGeometry(assemblyId), (leaf) => {
     result.push(leaf);
   });
   // TODO: when we typescriptify things, this should be a read-only list.
@@ -892,7 +931,7 @@ async function code(targetID, code, argumentsArray) {
       "Fillet",
       "Chamfer",
       "library",
-      "replicad",
+      "util.replicad",
     ];
     let inputValues = [
       rotate,
@@ -957,7 +996,7 @@ async function code(targetID, code, argumentsArray) {
  */
 function color(targetID, inputID, color) {
   return started.then(() => {
-    library[targetID] = actOnLeafs(library[inputID], (leaf) => {
+    library[targetID] = util.actOnLeafs(library[inputID], (leaf) => {
       // keep out color add tag
       if (color == "#D9544D") {
         leaf.tags.push("keepout");
@@ -1091,7 +1130,9 @@ function visExport(targetID, inputID, fileType) {
     if (fileType == "SVG") {
       /** Fuses input geometry, draws a top view projection*/
       if (is3D(library[inputID])) {
-        finalGeometry = [replicad.drawProjection(fusedGeometry, "top").visible];
+        finalGeometry = [
+          util.replicad.drawProjection(fusedGeometry, "top").visible,
+        ];
       } else {
         finalGeometry = [fusedGeometry];
       }
@@ -1141,7 +1182,7 @@ function downExport(ID, fileType, svgResolution, units) {
  * @returns {Promise<boolean>} A promise that resolves to true when the import is completed successfully
  */
 async function importingSTEP(targetID, file) {
-  let STEPresult = await replicad.importSTEP(file);
+  let STEPresult = await util.replicad.importSTEP(file);
 
   library[targetID] = {
     geometry: [STEPresult],
@@ -1159,7 +1200,7 @@ async function importingSTEP(targetID, file) {
  * @returns {Promise<boolean>} A promise that resolves to true when the import is completed successfully
  */
 async function importingSTL(targetID, file) {
-  let STLresult = await replicad.importSTL(file);
+  let STLresult = await util.replicad.importSTL(file);
 
   library[targetID] = {
     geometry: [STLresult],
@@ -1180,7 +1221,7 @@ async function importingSTL(targetID, file) {
  */
 async function importingSVG(targetID, svg, width) {
   const baseWidth = width + width * 0.05;
-  const baseShape = replicad
+  const baseShape = util.replicad
     .drawRectangle(baseWidth, baseWidth)
     .sketchOnPlane()
     .extrude(1);
@@ -1240,13 +1281,13 @@ function visualizeGcode(targetID, gcode) {
       let y = yMatch ? Number(yMatch[1]) : currentPosition[1];
       let z = zMatch ? Number(zMatch[1]) : currentPosition[2];
 
-      edges.push(replicad.makeLine(currentPosition, [x, y, z]));
+      edges.push(util.replicad.makeLine(currentPosition, [x, y, z]));
       currentPosition = [x, y, z];
     }
   });
 
   // Create a wire from the edges
-  const wire = replicad.assembleWire(edges);
+  const wire = util.replicad.assembleWire(edges);
   library[targetID] = {
     geometry: [wire],
     tags: [],
@@ -1269,8 +1310,8 @@ const prettyProjection = (shape) => {
     bbox.center[1] - bbox.height,
     bbox.center[2] + bbox.depth,
   ];
-  const camera = new replicad.ProjectionCamera(corner).lookAt(center);
-  const { visible, hidden } = replicad.drawProjection(shape, camera);
+  const camera = new util.replicad.ProjectionCamera(corner).lookAt(center);
+  const { visible, hidden } = util.replicad.drawProjection(shape, camera);
 
   return { visible, hidden };
 };
@@ -1295,7 +1336,10 @@ function generateThumbnail(inputID) {
         fusedGeometry = digFuse(library[inputID])
           .sketchOnPlane("XY")
           .extrude(0.0001);
-        projectionShape = replicad.drawProjection(fusedGeometry, "top").visible;
+        projectionShape = util.replicad.drawProjection(
+          fusedGeometry,
+          "top"
+        ).visible;
         svg = projectionShape.toSVG();
       }
       //let hiddenSvg = projectionShape.hidden.toSVGPaths();
@@ -1374,304 +1418,6 @@ function extractKeepOut(inputGeometry) {
 }
 
 /**
- * @param progressCallback - a function which takes two parameters:
- *    - progress - 0 to 1 inclusive
- *    - cancelationHandle - a callable which cancels this task.
- * @param {*} layoutConfig - dictionary with keys:
- *    - thickness - thickness of the stock material
- *    - width
- *    - height - together with width specifies the demensions of the stock material
- *    - partPadding - space between parts in the resulting placement
- * @param {*} previousPlacements - optional array of previous placements to use as starting point
- */
-function layout(
-  targetID,
-  inputID,
-  progressCallback,
-  warningCallback,
-  placementsCallback,
-  layoutConfig,
-  previousPlacements = null
-) {
-  return started.then(() => {
-    let rotateID = generateUniqueID();
-
-    var shapesForLayout = rotateForLayout(
-      rotateID,
-      inputID,
-      layoutConfig,
-      warningCallback
-    );
-
-    let positionsPromise = computePositions(
-      shapesForLayout,
-      progressCallback,
-      placementsCallback,
-      inputID,
-      targetID,
-      layoutConfig,
-      previousPlacements
-    );
-    return positionsPromise.then((positions) => {
-      //This does the actual layout of the parts.
-      applyLayout(targetID, rotateID, positions, layoutConfig);
-
-      if (positions.length == 0) {
-        throw new Error(
-          "Failed to place any parts. Are sheet dimensions right?"
-        );
-      } else {
-        let unplacedParts = shapesForLayout.length - positions.flat().length;
-        if (unplacedParts > 0) {
-          const warning =
-            unplacedParts +
-            " parts are too big to fit on this sheet size. Failed layout for " +
-            unplacedParts +
-            " part(s)";
-          warningCallback(warning);
-        }
-      }
-
-      return positions;
-    });
-  });
-}
-
-/**
- * Lay the input geometry flat and apply the transformations to display it
- */
-function displayLayout(
-  targetID,
-  inputID,
-  positions,
-  warningCallback,
-  layoutConfig
-) {
-  let rotateID = generateUniqueID();
-  rotateForLayout(rotateID, inputID, layoutConfig, warningCallback);
-
-  applyLayout(targetID, rotateID, positions, layoutConfig);
-}
-
-/**
- * Rotates and moves all leafs into an orientation which can be fed into
- * the nesting algorithm.
- *
- * Specific criteria of this pre-layout step are as follows:
- * 1) rotate the part such that the best possible face is aligned with the XY plane.
- *    Criteria for the best face are as follows (in order):
- *    a) face must be flat (eg: not the edge of a cylinder)
- *    b) face must have no protrusions below the XY plane
- *    c) face must be within the (inferred) thickness of the material
- *    d) face should have minimal number of interior voids and have the largest bounding box
- */
-function rotateForLayout(targetID, inputID, layoutConfig, warningCallback) {
-  var THICKNESS_TOLLERANCE = 0.001;
-
-  function equalThickness(a, b) {
-    return Math.abs(a - b) < THICKNESS_TOLLERANCE;
-  }
-
-  // Get geometry and remove any empty leafs.
-  let geometryToLayout = actOnLeafs(library[inputID], (leaf) => {
-    if (leaf.geometry.length > 0 && leaf.geometry[0].faces.length > 0) {
-      return leaf;
-    } else {
-      return undefined;
-    }
-  });
-
-  let localId = 0;
-  let shapesForLayout = [];
-
-  // Algo overview:
-  // collect all prospective orientations for all parts
-  // come up with a best-guess material thickness or n/a
-  // select among candidates for each part based on either good fit to the
-  //    estimated material thickness, or just take thinnest orientation.
-
-  // get candidates as {leaf_id: "abc", [candidate 1, candidate 2 etc]}
-  const all_candidates = {};
-  const intermediate = actOnLeafs(geometryToLayout, (leaf) => {
-    // For each face, consider it as the underside of the shape on the CNC bed.
-    // In order to be considered, a face must be...
-    //  1) a flat PLANE, not a cylinder, or sphere or other curved face type.
-    //  2) there must be no parts of the shape which protrude "below" this face
-    const candidates = [];
-    let faceIndex = 0;
-    leaf.geometry[0].faces.forEach((face) => {
-      let prospectiveGoem = moveFaceToCuttingPlane(leaf.geometry[0], face);
-      let offset = 0;
-      if (
-        prospectiveGoem.boundingBox.bounds[0][2] <
-        -1 * THICKNESS_TOLLERANCE
-      ) {
-        // this face causes protrusions below the XY plane, move the prospective geometry so that
-        // all points are above the XY plane. Record this movement, since it's a red flag for
-        // this candidate.
-        offset = -1 * prospectiveGoem.boundingBox.bounds[0][2];
-        prospectiveGoem = prospectiveGoem.translate(0, 0, offset);
-      }
-      candidates.push({
-        face: face,
-        offset: offset,
-        geom: prospectiveGoem,
-        faceIndex: faceIndex,
-        thickness: prospectiveGoem.boundingBox.depth,
-      });
-      faceIndex++;
-    });
-
-    all_candidates[localId] = candidates;
-    const newLeaf = {
-      geometry: leaf.geometry,
-      id: localId,
-      tags: leaf.tags,
-      color: leaf.color,
-      plane: leaf.plane,
-      bom: leaf.bom,
-    };
-    localId++;
-    return newLeaf;
-  });
-
-  // Heuristic here is... for each part get it's minimum thickness. If the largest of these is
-  // <= 1" then it's credibly the size of stock being used, so set that as our material
-  // thickness and select among candidates for each part.
-
-  let material_thickness = -1;
-  if (layoutConfig.units) {
-    const LARGEST_PLAUSIBLE_STOCK = layoutConfig.units == "MM" ? 25.4 : 1;
-    const min_thickness_per_part = Object.values(all_candidates).map((s) =>
-      Math.min(...s.map((c) => c.thickness))
-    );
-    if (
-      Math.max(...min_thickness_per_part) <=
-      LARGEST_PLAUSIBLE_STOCK + THICKNESS_TOLLERANCE
-    ) {
-      material_thickness = Math.max(...min_thickness_per_part);
-    }
-  }
-
-  const layoutWarnList = [];
-
-  library[targetID] = actOnLeafs(intermediate, (leaf) => {
-    let candidates = all_candidates[leaf.id];
-    if (candidates == undefined || candidates.length == 0) {
-      // This should be impossible.
-      throw new Error("Failed to filter unplacable part. id: " + leaf.id);
-    }
-    let selected;
-    if (candidates.length == 1) {
-      selected = candidates[0];
-    } else {
-      // For each candidate generate a descriptive struct with the properties we care about.
-      // namely:
-      //  - is planar face
-      //  - offset (how much the of the object is below the face)
-      //  - thickness
-      //  - area (approx)
-      //  - number of interior wires (if any)
-      const scores = candidates.map((c, index) => {
-        return {
-          candidate_index: index,
-          is_planar: c.face.geomType == "PLANE",
-          offset: c.offset,
-          thickness: c.thickness,
-          area: areaApprox(c.face.UVBounds),
-          interiorWires: c.face.clone().innerWires().length,
-        };
-      });
-
-      // Sort in order of preference (scores[0] being best).
-      scores.sort((a, b) => {
-        // Planar faces are preferred because typical cnc machines won't be able to reach the
-        // underside face to make cuts.
-        if (a.is_planar != b.is_planar) {
-          return a.is_planar ? -1 : 1; // prefer planar faces
-        }
-
-        // offset == 0 is preferred since it means our face is flush with the xy plane.
-        if (a.offset != b.offset) {
-          return a.offset - b.offset; // prefer candidates with no offset
-        }
-
-        // Next, prefer thickness that matches material if possible, else pick thinnest
-        // orientation. Or defer if thickness is equal.
-        if (!equalThickness(a.thickness, b.thickness)) {
-          // Candidates with thickness exactly equal to material thickness always win.
-          if (equalThickness(a.thickness, material_thickness)) {
-            return -1;
-          } else if (equalThickness(b.thickness, material_thickness)) {
-            return 1;
-          } else {
-            // Neither candidate is equal to material thickness. Prefer thinnest
-            // candidate.
-            return a.thickness - b.thickness;
-          }
-        }
-
-        // Tie brakes for candidates of equal thickness.
-
-        // First, look for interior wires, if unequal we prefer candidates with fewer since
-        // interior wires *might* indicate carve-outs which are unreachable on the underside of the sheet.
-        if (a.interiorWires != b.interiorWires) {
-          return a.interiorWires - b.interiorWires;
-        }
-
-        // Second (finally), prefer candidates with larger area.
-        if (Math.abs(a.area - b.area) > THICKNESS_TOLLERANCE) {
-          return b.area - a.area;
-        }
-
-        return 0; // we can't decide.
-      });
-      selected = candidates[scores[0].candidate_index];
-    }
-    if (
-      selected.face.geomType != "PLANE" ||
-      selected.offset > THICKNESS_TOLLERANCE
-    ) {
-      layoutWarnList.push(leaf.id);
-    }
-    // move so center of face is at (0, 0, 0)
-    const newGeom = selected.geom
-      .clone()
-      .translate(-1 * selected.face.center.x, -1 * selected.face.center.y, 0);
-
-    let newLeaf = {
-      geometry: [newGeom],
-      id: leaf.id,
-      referencePoint: selected.face.center,
-      tags: leaf.tags,
-      color: leaf.color,
-      plane: leaf.plane,
-      bom: leaf.bom,
-    };
-    // Retrieve face from the re-positioned shape so that we get the shape of the face after
-    // it's been moved to the xy cutting plane. Otherwise we can get weird skewed projections
-    // of the face shape.
-    shapesForLayout.push({
-      id: leaf.id,
-      shape: newLeaf.geometry[0].faces[selected.faceIndex],
-    });
-
-    return newLeaf;
-  });
-
-  // If we have a warning, pass it to the callback
-  if (layoutWarnList.length > 0 && warningCallback) {
-    warningCallback(
-      `Part(s) ${layoutWarnList.join(
-        ", "
-      )} have no orientation suitable for layout.`
-    );
-  }
-
-  return shapesForLayout;
-}
-
-/**
  * Calculate the bounding box of the input geometry by walking through it and finding the min/max of
  * the bounding box of each leaf.
  */
@@ -1684,7 +1430,7 @@ function getBoundingBox(inputID) {
     maxY = -Infinity,
     maxZ = -Infinity;
 
-  actOnLeafs(library[inputID], (leaf) => {
+  util.actOnLeafs(library[inputID], (leaf) => {
     const bbox = leaf.geometry[0].boundingBox.bounds;
     minX = Math.min(minX, bbox[0][0]);
     minY = Math.min(minY, bbox[0][1]);
@@ -1702,7 +1448,7 @@ function getBoundingBox(inputID) {
 
 /**
  * Gets the bounds of the input geometry or assembly.
- * @param {*} input - Can be a library ID, replicad geometry, or assembly
+ * @param {*} input - Can be a library ID, util.replicad geometry, or assembly
  * @returns {Object} The bounds object with min and max arrays
  */
 function getBounds(input) {
@@ -1718,7 +1464,7 @@ function getBounds(input) {
 
     if (isAssembly(geometry)) {
       // Handle assembly by iterating through all parts
-      actOnLeafs(geometry, (leaf) => {
+      util.actOnLeafs(geometry, (leaf) => {
         if (leaf.geometry && leaf.geometry[0] && leaf.geometry[0].boundingBox) {
           const bbox = leaf.geometry[0].boundingBox.bounds;
           minX = Math.min(minX, bbox[0][0]);
@@ -1756,396 +1502,6 @@ function getBounds(input) {
     console.error("GetBounds error:", error);
     throw new Error(`GetBounds failed: ${error.message}`);
   }
-}
-
-/**
- * Apply the transformations to the geometry to apply the layout
- */
-function applyLayout(targetID, inputID, positions, layoutConfig) {
-  console.log("Applying layout");
-  console.log(positions);
-  library[targetID] = actOnLeafs(library[inputID], (leaf) => {
-    let transform, index;
-    for (var i = 0; i < positions.length; i++) {
-      let candidates = positions[i].filter(
-        (transform) => transform.id == leaf.id
-      );
-      if (candidates.length == 1) {
-        transform = candidates[0];
-        index = i;
-        break;
-      } else if (candidates.length > 1) {
-        console.warn("Found more than one transformation for same id");
-      }
-    }
-    if (transform == undefined) {
-      console.log("didn't find transform for id: " + leaf.id);
-      return undefined;
-    }
-    // apply rotation first. All rotations are around (0, 0, 0)
-    // Additionally, shift by sheet-index * sheet height so that multiple
-    // sheet layouts are spaced out from one another.
-    let newGeom = leaf.geometry[0]
-      .clone()
-      .rotate(
-        transform.rotate,
-        new replicad.Vector([0, 0, 0]),
-        new replicad.Vector([0, 0, 1])
-      )
-      .translate(
-        transform.translate.x,
-        transform.translate.y + i * layoutConfig.height,
-        0
-      );
-
-    return {
-      geometry: [newGeom],
-      tags: leaf.tags,
-      color: leaf.color,
-      plane: leaf.plane,
-      bom: leaf.bom,
-      id: leaf.id,
-    };
-  });
-}
-
-/**
- * Converts a shape array of {x, y} points to a Float64Array format for polygon packing.
- * @param {Array} shape - Array of point objects with x and y properties
- * @returns {Float64Array} Float64Array containing points as [x1, y1, x2, y2, ...] with the polygon closed
- * @throws {Error} Throws an error if any points contain NaN values
- */
-function asFloat64(shape) {
-  const points = new Float64Array(shape.length * 2 + 2);
-  let i = 0;
-  shape.forEach((point) => {
-    points[i] = point.x;
-    points[i + 1] = point.y;
-    i += 2;
-  });
-  points[i] = shape[0].x;
-  points[i + 1] = shape[0].y; // close the polygon
-
-  if (points.filter((c) => !Number.isFinite(c)).length > 0) {
-    throw new Error(
-      "NaN points in Float64Array from: " + JSON.stringify(shape)
-    );
-  }
-
-  return points;
-}
-
-/**
- * Use the packing engine, this is potentially time consuming step.
- */
-function computePositions(
-  shapesForLayout,
-  progressCallback,
-  placementsCallback,
-  inputID,
-  targetID,
-  layoutConfig,
-  previousPlacements = null
-) {
-  console.log("Starting to compute positions for shapes: ");
-  console.log(shapesForLayout);
-  
-  const tolerance = 0.2;
-  const runtimeMs = 120000;
-  const config = {
-    curveTolerance: 0.1,
-    spacing: layoutConfig.partPadding + tolerance * 2,
-    rotations: 12, // TODO: this should be higher, like at least 8? idk
-    populationSize: 8,
-    mutationRate: 50,
-    useHoles: false,
-  };
-  // from the mesh format of [x1, y1, z1, x2, y2, z2, ...] to FloatPolygon friendly format of
-  // [{x: x1, y: y1}, {x: x2, y: y2}...]
-  const polygons = shapesForLayout.map((shape, index) => {
-    let face = shape.shape;
-    const mesh = face
-      .clone()
-      .outerWire()
-      .meshEdges({ tolerance: tolerance, angularTolerance: 0.5 }); //The tolerance here is described in the conversation here https://github.com/BarbourSmith/Abundance/pull/173
-
-    const prepared = preparePoints(mesh, tolerance / 100);
-    const result = asFloat64(prepared);
-    return result;
-  });
-
-  // Clockwise winding direction appears to matter here for the current packing algo.
-  const bin = asFloat64([
-    { x: 0, y: 0 },
-    { x: 0, y: layoutConfig.height },
-    { x: layoutConfig.width, y: layoutConfig.height },
-    { x: layoutConfig.width, y: 0 },
-  ]);
-
-  const packer = new PolygonPacker();
-
-  let progressCallbackCounter = 0;
-  const callbackFunction = (num) => {
-    // Forward to the UI thread along with a cancelation handle.
-    // Expect a call every 0.1 seconds for this method.
-    // Unclear what the num argument is supposed to represent
-    progressCallbackCounter++;
-    progressCallback(
-      0.1 + 0.9 * ((progressCallbackCounter * 100) / runtimeMs),
-      proxy(() => {
-        packer.stop(false);
-      })
-    );
-  };
-
-  const result = new Promise((resolve, reject) => {
-    // See https://github.com/yuriilychak/SVGnest/blob/6ed19cf44cb458b11d7ae4abf1868a513c53420a/packages/polygon-packer/src/types.ts#L31
-    let callbackCounter = 0;
-    let bestPlacement = null;
-    const displayCallback = (
-      placementsData,
-      placementPercentage,
-      placedParts,
-      partCount
-    ) => {
-      callbackCounter++;
-      if (placedParts > 0) {
-        let placements = translatePlacements(
-          placementsData,
-          placedParts,
-          partCount
-        );
-
-        placementsCallback(placements);
-        bestPlacement = placements;
-      }
-    };
-
-    try {
-      packer.start(config, polygons, bin, callbackFunction, displayCallback, previousPlacements);
-
-      setTimeout(() => {
-        console.log("Timeout reached. Stopping packer.");
-        if (bestPlacement != null) {
-          packer.stop(true);
-          resolve(bestPlacement);
-        } else {
-          packer.stop(true);
-          reject(new Error("Failed to find placements within the time limit."));
-        }
-      }, runtimeMs);
-    } catch (err) {
-      console.log("error in nesting engine: " + err);
-      packer.stop(true);
-      reject(err);
-    }
-  });
-  return result;
-}
-
-/**
- *
- * @param {} placement
- * @returns List of placements as expected by applyLayout
- *  ie. a list of list of transforms, where each entry in the outer list is for 1 sheet's worth of placement
- *  Each transform follows the structure: {id: "part_id", rotate: degrees, translate: {x: x, y: y}}
- */
-
-function translatePlacements(placement, placedParts, partCount) {
-  const placements = new PlacementWrapper(
-    placement.placementsData,
-    placement.angleSplit
-  );
-  console.log(
-    "new placement received. " +
-      placedParts +
-      " of " +
-      partCount +
-      " parts placed. score: " +
-      placement.placementsData[0]
-  );
-
-  const result = [];
-  for (let i = 0; i < placements.placementCount; i++) {
-    const sheet = [];
-    placements.bindPlacement(i);
-    for (let j = 0; j < placements.size; j++) {
-      placements.bindData(j);
-      sheet.push({
-        id: placements.id,
-        rotate: placements.rotation,
-        translate: { x: placements.x, y: placements.y },
-      });
-    }
-    result.push(sheet);
-  }
-
-  return result;
-}
-
-/**
- * Converts mesh edge data to a polygon-friendly format with proper winding order.
- * @param {Object} mesh - The mesh object containing edge groups and line data
- * @param {number} tolerance - The tolerance for determining if points are equal
- * @returns {Array} Array of {x, y} points in proper winding order
- * @throws {Error} Throws an error if geometry has inconsistent edge continuations
- */
-function preparePoints(mesh, tolerance) {
-  // Unfortunately the "edges" of this mesh aren't always in sequential order. Here we re-sort them so we can
-  // provide them in a winding order, ie, starting at one point and winding around the perimeter of the shape.
-
-  // create structure for lookup of line segments by start point or end point
-  let edgeStarts = [];
-  mesh.edgeGroups.forEach((edge) => {
-    edgeStarts.push({
-      startPoint: {
-        x: mesh.lines[edge.start * 3],
-        y: mesh.lines[edge.start * 3 + 1],
-      },
-      start: edge.start * 3,
-      len: edge.count,
-      edgeId: edge.edgeId,
-    });
-    const endIndex = (edge.start + edge.count - 1) * 3;
-    edgeStarts.push({
-      startPoint: { x: mesh.lines[endIndex], y: mesh.lines[endIndex + 1] },
-      start: endIndex,
-      len: -1 * edge.count,
-      edgeId: edge.edgeId,
-    });
-  });
-
-  const almostEqual = (p1, p2, t = tolerance) => {
-    const x = Math.abs(p1.x - p2.x) < t;
-    const y = Math.abs(p1.y - p2.y) < t;
-    return x && y;
-  };
-
-  const result = [];
-  let currentEdge = edgeStarts[0];
-  while (edgeStarts.length > 0) {
-    // add currentEdge to result. Remember, it could be reverse direction if we matched
-    // an endpoint.
-    for (var i = 1; i < Math.abs(currentEdge.len); i++) {
-      // skip start point
-      let offset = i * 3;
-      if (currentEdge.len < 0) {
-        offset = -1 * offset;
-      }
-      const index = currentEdge.start + offset;
-      const nextPoint = { x: mesh.lines[index], y: mesh.lines[index + 1] };
-      if (
-        result.length == 0 ||
-        !almostEqual(result[result.length - 1], nextPoint)
-      ) {
-        result.push(nextPoint);
-      }
-    }
-
-    // Remove this edge and it's inverse from the lookup table.
-    edgeStarts = edgeStarts.filter((edge) => {
-      return edge.edgeId != currentEdge.edgeId;
-    });
-    if (edgeStarts.length == 0) {
-      break;
-    }
-
-    // else find next edge which starts where current result ends.
-    const nextEdges = edgeStarts.filter((edge) => {
-      return almostEqual(result[result.length - 1], edge.startPoint);
-    });
-    if (nextEdges.length == 0) {
-      throw new Error(
-        "Found a discontinuity in the perimeter of an input part."
-      );
-    } else if (nextEdges.length == 1) {
-      currentEdge = nextEdges[0];
-    } else {
-      // nextEdges.length > 1
-      console.warn("Multiple edges starting at seemingly the same point.");
-      nextEdges.sort((a, b) => {
-        const p1 = result[result.length - 1];
-        const p2 = a.startPoint;
-        const p3 = b.startPoint;
-        const distA = Math.sqrt(
-          Math.pow(p1.x - p2.x, 2) + Math.pow(p1.y - p2.y, 2)
-        );
-        const distB = Math.sqrt(
-          Math.pow(p1.x - p3.x, 2) + Math.pow(p1.y - p3.y, 2)
-        );
-        return distA - distB;
-      });
-      currentEdge = nextEdges[0];
-    }
-  }
-
-  if (result.length < 3) {
-    throw new Error(
-      "Part perimiter has less than 3 points: " + JSON.stringify(result)
-    );
-  }
-  return result;
-}
-
-/**
- * Moves a face to the cutting plane by rotating and translating the geometry.
- * @param {Object} geom - The geometry to transform
- * @param {Object} face - The face to align with the cutting plane
- * @returns {Object} The transformed geometry with the face aligned to the XY cutting plane
- */
-function moveFaceToCuttingPlane(geom, face) {
-  // There's a broken edge case in the clipper lib which gets triggered if one of the perimeter lines is
-  // co-incident with the X or Y axis. Here use the center of the face to ensure the origin isn't aligned with
-  // any perimeter edge of this face.
-  // Try removing this once https://github.com/BarbourSmith/Abundance/issues/572 is resolved.
-  let center = {
-    x: (face.UVBounds.uMin + face.UVBounds.uMax) / 2,
-    y: (face.UVBounds.vMin + face.UVBounds.vMax) / 2,
-  };
-
-  let pointOnSurface = face.pointOnSurface(center.x, center.y);
-  let faceNormal = face.normalAt();
-
-  // Always use "XY" plane as the cutting surface. Attempt to reorient
-  // the given face so it's normal vector points down the Z axis. Down because
-  // the normal vector points out of the surface of our 3d shape, and the interior
-  // of the 3D shape should be placed above the XY plane.
-  let targetOrientation = new replicad.Vector([0, 0, -1]);
-
-  let rotationAxis = faceNormal.cross(targetOrientation);
-  if (rotationAxis.Length == 0) {
-    if (faceNormal.dot(targetOrientation) < 0) {
-      // Face points upward but is otherwise parallel to cut plane. flip 180 around x axis.
-      geom = geom
-        .clone()
-        .rotate(180, pointOnSurface, new replicad.Vector([1, 0, 0]));
-    }
-
-    // Face already parallel to cut plane and on underside of the shape.
-    return geom.clone().translate(0, 0, -1 * pointOnSurface.z);
-  }
-
-  let rotationDegrees =
-    (Math.acos(
-      faceNormal.dot(targetOrientation) /
-        (targetOrientation.Length * faceNormal.Length)
-    ) *
-      360) /
-    (2 * Math.PI);
-
-  return geom
-    .clone()
-    .rotate(rotationDegrees, pointOnSurface, rotationAxis)
-    .translate(0, 0, -1 * pointOnSurface.z);
-}
-
-/**
- * Calculates an approximate area from UV bounds.
- * @param {Object} bounds - The bounds object containing uMin, uMax, vMin, vMax properties
- * @returns {number} The approximate area calculated from the bounds
- */
-function areaApprox(bounds) {
-  return (bounds.uMax - bounds.uMin) * (bounds.vMax - bounds.vMin);
 }
 
 /**
@@ -2217,7 +1573,7 @@ function cutAssembly(partToCut, cuttingParts) {
       /*   if the part is a compound return each solid as a new assembly */
       function getSolids(compound) {
         return Array.from(
-          replicad.iterTopo(compound.wrapped, "solid"),
+          util.replicad.iterTopo(compound.wrapped, "solid"),
           (s) => new Solid(s)
         );
       }
@@ -2422,45 +1778,6 @@ function fusion(targetID, inputIDs) {
     };
     return true;
   });
-}
-
-/**
- * Recursively applies an action function to all leaf geometries in an assembly tree.
- * @param {Object} assembly - The assembly or leaf geometry to process
- * @param {Function} action - The function to apply to each leaf geometry. Should return the transformed leaf or undefined to remove it
- * @param {Object} plane - Optional plane to use for the resulting assembly
- * @returns {Object} The transformed assembly with the action applied to all leaves
- */
-function actOnLeafs(assembly, action, plane) {
-  plane = plane || assembly.plane;
-  //This is a leaf
-  if (assembly.geometry == undefined) {
-    console.log("empty geometry found:");
-    console.log(assembly);
-  }
-
-  if (
-    assembly.geometry.length == 1 &&
-    assembly.geometry[0].geometry == undefined
-  ) {
-    return action(assembly);
-  }
-  //This is a branch
-  else {
-    let transformedAssembly = [];
-    assembly.geometry.forEach((subAssembly) => {
-      const result = actOnLeafs(subAssembly, action);
-      if (result != undefined) {
-        transformedAssembly.push(result);
-      }
-    });
-    return {
-      geometry: transformedAssembly,
-      tags: assembly.tags,
-      bom: assembly.bom,
-      plane: plane,
-    };
-  }
 }
 
 /**
@@ -2795,7 +2112,7 @@ if (
     visualizeGcode,
     getBoundingBox,
     getBounds,
-  })
+  });
 }
 
 // Export functions for testing and ES module environments

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -30,7 +30,27 @@ async function code(targetID, codeText, argumentsArray) {
   return true;
 }
 
-// Wrap layout and manage library accesses
+/**
+ * Lay out the parts from inputID to be cut out from a sheet of material. Attempts to lay them out
+ * in a compact and machinable way while respecting the layoutConfig.
+ *
+ * @param {string} inputID - Shape or assembly to be layed out
+ * @param {string} targetID - The unique identifier to store the layed out assembly in the library
+ * @param progressCallback - a function which takes two parameters:
+ *    - progress - 0 to 1 inclusive
+ *    - cancelationHandle - a callable which cancels this task.
+ * @param warningCallback - a to be called with an informational message if layout fails or partially fails.
+ * @param placementCallback - called back with a placement object specifying a singular layout for these parts.
+ *    - will be called multiple times as progressively better layouts are found.
+ * @param {*} layoutConfig - dictionary with keys:
+ *    - width
+ *    - height - together with width specifies the dimensions of the stock material
+ *    - partPadding - space between parts in the resulting placement
+ *    - units - MM or Inches. Used for resolution when generating part perimeters
+ * @param {*} priorPlacements - optional array of previous placements to use as starting point
+ *
+ * @returns {Promise<Array>} A promise that resolves to the best placement found during this run.
+ */
 async function layout(
   targetID,
   inputID,
@@ -58,7 +78,17 @@ async function layout(
     });
 }
 
-// Wrap displayLayout and manage library accesses
+/**
+ * Lays out the parts of InputID according to the positions described in placements. Where `placements`
+ * is the result of an earlier call to `layout`.
+ *
+ * @param {string} targetID - where in the library to store the resulting layed out assembly.
+ * @param {string} inputID - the ID of the input geometry to layout
+ * @param {*} placements - the placement information from the layout
+ * @param {*} warningCallback - will be called back if there are issues with this placement (eg: does not account for all parts)
+ * @param {*} layoutConfig - the layout configuration. See `layout` for expected properties.
+ * @returns {Promise<boolean>} A promise that resolves when the layout is displayed.
+ */
 async function displayLayout(
   targetID,
   inputID,
@@ -74,6 +104,8 @@ async function displayLayout(
     warningCallback,
     layoutConfig
   );
+
+  return true;
 }
 
 /**

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -32,7 +32,6 @@ async function layout(
   await started;
   assertInLibrary(inputID);
 
-  // TODO: check inputID exists in library.
   return cutlayout
     .layout(
       library[inputID],
@@ -931,7 +930,7 @@ async function code(targetID, code, argumentsArray) {
       "Fillet",
       "Chamfer",
       "library",
-      "util.replicad",
+      "replicad",
     ];
     let inputValues = [
       rotate,
@@ -946,7 +945,7 @@ async function code(targetID, code, argumentsArray) {
       fillet,
       chamfer,
       library,
-      replicad,
+      util.replicad,
     ];
     for (const [key, value] of Object.entries(argumentsArray)) {
       // Sanitize parameter names to prevent injection

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -14,6 +14,9 @@ var library = {};
 const started = util.init();
 
 function getOrThrow(id) {
+  if (id == undefined) {
+    throw new Error("Missing a required input");
+  }
   if (!library[id]) {
     throw new Error(`Library ID ${id} does not exist.`);
   }
@@ -169,14 +172,14 @@ async function regularPolygon(id, radius, numberOfSides) {
  * @param {string} text - The text content to be rendered
  * @param {number} fontSize - The size of the font
  * @param {string} fontFamily - The font family to use for rendering the text
- * @returns {Promise<Object>} A promise that resolves to the created text geometry object
+ * @returns {Promise<boolean>} A promise that resolves to true when the text geometry is created successfully
  * @throws {Error} Throws an error if the font fails to load
  */
 async function text(id, text, fontSize, fontFamily) {
   return started.then(async () => {
     const result = await shapes.text(text, fontSize, fontFamily);
     library[id] = result;
-    return result;
+    return true;
   });
 }
 
@@ -204,7 +207,7 @@ async function loftShapes(targetID, inputsIDs) {
  */
 async function extrude(targetID, inputID, height) {
   await started;
-  library[targetID] = await actions.extrude(getOrThrow, height);
+  library[targetID] = await actions.extrude(getOrThrow(inputID), height);
   return true;
 }
 
@@ -502,7 +505,7 @@ function extractBomList(inputID) {
  */
 function visExport(targetID, inputID, fileType) {
   return started.then(() => {
-    let geometryToExport = extractKeepOut(library[inputID]);
+    let geometryToExport = tags.extractKeepOut(library[inputID]);
     let fusedGeometry = interaction.digFuse(geometryToExport);
     let displayColor =
       fileType == "STL"

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -1,15 +1,15 @@
-import * as replicad from "replicad";
-import { expose, proxy } from "comlink";
-import { Plane, Solid, Wire } from "replicad";
-import shrinkWrap from "replicad-shrink-wrap";
+import { expose } from "comlink";
+import { Plane } from "replicad";
 import { drawSVG } from "replicad-decorate";
-import { v4 as uuidv4 } from "uuid";
-import Fonts from "../js/fonts.js";
 import * as cutlayout from "./cutlayout.js";
 import * as util from "./util.js";
+import * as shapes from "./shapes.js";
+import * as actions from "./actions.js";
+import * as interaction from "./interaction.js";
+import * as tags from "./tags.js";
+import * as codeLib from "./code.js";
 
 var library = {};
-let defaultColor = "#aad7f2";
 
 const started = util.init();
 
@@ -17,6 +17,13 @@ function assertInLibrary(id) {
   if (!library[id]) {
     throw new Error(`Library ID ${id} does not exist.`);
   }
+}
+
+async function code(targetID, codeText, argumentsArray) {
+  await started;
+  const result = codeLib.executeCode(codeText, argumentsArray);
+  library[targetID] = result;
+  return true;
 }
 
 // Wrap layout and manage library accesses
@@ -88,20 +95,13 @@ function toGeometry(input, name = "geometry") {
     return {
       geometry: [input],
       tags: [],
-      color: defaultColor,
+      color: util.defaultColor,
       bom: [],
     };
   } else {
     // If it's something else, we throw an error
     throw new Error(name + " value cannot be interpreted as geometry.");
   }
-}
-
-/**
- * A function to generate a unique ID value.
- */
-function generateUniqueID() {
-  return uuidv4();
 }
 
 /**
@@ -134,14 +134,7 @@ function createMesh(thickness) {
  */
 function circle(id, diameter) {
   return started.then(() => {
-    const newPlane = new Plane().pivot(0, "Y");
-    library[id] = {
-      geometry: [util.replicad.drawCircle(diameter / 2)],
-      tags: [],
-      plane: newPlane,
-      color: defaultColor,
-      bom: [],
-    };
+    library[id] = shapes.circle(diameter);
     return true;
   });
 }
@@ -155,14 +148,7 @@ function circle(id, diameter) {
  */
 function rectangle(id, x, y) {
   return started.then(() => {
-    const newPlane = new Plane().pivot(0, "Y");
-    library[id] = {
-      geometry: [util.replicad.drawRectangle(x, y)],
-      tags: [],
-      plane: newPlane,
-      color: defaultColor,
-      bom: [],
-    };
+    library[id] = shapes.rectangle(x, y);
     return true;
   });
 }
@@ -176,17 +162,11 @@ function rectangle(id, x, y) {
  */
 function regularPolygon(id, radius, numberOfSides) {
   return started.then(() => {
-    const newPlane = new Plane().pivot(0, "Y");
-    library[id] = {
-      geometry: [util.replicad.drawPolysides(radius, numberOfSides)],
-      tags: [],
-      plane: newPlane,
-      color: defaultColor,
-      bom: [],
-    };
+    library[id] = shapes.regularPolygon(radius, numberOfSides);
     return true;
   });
 }
+
 /**
  * Creates text geometry with the specified text, font size, and font family, and stores it in the library.
  * @param {string} id - The unique identifier to store the text geometry in the library
@@ -197,32 +177,11 @@ function regularPolygon(id, radius, numberOfSides) {
  * @throws {Error} Throws an error if the font fails to load
  */
 async function text(id, text, fontSize, fontFamily) {
-  await util.replicad
-    .loadFont(Fonts[fontFamily])
-    .then(() => {
-      console.log("Font loaded");
-      return started.then(() => {
-        const newPlane = new Plane().pivot(0, "Y");
-
-        const textGeometry = util.replicad.drawText(text, {
-          startX: 0,
-          startY: 0,
-          fontSize: fontSize,
-          font: fontFamily,
-        });
-        library[id] = {
-          geometry: [textGeometry],
-          tags: [],
-          plane: newPlane,
-          color: defaultColor,
-          bom: [],
-        };
-        return true;
-      });
-    })
-    .catch((err) => {
-      throw new Error("Error loading font: ", err);
-    });
+  return started.then(async () => {
+    const result = await shapes.text(text, fontSize, fontFamily);
+    library[id] = result;
+    return result;
+  });
 }
 
 /**
@@ -234,30 +193,12 @@ async function text(id, text, fontSize, fontFamily) {
  */
 function loftShapes(targetID, inputsIDs) {
   return started.then(() => {
-    let arrayOfSketchedGeometry = [];
-
-    inputsIDs.forEach((inputID) => {
-      if (is3D(library[inputID])) {
-        throw new Error("Parts to be lofted must be sketches");
-      }
-      let partToLoft = digFuse(library[inputID]);
-      let sketchedpart = partToLoft.sketchOnPlane(library[inputID].plane);
-      if (!sketchedpart.sketches) {
-        arrayOfSketchedGeometry.push(sketchedpart);
-      } else {
-        throw new Error("Sketches to be lofted can't have interior geometries");
-      }
-    });
-    let startGeometry = arrayOfSketchedGeometry.shift();
-    const newPlane = new Plane().pivot(0, "Y");
-
-    library[targetID] = {
-      geometry: [startGeometry.loftWith([...arrayOfSketchedGeometry])],
-      tags: [],
-      plane: newPlane,
-      color: defaultColor,
-      bom: [],
-    };
+    library[targetID] = interaction.loftShapes(
+      (inputsIDs || []).map((id) => {
+        assertInLibrary(id);
+        return library[id];
+      })
+    );
     return true;
   });
 }
@@ -271,53 +212,9 @@ function loftShapes(targetID, inputsIDs) {
  */
 function extrude(targetID, inputID, height) {
   return started.then(() => {
-    library[targetID] = util.actOnLeafs(library[inputID], (leaf) => {
-      return {
-        geometry: [
-          leaf.geometry[0].clone().sketchOnPlane(leaf.plane).extrude(height),
-        ],
-        tags: leaf.tags,
-        plane: leaf.plane,
-        color: leaf.color,
-        bom: leaf.bom,
-      };
-    });
+    library[targetID] = actions.extrude(library[inputID], height);
     return true;
   });
-}
-
-/**
- * Checks if the input geometry is 3D (has a mesh) or 2D (sketch).
- * @param {Object} inputs - The geometry object to check
- * @returns {boolean} True if the geometry is 3D, false if it's a 2D sketch
- */
-function is3D(inputs) {
-  // if it's an assembly assume it's 3d since our assemblies don't work for drawings right now
-  if (isAssembly(inputs)) {
-    return inputs.geometry.some((input) => is3D(input));
-  } else if (
-    inputs.geometry[0].mesh !== undefined ||
-    inputs.geometry[0] instanceof Wire
-  ) {
-    return true;
-  } else {
-    return false;
-  }
-}
-
-/**
- * Checks if the input geometry is wire geometry (like from G-code).
- * @param {Object} inputs - The geometry object to check
- * @returns {boolean} True if the geometry is wire geometry, false otherwise
- */
-function isWireGeometry(inputs) {
-  if (isAssembly(inputs)) {
-    return inputs.geometry.some((input) => isWireGeometry(input));
-  } else if (inputs.geometry && inputs.geometry[0] instanceof Wire) {
-    return true;
-  } else {
-    return false;
-  }
 }
 
 /**
@@ -332,47 +229,12 @@ function isWireGeometry(inputs) {
 async function move(geom, x, y, z, targetID = null) {
   await started;
 
-  geom = toGeometry(geom, "move-geometry");
-  if (is3D(geom)) {
-    let result = util.actOnLeafs(
-      geom,
-      (leaf) => {
-        return {
-          geometry: [leaf.geometry[0].clone().translate(x, y, z)],
-          plane: leaf.plane,
-          tags: leaf.tags,
-          color: leaf.color,
-          bom: leaf.bom,
-        };
-      },
-      geom.plane
-    );
-    if (targetID) {
-      library[targetID] = result;
-    } else {
-      return result;
-    }
+  const result = actions.move(geom, x, y, z);
+  if (targetID) {
+    library[targetID] = result;
   } else {
-    let result = util.actOnLeafs(
-      geom,
-      (leaf) => {
-        return {
-          geometry: [leaf.geometry[0].clone().translate([x, y])],
-          tags: leaf.tags,
-          plane: leaf.plane.translate([0, 0, z]),
-          color: leaf.color,
-          bom: leaf.bom,
-        };
-      },
-      geom.plane.translate([0, 0, z])
-    );
-    if (targetID) {
-      library[targetID] = result;
-    } else {
-      return result;
-    }
+    return result;
   }
-  return true;
 }
 
 /**
@@ -385,48 +247,15 @@ async function move(geom, x, y, z, targetID = null) {
  * @returns {Promise<Object>} A promise that resolves to the rotated geometry
  **/
 async function rotate(geom, x, y, z, targetID = null) {
-  let input = toGeometry(geom, "rotate-geometry");
   await started;
 
-  if (is3D(input)) {
-    let result = util.actOnLeafs(input, (leaf) => {
-      return {
-        geometry: [
-          leaf.geometry[0]
-            .clone()
-            .rotate(x, [0, 0, 0], [1, 0, 0])
-            .rotate(y, [0, 0, 0], [0, 1, 0])
-            .rotate(z, [0, 0, 0], [0, 0, 1]),
-        ],
-        tags: leaf.tags,
-        plane: leaf.plane,
-        color: leaf.color,
-        bom: leaf.bom,
-      };
-    });
-    if (targetID) {
-      library[targetID] = result;
-    } else {
-      return result;
-    }
+  const asGeom = toGeometry(geom, "rotate-geometry"); // TODO(tristan): I'd love to deprecate use of this method here.
+  const result = actions.rotate(asGeom, x, y, z);
+  if (targetID) {
+    library[targetID] = result;
   } else {
-    let result = util.actOnLeafs(input, (leaf) => {
-      return {
-        geometry: [leaf.geometry[0].clone().rotate(z, [0, 0, 0], [0, 0, 1])],
-        tags: leaf.tags,
-        plane: leaf.plane.pivot(x, "X").pivot(y, "Y"),
-        color: leaf.color,
-        bom: leaf.bom,
-      };
-    });
-    if (targetID) {
-      library[targetID] = result;
-      //library[inputID].plane.pivot(x, "X").pivot(y, "Y"); //@Alzatin what is this line for?
-    } else {
-      return result;
-    }
+    return result;
   }
-  return true;
 }
 
 /**
@@ -440,46 +269,12 @@ async function scale(geom, scaleFactor, targetID = null) {
   await started;
 
   geom = toGeometry(geom, "scale-geometry");
-  if (is3D(geom)) {
-    let result = util.actOnLeafs(
-      geom,
-      (leaf) => {
-        return {
-          geometry: [leaf.geometry[0].clone().scale(scaleFactor)],
-          plane: leaf.plane,
-          tags: leaf.tags,
-          color: leaf.color,
-          bom: leaf.bom,
-        };
-      },
-      geom.plane
-    );
-    if (targetID) {
-      library[targetID] = result;
-    } else {
-      return result;
-    }
+  const result = actions.scale(geom, scaleFactor);
+  if (targetID) {
+    library[targetID] = result;
   } else {
-    let result = util.actOnLeafs(
-      geom,
-      (leaf) => {
-        return {
-          geometry: [leaf.geometry[0].clone().scale(scaleFactor)],
-          tags: leaf.tags,
-          plane: leaf.plane,
-          color: leaf.color,
-          bom: leaf.bom,
-        };
-      },
-      geom.plane
-    );
-    if (targetID) {
-      library[targetID] = result;
-    } else {
-      return result;
-    }
+    return result;
   }
-  return true;
 }
 
 /**
@@ -492,47 +287,12 @@ async function scale(geom, scaleFactor, targetID = null) {
 async function fillet(geom, radius, targetID = null) {
   await started;
 
-  geom = toGeometry(geom, "fillet-geometry");
-  if (is3D(geom)) {
-    let result = util.actOnLeafs(
-      geom,
-      (leaf) => {
-        return {
-          geometry: [leaf.geometry[0].clone().fillet(radius)],
-          plane: leaf.plane,
-          tags: leaf.tags,
-          color: leaf.color,
-          bom: leaf.bom,
-        };
-      },
-      geom.plane
-    );
-    if (targetID) {
-      library[targetID] = result;
-    } else {
-      return result;
-    }
+  const result = actions.fillet(toGeometry(geom, "fillet-geometry"), radius);
+  if (targetID) {
+    library[targetID] = result;
   } else {
-    let result = util.actOnLeafs(
-      geom,
-      (leaf) => {
-        return {
-          geometry: [leaf.geometry[0].clone().fillet(radius)],
-          tags: leaf.tags,
-          plane: leaf.plane,
-          color: leaf.color,
-          bom: leaf.bom,
-        };
-      },
-      geom.plane
-    );
-    if (targetID) {
-      library[targetID] = result;
-    } else {
-      return result;
-    }
+    return result;
   }
-  return true;
 }
 
 /**
@@ -545,47 +305,12 @@ async function fillet(geom, radius, targetID = null) {
 async function chamfer(geom, size, targetID = null) {
   await started;
 
-  geom = toGeometry(geom, "chamfer-geometry");
-  if (is3D(geom)) {
-    let result = util.actOnLeafs(
-      geom,
-      (leaf) => {
-        return {
-          geometry: [leaf.geometry[0].clone().chamfer(size)],
-          plane: leaf.plane,
-          tags: leaf.tags,
-          color: leaf.color,
-          bom: leaf.bom,
-        };
-      },
-      geom.plane
-    );
-    if (targetID) {
-      library[targetID] = result;
-    } else {
-      return result;
-    }
+  const result = actions.chamfer(toGeometry(geom, "chamfer-geometry"), size);
+  if (targetID) {
+    library[targetID] = result;
   } else {
-    let result = util.actOnLeafs(
-      geom,
-      (leaf) => {
-        return {
-          geometry: [leaf.geometry[0].clone().chamfer(size)],
-          tags: leaf.tags,
-          plane: leaf.plane,
-          color: leaf.color,
-          bom: leaf.bom,
-        };
-      },
-      geom.plane
-    );
-    if (targetID) {
-      library[targetID] = result;
-    } else {
-      return result;
-    }
+    return result;
   }
-  return true;
 }
 
 /**
@@ -604,29 +329,12 @@ async function chamfer(geom, size, targetID = null) {
  */
 function difference(targetID, input1ID, input2ID) {
   return started.then(() => {
-    if (
-      (is3D(library[input1ID]) && is3D(library[input2ID])) ||
-      (!is3D(library[input1ID]) && !is3D(library[input2ID]))
-    ) {
-      // Process each leaf of input1ID independently
-      library[targetID] = util.actOnLeafs(library[input1ID], (leaf) => {
-        // Start with a clone of the original geometry
-        let resultGeometry = leaf.geometry[0].clone();
-
-        // Apply cuts recursively from input2ID, checking bounding boxes
-        resultGeometry = recursiveCut(resultGeometry, library[input2ID]);
-
-        return {
-          geometry: [resultGeometry],
-          tags: leaf.tags,
-          color: leaf.color,
-          plane: leaf.plane,
-          bom: leaf.bom,
-        };
-      });
-    } else {
-      throw new Error("Both inputs must be either 3D or 2D");
-    }
+    assertInLibrary(input1ID);
+    assertInLibrary(input2ID);
+    library[targetID] = interaction.difference(
+      library[input1ID],
+      library[input2ID]
+    );
     return true;
   });
 }
@@ -640,32 +348,13 @@ function difference(targetID, input1ID, input2ID) {
  */
 function shrinkWrapSketches(targetID, inputIDs) {
   return started.then(() => {
-    let BOM = [];
-    if (inputIDs.every((inputID) => !is3D(library[inputID]))) {
-      let inputsToFuse = [];
-      inputIDs.forEach((inputID) => {
-        let fusedInput = digFuse(library[inputID]);
-        inputsToFuse.push(fusedInput);
-        if (fusedInput.innerShape.blueprints) {
-          throw new Error(
-            "Sketches to be lofted can't have interior geometries"
-          );
-        }
-        BOM.push(library[inputID].bom);
-      });
-      let geometryToWrap = chainFuse(inputsToFuse);
-      const newPlane = new Plane().pivot(0, "Y");
-      library[targetID] = {
-        geometry: [shrinkWrap(geometryToWrap, 50)],
-        tags: [],
-        color: defaultColor,
-        plane: newPlane,
-        bom: BOM,
-      };
-      return true;
-    } else {
-      throw new Error("All inputs must be sketches");
-    }
+    library[targetID] = interaction.shrinkWrapSketches(
+      inputIDs.map((id) => {
+        assertInLibrary(id);
+        return library[id];
+      })
+    );
+    return true;
   });
 }
 
@@ -677,25 +366,16 @@ function shrinkWrapSketches(targetID, inputIDs) {
  * @returns {Promise<boolean|Object>} A promise that resolves to true if targetID is provided, or the intersected geometry if targetID is null
  */
 function intersect(input1ID, input2ID, targetID = null) {
-  let inputGeometry1 = toGeometry(input1ID, "geometry1");
-  let inputGeometry2 = toGeometry(input2ID, "geometry2");
   return started.then(() => {
-    let generatedAssembly = util.actOnLeafs(inputGeometry1, (leaf) => {
-      const shapeToIntersectWith = digFuse(inputGeometry2);
-      const newGeom = leaf.geometry[0].clone().intersect(shapeToIntersectWith);
-      return {
-        geometry: [newGeom],
-        tags: leaf.tags,
-        color: leaf.color,
-        plane: leaf.plane,
-        bom: leaf.bom,
-      };
-    });
-    if (targetID != null) {
-      library[targetID] = generatedAssembly;
+    assertInLibrary(input1ID);
+    assertInLibrary(input2ID);
+
+    const result = interaction.intersect(input1ID, input2ID);
+    if (targetID) {
+      library[targetID] = result;
       return true;
     } else {
-      return generatedAssembly;
+      return result;
     }
   });
 }
@@ -709,13 +389,8 @@ function intersect(input1ID, input2ID, targetID = null) {
  */
 function tag(targetID, inputID, TAG) {
   return started.then(() => {
-    library[targetID] = {
-      geometry: library[inputID].geometry,
-      bom: library[inputID].bom,
-      tags: [...TAG, ...library[inputID].tags],
-      color: library[inputID].color,
-      plane: library[inputID].plane,
-    };
+    assertInLibrary(inputID);
+    library[targetID] = tags.tag(library[inputID], TAG);
     return true;
   });
 }
@@ -729,260 +404,9 @@ function tag(targetID, inputID, TAG) {
  */
 function extractAllTags(inputID, tag) {
   return started.then(() => {
-    // Recursive helper function to collect tags
-    function collectTags(geometry) {
-      let tags = new Set(geometry.tags || []); // Use a Set to ensure uniqueness
-
-      // If the geometry is an assembly, recursively collect tags from subassemblies
-      if (isAssembly(geometry)) {
-        geometry.geometry.forEach((subAssembly) => {
-          const subTags = collectTags(subAssembly);
-          subTags.forEach((tag) => tags.add(tag)); // Add tags from subassemblies
-        });
-      }
-
-      return tags;
-    }
-
-    // Start collecting tags from the input geometry
-    const inputGeometry = library[inputID];
-    if (!inputGeometry) {
-      throw new Error(`Geometry with ID ${inputID} not found in library`);
-    }
-
-    const allTags = collectTags(inputGeometry);
-    let returningArray = Array.from(allTags); // Convert the Set to an array
-
-    returningArray = ["Select Tag", ...new Set(returningArray)];
-    return returningArray;
+    assertInLibrary(inputID);
+    return tags.extractAllTags(library[inputID]);
   });
-}
-
-//---------------------Functions for the code atom---------------------
-
-/**
- * AssemblyMap
- *
- * Maps the given callbackFn to each leaf in the specified assembly. And returns
- * a new assembly of the same structure and metadata, but with transformed leafs.
- * If the provided assembly is a single entity, returns a transformed singular entity.
- *
- * @param {*} assemblyId
- * @param {*} callbackFn - A function that takes a leaf and returns a new leaf.
- * @returns a new assembly with the same structure and metadata as assemblyId,
- * but where each leaf is the result of applying callbackFn to the
- * corresponding leaf in the input assembly.
- */
-async function assemblyMap(assemblyId, callbackFn) {
-  try {
-    const assembly = toGeometry(assemblyId);
-
-    // Helper function to process nodes recursively
-    async function processNode(node, depth) {
-      // If this is a leaf node
-      if (
-        node.geometry.length === 1 &&
-        node.geometry[0].geometry === undefined
-      ) {
-        // Apply callback and return result
-        let result = await callbackFn(node, depth);
-        return result;
-      }
-      // This is a branch node (an assembly)
-      else {
-        const newGeometry = await Promise.all(
-          node.geometry.map(async (child) => {
-            return await processNode(child, depth + 1);
-          })
-        );
-
-        // Filter out any undefined results (in case callbackFn filters some nodes)
-        const filteredGeometry = newGeometry.filter(
-          (item) => item !== undefined
-        );
-
-        // Return a new node with the same metadata but transformed children
-        return {
-          geometry: filteredGeometry,
-          tags: node.tags || [],
-          color: node.color,
-          plane: node.plane,
-          bom: node.bom || [],
-        };
-      }
-    }
-
-    // Start processing from the root
-    const result = await processNode(assembly, 0);
-    return result;
-  } catch (error) {
-    logError(error, "AssemblyMap");
-    throw error;
-  }
-}
-
-async function assemblyAsIterable(assemblyId) {
-  const result = [];
-  util.actOnLeafs(toGeometry(assemblyId), (leaf) => {
-    result.push(leaf);
-  });
-  // TODO: when we typescriptify things, this should be a read-only list.
-  return result;
-}
-
-function logError(error, context) {
-  console.warn("error from context: ", context);
-  if (error instanceof SyntaxError) {
-    console.error("SyntaxError encountered:", error.message);
-  } else if (error instanceof ReferenceError) {
-    console.error("ReferenceError encountered:", error.message);
-  } else {
-    console.error("An error occurred:", error.message);
-  }
-
-  // Log additional error details if available
-  if (error.stack) {
-    console.error("Stack trace:", error.stack);
-  }
-  if (error.lineNumber) {
-    console.error("Line number:", error.lineNumber);
-  }
-  if (error.columnNumber) {
-    console.error("Column number:", error.columnNumber);
-  }
-  console.log("full error:");
-  console.log(error);
-}
-
-/**
- * Validates that user-provided code doesn't contain dangerous patterns
- * @param {string} code - The JavaScript code string to validate
- * @returns {boolean} True if code appears safe, throws error if dangerous patterns detected
- */
-function validateUserCode(code) {
-  const dangerousPatterns = [
-    /eval\s*\(/,
-    /import\s*\(/,
-    /require\s*\(/,
-    /process\s*\./,
-    /global\s*\./,
-    /window\s*\./,
-    /document\s*\./,
-    /XMLHttpRequest/,
-    /fetch\s*\(/,
-    /localStorage/,
-    /sessionStorage/,
-    /IndexedDB/,
-    /WebSocket/,
-    /Worker\s*\(/,
-    /setTimeout\s*\(/,
-    /setInterval\s*\(/,
-    /__proto__/,
-    /constructor/,
-    /prototype/,
-  ];
-
-  for (const pattern of dangerousPatterns) {
-    if (pattern.test(code)) {
-      throw new Error(
-        `Code contains potentially dangerous pattern: ${pattern.source}`
-      );
-    }
-  }
-
-  return true;
-}
-
-/**
- * Executes user-provided code in the worker thread with access to predefined geometry functions.
- * @param {string} targetID - The unique identifier to store the code execution result in the library
- * @param {string} code - The JavaScript code string to execute
- * @param {Object} argumentsArray - Object containing key-value pairs of additional variables to make available to the code
- * @returns {Promise<boolean|number>} A promise that resolves to the result value if it's a number, or true otherwise
- * @note Uses eval() for code execution - consider security implications in production environments
- */
-async function code(targetID, code, argumentsArray) {
-  await started;
-  try {
-    // Validate input parameters
-    if (typeof code !== "string") {
-      throw new Error("Code must be a string");
-    }
-    if (code.length > 50000) {
-      throw new Error("Code too long (maximum 50,000 characters)");
-    }
-
-    // Validate code for dangerous patterns
-    // TODO: we probably want to allow some of these but still need to warn about them before executing
-    // the code molecule.
-    validateUserCode(code);
-
-    let keys1 = [
-      "Rotate",
-      "Move",
-      "Scale",
-      "Assembly",
-      "Intersect",
-      "CutAssembly",
-      "AssemblyMap",
-      "AssemblyAsIterable",
-      "GetBounds",
-      "Fillet",
-      "Chamfer",
-      "library",
-      "replicad",
-    ];
-    let inputValues = [
-      rotate,
-      move,
-      scale,
-      assembly,
-      intersect,
-      cutAssembly,
-      assemblyMap,
-      assemblyAsIterable,
-      getBounds,
-      fillet,
-      chamfer,
-      library,
-      util.replicad,
-    ];
-    for (const [key, value] of Object.entries(argumentsArray)) {
-      // Sanitize parameter names to prevent injection
-      if (!/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(key)) {
-        throw new Error(`Invalid parameter name: ${key}`);
-      }
-      keys1.push(key);
-      inputValues.push(value);
-    }
-
-    // Use Function constructor instead of eval - still allows code execution but safer than eval
-    const userFunction = new Function(
-      ...keys1,
-      `return (async () => { ${code} })();`
-    );
-
-    // Execute with timeout protection
-    const timeoutPromise = new Promise((_, reject) => {
-      setTimeout(() => reject(new Error("Code execution timed out")), 60000); // 1 min timeout
-    });
-
-    const result = await Promise.race([
-      userFunction(...inputValues),
-      timeoutPromise,
-    ]);
-
-    library[targetID] = result;
-    // If the type of the result is a number return the number so it can be passed to the next atom
-    if (typeof result === "number") {
-      return result;
-    } else {
-      return true;
-    }
-  } catch (error) {
-    console.error("Code execution error:", error);
-    throw new Error(`Code execution failed: ${error.message}`);
-  }
 }
 
 /**
@@ -995,19 +419,9 @@ async function code(targetID, code, argumentsArray) {
  */
 function color(targetID, inputID, color) {
   return started.then(() => {
-    library[targetID] = util.actOnLeafs(library[inputID], (leaf) => {
-      // keep out color add tag
-      if (color == "#D9544D") {
-        leaf.tags.push("keepout");
-      }
-      return {
-        geometry: leaf.geometry,
-        tags: [...leaf.tags],
-        color: color,
-        bom: leaf.bom,
-        plane: leaf.plane,
-      };
-    });
+    assertInLibrary(inputID);
+    library[targetID] = tags.color(library[inputID], color);
+    return true;
   });
 }
 
@@ -1020,15 +434,8 @@ function color(targetID, inputID, color) {
  */
 function bom(targetID, inputID, BOM) {
   return started.then(() => {
-    if (library[inputID].bom != []) {
-      BOM = [...library[inputID].bom, BOM];
-    }
-    library[targetID] = {
-      geometry: library[inputID].geometry,
-      tags: [...library[inputID].tags],
-      bom: BOM,
-      color: library[inputID].color,
-    };
+    assertInLibrary(inputID);
+    library[targetID] = tags.bom(library[inputID], BOM);
     return true;
   });
 }
@@ -1101,11 +508,8 @@ function molecule(targetID, inputID) {
  * @returns {Array|boolean} The BOM array if it exists, or false if BOM is undefined
  */
 function extractBomList(inputID) {
-  if (library[inputID].bom !== undefined) {
-    return library[inputID].bom;
-  } else {
-    return false;
-  }
+  assertInLibrary(inputID);
+  return tags.extractBomList(library[inputID]);
 }
 
 /**
@@ -1118,7 +522,7 @@ function extractBomList(inputID) {
 function visExport(targetID, inputID, fileType) {
   return started.then(() => {
     let geometryToExport = extractKeepOut(library[inputID]);
-    let fusedGeometry = digFuse(geometryToExport);
+    let fusedGeometry = interaction.digFuse(geometryToExport);
     let displayColor =
       fileType == "STL"
         ? "#91C8D5"
@@ -1128,7 +532,7 @@ function visExport(targetID, inputID, fileType) {
     let finalGeometry;
     if (fileType == "SVG") {
       /** Fuses input geometry, draws a top view projection*/
-      if (is3D(library[inputID])) {
+      if (util.is3D(library[inputID])) {
         finalGeometry = [
           util.replicad.drawProjection(fusedGeometry, "top").visible,
         ];
@@ -1186,7 +590,7 @@ async function importingSTEP(targetID, file) {
   library[targetID] = {
     geometry: [STEPresult],
     tags: [],
-    color: defaultColor,
+    color: util.defaultColor,
     bom: [],
   };
   return true;
@@ -1204,7 +608,7 @@ async function importingSTL(targetID, file) {
   library[targetID] = {
     geometry: [STLresult],
     tags: [],
-    color: defaultColor,
+    color: util.defaultColor,
     bom: [],
   };
   return true;
@@ -1241,7 +645,7 @@ async function importingSVG(targetID, svg, width) {
       geometry: [drawnSVG.clone().translate(-center[0], -center[1])],
       tags: [],
       plane: new Plane().pivot(0, "Y"),
-      color: defaultColor,
+      color: util.defaultColor,
       bom: [],
     };
     console.log("SVG imported successfully");
@@ -1291,7 +695,7 @@ function visualizeGcode(targetID, gcode) {
     geometry: [wire],
     tags: [],
     plane: new Plane().pivot(0, "Y"),
-    color: defaultColor,
+    color: util.defaultColor,
     bom: [],
   };
 }
@@ -1327,12 +731,13 @@ function generateThumbnail(inputID) {
       let fusedGeometry;
       let projectionShape;
       let svg;
-      if (is3D(library[inputID])) {
-        fusedGeometry = digFuse(library[inputID]);
+      if (util.is3D(library[inputID])) {
+        fusedGeometry = interaction.digFuse(library[inputID]);
         projectionShape = prettyProjection(fusedGeometry);
         svg = projectionShape.visible.toSVG();
       } else {
-        fusedGeometry = digFuse(library[inputID])
+        fusedGeometry = interaction
+          .digFuse(library[inputID])
           .sketchOnPlane("XY")
           .extrude(0.0001);
         projectionShape = util.replicad.drawProjection(
@@ -1347,73 +752,6 @@ function generateThumbnail(inputID) {
       throw new Error("can't generate thumbnail for undefined geometry");
     }
   });
-}
-
-/**
- * Recursively extracts geometry with a specific tag from an assembly or single geometry.
- * @param {Object} inputGeometry - The geometry object to search for the tag
- * @param {string} TAG - The tag to search for and extract
- * @returns {Object|boolean} The geometry containing the tag, or false if the tag is not found
- */
-function extractTags(inputGeometry, TAG) {
-  if (inputGeometry.tags.includes(TAG)) {
-    return inputGeometry;
-  } else if (isAssembly(inputGeometry)) {
-    let geometryWithTags = [];
-    inputGeometry.geometry.forEach((subAssembly) => {
-      let extractedGeometry = extractTags(subAssembly, TAG);
-
-      if (extractedGeometry != false) {
-        geometryWithTags.push(extractedGeometry);
-      }
-    });
-    if (geometryWithTags.length > 0) {
-      let thethingtoreturn = {
-        geometry: geometryWithTags,
-        tags: inputGeometry.tags,
-        color: inputGeometry.color,
-        bom: inputGeometry.bom,
-      };
-      return thethingtoreturn;
-    } else {
-      return false;
-    }
-  } else {
-    return false;
-  }
-}
-
-/**
- * Recursively extracts geometry that does NOT have "keepout" tags from an assembly or single geometry.
- * @param {Object} inputGeometry - The geometry object to filter keepout tags from
- * @returns {Object|boolean} The geometry without keepout tags, or false if all geometry has keepout tags
- */
-function extractKeepOut(inputGeometry) {
-  if (inputGeometry.tags.includes("keepout")) {
-    return false;
-  } else if (isAssembly(inputGeometry)) {
-    let geometryNoKeepOut = [];
-    inputGeometry.geometry.forEach((subAssembly) => {
-      let extractedGeometry = extractKeepOut(subAssembly, "keepout");
-
-      if (extractedGeometry != false) {
-        geometryNoKeepOut.push(extractedGeometry);
-      }
-    });
-    if (geometryNoKeepOut.length > 0) {
-      let thethingtoreturn = {
-        geometry: geometryNoKeepOut,
-        tags: inputGeometry.tags,
-        color: inputGeometry.color,
-        bom: inputGeometry.bom,
-      };
-      return thethingtoreturn;
-    } else {
-      return false;
-    }
-  } else {
-    return inputGeometry;
-  }
 }
 
 /**
@@ -1461,7 +799,7 @@ function getBounds(input) {
       maxY = -Infinity,
       maxZ = -Infinity;
 
-    if (isAssembly(geometry)) {
+    if (util.isAssembly(geometry)) {
       // Handle assembly by iterating through all parts
       util.actOnLeafs(geometry, (leaf) => {
         if (leaf.geometry && leaf.geometry[0] && leaf.geometry[0].boundingBox) {
@@ -1504,242 +842,24 @@ function getBounds(input) {
 }
 
 /**
- * Checks if a part is an assembly (contains sub-geometries) or a single part.
- * @param {Object} part - The part object to check
- * @returns {boolean} True if the part is an assembly, false if it's a single part
- */
-function isAssembly(part) {
-  if (part == undefined || part.geometry == undefined) {
-    return false;
-  }
-  if (part.geometry.length > 0) {
-    if (part.geometry[0].geometry) {
-      return true;
-    } else {
-      return false;
-    }
-  } else {
-    return false;
-  }
-}
-
-/**
- * Performs a boolean cut operation on an assembly or part with one or more cutting geometries.
- *
- * @param {Object} partToCut - The library object (part or assembly) that will be cut
- * @param {Object[]} cuttingParts - Array of geometries that will cut the part
- * @returns {Object} - A new object containing either a single cut part or an assembly of cut parts
- *
- * This function handles cutting operations on complex hierarchical structures:
- * - If partToCut is a simple part, it applies all cutting geometries to it sequentially
- * - If partToCut is an assembly, it recursively processes each leaf in the assembly tree
- * - Maintains the original hierarchy, tags, colors, and metadata
- * - Avoids unnecessary operations by checking bounding box intersections
- * - Preserves the original assembly structure while applying cuts
- */
-function cutAssembly(partToCut, cuttingParts) {
-  try {
-    //If the partToCut is an assembly pass each part back into cutAssembly function to be cut separately
-    if (isAssembly(partToCut)) {
-      let assemblyToCut = partToCut.geometry;
-      let assemblyCut = [];
-      assemblyToCut.forEach((part) => {
-        // make new assembly from cut parts
-        assemblyCut.push(cutAssembly(part, cuttingParts));
-      });
-
-      let subID = generateUniqueID();
-      //returns new assembly that has been cut
-      library[subID] = {
-        //This feels like a hack, we shouldn't be using the library internally like this
-        geometry: assemblyCut,
-        tags: partToCut.tags,
-        bom: partToCut.bom,
-      };
-      return library[subID];
-    } else {
-      // if part to cut is wire geometry, return it unchanged (wires should pass through assemblies)
-      if (isWireGeometry(partToCut)) {
-        return partToCut;
-      }
-
-      // if part to cut is a single part send to cutting function with cutting parts
-      var partCutCopy = partToCut.geometry[0];
-      cuttingParts.forEach((cuttingPart) => {
-        // for each cutting part cut the part
-        partCutCopy = recursiveCut(partCutCopy, cuttingPart);
-      });
-      /*   if the part is a compound return each solid as a new assembly */
-      function getSolids(compound) {
-        return Array.from(
-          util.replicad.iterTopo(compound.wrapped, "solid"),
-          (s) => new Solid(s)
-        );
-      }
-      if (partCutCopy.wrapped) {
-        let solids = getSolids(partCutCopy);
-        if (solids.length > 1) {
-          let newAssembly = [];
-          solids.forEach((solid) => {
-            newAssembly.push({
-              geometry: [solid],
-              tags: partToCut.tags,
-              color: partToCut.color,
-              bom: partToCut.bom,
-              plane: partToCut.plane,
-            });
-          });
-          // return new cut part
-          let newID = generateUniqueID();
-          library[newID] = {
-            geometry: newAssembly,
-            tags: partToCut.tags,
-            color: partToCut.color,
-            bom: partToCut.bom,
-            plane: partToCut.plane,
-          };
-
-          return library[newID];
-        }
-      }
-      // return new cut part
-      let newID = generateUniqueID();
-      library[newID] = {
-        geometry: [partCutCopy],
-        tags: partToCut.tags,
-        color: partToCut.color,
-        bom: partToCut.bom,
-        plane: partToCut.plane,
-      };
-
-      return library[newID];
-    }
-  } catch (e) {
-    console.log(e);
-    throw new Error("Cut Assembly failed", e);
-  }
-}
-
-/**
- * Recursively applies boolean cutting operations between geometries with optimization.
- *
- * @param {Object} partToCut - The geometry object to be cut
- * @param {Object} cuttingPart - The library object (may be assembly) used to cut the part
- * @returns {Object} - The resulting geometry after all applicable cuts have been performed
- *
- * This function:
- * - Recursively processes assemblies, applying cuts only when necessary
- * - Performs bounding box intersection checks to skip non-intersecting geometries
- * - Handles nested assemblies by traversing the entire tree of cutting geometries
- * - Optimizes performance by avoiding cuts with geometries that cannot intersect
- * - Preserves the structure of both the target and cutting geometries
- *
- * The function is a core part of the boolean difference system and is designed
- * to efficiently handle complex hierarchical structures.
- */
-function recursiveCut(partToCut, cuttingPart) {
-  try {
-    let cutGeometry = partToCut;
-
-    // Wire geometry should not participate in cutting operations
-    if (isWireGeometry({ geometry: [partToCut] })) {
-      return partToCut; // Wire parts should pass through unchanged
-    }
-
-    // if cutting part is an assembly pass back into the function to be cut by each part in that assembly
-    if (isAssembly(cuttingPart)) {
-      for (let i = 0; i < cuttingPart.geometry.length; i++) {
-        // Skip cutting with wire geometry
-        if (!isWireGeometry(cuttingPart.geometry[i])) {
-          cutGeometry = recursiveCut(cutGeometry, cuttingPart.geometry[i]);
-        }
-      }
-      return cutGeometry;
-    } else {
-      // Skip cutting if the cutting part is wire geometry
-      if (isWireGeometry(cuttingPart)) {
-        return partToCut;
-      }
-
-      //If the shapes don't overlap, we don't need to cut them
-      if (partToCut.boundingBox.isOut(cuttingPart.geometry[0].boundingBox)) {
-        return partToCut;
-      }
-      // cut and return part
-      else {
-        let cutPart;
-        cutPart = partToCut.cut(cuttingPart.geometry[0]);
-        return cutPart;
-      }
-    }
-  } catch (e) {
-    console.log(e);
-    throw new Error("Recursive Cut failed", e);
-  }
-}
-
-/**
  * A function which takes in an array of target geometries and forms them into an assembly
  * Geometries will cut all geometries below them in the list to make sure that no parts intersect
  * If the targetID is defined, the assembly will be stored in the library under that ID, otherwise it will be returned
  */
 async function assembly(geometries, targetID = null) {
-  if (!Array.isArray(geometries) || geometries.length === 0) {
-    throw new Error("inputIDs must be a non-empty array");
-  }
-
   await started;
-
-  let assembly = [];
-  let bomAssembly = [];
-
-  if (geometries.length > 1) {
-    const all3D = geometries.every((inputID) => is3D(toGeometry(inputID)));
-    const all2D = geometries.every((inputID) => !is3D(toGeometry(inputID)));
-
-    if (all3D || all2D) {
-      for (let i = 0; i < geometries.length; i++) {
-        const geometry = toGeometry(geometries[i]);
-        assembly.push(
-          cutAssembly(
-            geometry,
-            geometries.slice(i + 1).map(toGeometry),
-            targetID
-          )
-        );
-        if (geometry.bom.length > 0) {
-          bomAssembly.push(...geometry.bom);
-        }
-      }
-    } else {
-      console.trace("assembly error. inputs: " + geometries);
-      throw new Error(
-        "Assemblies must be composed from only sketches OR only solids"
-      );
-    }
-  } else {
-    const geometry = toGeometry(geometries[0]);
-    assembly.push(geometry);
-    if (geometry.bom.length > 0) {
-      bomAssembly.push(...geometry.bom);
-    }
-  }
-
-  const newPlane = new Plane().pivot(0, "Y");
-  let generatedAssembly = {
-    geometry: assembly,
-    plane: newPlane,
-    tags: [],
-    bom: bomAssembly,
-  };
-
+  const result = interaction.assembly(
+    geometries.map((id) => {
+      assertInLibrary(id);
+      return library[id];
+    })
+  );
   if (targetID != null) {
-    library[targetID] = generatedAssembly;
+    library[targetID] = result;
+    return true;
   } else {
-    return generatedAssembly;
+    return result;
   }
-
-  return true;
 }
 
 /**
@@ -1751,30 +871,12 @@ async function assembly(geometries, targetID = null) {
  */
 function fusion(targetID, inputIDs) {
   return started.then(() => {
-    let fusedGeometry = [];
-    let bomAssembly = [];
-    inputIDs.forEach((inputID) => {
-      if (inputIDs.every((inputID) => is3D(library[inputID]))) {
-        fusedGeometry.push(digFuse(library[inputID]));
-      } else if (inputIDs.every((inputID) => !is3D(library[inputID]))) {
-        fusedGeometry.push(digFuse(library[inputID]));
-      } else {
-        throw new Error(
-          "Fusion must be composed from only sketches OR only solids"
-        );
-      }
-      if (library[inputID].bom.length > 0) {
-        bomAssembly.push(...library[inputID].bom);
-      }
-    });
-    const newPlane = new Plane().pivot(0, "Y");
-    library[targetID] = {
-      geometry: [chainFuse(fusedGeometry)],
-      tags: [],
-      bom: bomAssembly,
-      plane: newPlane,
-      color: defaultColor,
-    };
+    library[targetID] = intersection.fusion(
+      inputIDs.map((id) => {
+        assertInLibrary(id);
+        return library[id];
+      })
+    );
     return true;
   });
 }
@@ -1786,6 +888,11 @@ function fusion(targetID, inputIDs) {
  */
 function flattenAssembly(assembly) {
   var flattened = [];
+  if (assembly == undefined || assembly.geometry == undefined) {
+    console.trace("attempted to flatten empty assembly");
+    return flattened;
+  }
+
   //This is a leaf
   if (
     assembly.geometry.length == 1 &&
@@ -1803,51 +910,8 @@ function flattenAssembly(assembly) {
   }
 }
 
-/**
- * Performs a chain fusion operation on an array of geometries.
- * @param {Array} chain - Array of geometry objects to fuse together sequentially
- * @returns {Object} The resulting fused geometry
- * @throws {Error} Throws an error if the fusion operation fails
- */
-function chainFuse(chain) {
-  try {
-    let fused = chain[0].clone();
-    for (let i = 1; i < chain.length; i++) {
-      fused = fused.fuse(chain[i]);
-    }
-    return fused;
-  } catch (e) {
-    throw new Error("Fusion failed");
-  }
-}
-
-/**
- * Recursively digs through an assembly and fuses all leaf geometries into a single geometry.
- * @param {Object} assembly - The assembly or leaf geometry to process
- * @returns {Object} A single fused geometry combining all leaves in the assembly
- */
-function digFuse(assembly) {
-  var flattened = [];
-
-  if (isAssembly(assembly)) {
-    assembly.geometry.forEach((subAssembly) => {
-      if (!isAssembly(subAssembly)) {
-        //if it's not an assembly hold on add it to the fusion list
-        flattened.push(subAssembly.geometry[0]);
-      } else {
-        // if it is an assembly keep digging
-        // add the fused things in
-        flattened.push(digFuse(subAssembly));
-      }
-    });
-    return chainFuse(flattened);
-  } else {
-    return assembly.geometry[0];
-  }
-}
-
 let colorOptions = {
-  Default: defaultColor,
+  Default: util.defaultColor,
   Red: "#FF9065",
   Orange: "#FFB458",
   Yellow: "#FFD600",
@@ -1877,8 +941,7 @@ let colorOptions = {
  * @returns {Promise} A promise that resolves to the default text mesh
  */
 async function generateDefaultMesh(id) {
-  let defaultMesh = await text(id, "No output to display", 28, "ROBOTO");
-  return defaultMesh;
+  return text(id, "No output to display", 28, "ROBOTO");
 }
 
 /**
@@ -1995,7 +1058,7 @@ function generateDisplayMesh(id) {
     if (library[id] == undefined || id == undefined) {
       console.log("ID undefined or not found in library");
       //throw new Error("ID not found in library");
-      generateDefaultMesh(id).then((result) => {
+      return generateDefaultMesh(id).then((result) => {
         console.log(result);
       });
     }
@@ -2150,7 +1213,6 @@ export {
   visualizeGcode,
   getBoundingBox,
   getBounds,
-  is3D,
   generateThumbnail,
   visExport,
   downExport,

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -223,10 +223,11 @@ async function extrude(targetID, inputID, height) {
  */
 async function move(geom, x, y, z, targetID = null) {
   await started;
-
+  console.log("move called for target " + targetID);
   const result = await actions.move(toGeometry(geom, "move-geometry"), x, y, z);
   if (targetID) {
     library[targetID] = result;
+    return true;
   } else {
     return result;
   }
@@ -813,10 +814,10 @@ async function assembly(geometries, targetID = null) {
  * @throws {Error} Throws an error if inputs are mixed between 2D and 3D geometries
  */
 function fusion(targetID, inputIDs) {
-  return started.then(() => {
+  return started.then(async () => {
     console.log("fusion with inputs: " + inputIDs.length);
     console.log(inputIDs);
-    library[targetID] = interaction.fusion(
+    library[targetID] = await interaction.fusion(
       inputIDs.map((id) => {
         assertInLibrary(id);
         return library[id];
@@ -886,7 +887,7 @@ let colorOptions = {
  * @returns {Promise} A promise that resolves to the default text mesh
  */
 async function generateDefaultMesh(id) {
-  return text(id, "No output to display", 28, "ROBOTO");
+  return await text(id, "No output to display", 28, "ROBOTO");
 }
 
 /**
@@ -1003,7 +1004,7 @@ function generateDisplayMesh(id) {
     if (library[id] == undefined || id == undefined) {
       console.log("ID undefined or not found in library");
       //throw new Error("ID not found in library");
-      return generateDefaultMesh(id).then((result) => {
+      generateDefaultMesh(id).then((result) => {
         console.log(result);
       });
     }

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -304,7 +304,7 @@ async function fillet(geom, radius, targetID = null) {
 async function chamfer(geom, size, targetID = null) {
   await started;
 
-  const result = awaitactions.chamfer(
+  const result = await actions.chamfer(
     toGeometry(geom, "chamfer-geometry"),
     size
   );

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -13,10 +13,11 @@ var library = {};
 
 const started = util.init();
 
-function assertInLibrary(id) {
+function getOrThrow(id) {
   if (!library[id]) {
     throw new Error(`Library ID ${id} does not exist.`);
   }
+  return library[id];
 }
 
 async function code(targetID, codeText, argumentsArray) {
@@ -37,11 +38,10 @@ async function layout(
   priorPlacements
 ) {
   await started;
-  assertInLibrary(inputID);
 
   return cutlayout
     .layout(
-      library[inputID],
+      getOrThrow(inputID),
       progressCallback,
       warningCallback,
       placementCallback,
@@ -64,10 +64,9 @@ async function displayLayout(
   layoutConfig
 ) {
   await started;
-  assertInLibrary(inputID);
 
   library[targetID] = await cutlayout.displayLayout(
-    library[inputID],
+    getOrThrow(inputID),
     placements,
     warningCallback,
     layoutConfig
@@ -191,10 +190,7 @@ async function text(id, text, fontSize, fontFamily) {
 async function loftShapes(targetID, inputsIDs) {
   await started;
   library[targetID] = await interaction.loftShapes(
-    (inputsIDs || []).map((id) => {
-      assertInLibrary(id);
-      return library[id];
-    })
+    (inputsIDs || []).map(getOrThrow)
   );
   return true;
 }
@@ -208,7 +204,7 @@ async function loftShapes(targetID, inputsIDs) {
  */
 async function extrude(targetID, inputID, height) {
   await started;
-  library[targetID] = await actions.extrude(library[inputID], height);
+  library[targetID] = await actions.extrude(getOrThrow, height);
   return true;
 }
 
@@ -335,11 +331,9 @@ async function chamfer(geom, size, targetID = null) {
  */
 function difference(targetID, input1ID, input2ID) {
   return started.then(async () => {
-    assertInLibrary(input1ID);
-    assertInLibrary(input2ID);
     library[targetID] = await interaction.difference(
-      library[input1ID],
-      library[input2ID]
+      getOrThrow(input1ID),
+      getOrThrow(input2ID)
     );
     return true;
   });
@@ -355,10 +349,7 @@ function difference(targetID, input1ID, input2ID) {
 function shrinkWrapSketches(targetID, inputIDs) {
   return started.then(async () => {
     library[targetID] = await interaction.shrinkWrapSketches(
-      inputIDs.map((id) => {
-        assertInLibrary(id);
-        return library[id];
-      })
+      inputIDs.map(getOrThrow)
     );
     return true;
   });
@@ -373,10 +364,10 @@ function shrinkWrapSketches(targetID, inputIDs) {
  */
 function intersect(input1ID, input2ID, targetID = null) {
   return started.then(async () => {
-    assertInLibrary(input1ID);
-    assertInLibrary(input2ID);
-
-    const result = await interaction.intersect(input1ID, input2ID);
+    const result = await interaction.intersect(
+      getOrThrow(input1ID),
+      getOrThrow(input2ID)
+    );
     if (targetID) {
       library[targetID] = result;
       return true;
@@ -395,8 +386,7 @@ function intersect(input1ID, input2ID, targetID = null) {
  */
 function tag(targetID, inputID, TAG) {
   return started.then(() => {
-    assertInLibrary(inputID);
-    library[targetID] = tags.tag(library[inputID], TAG);
+    library[targetID] = tags.tag(getOrThrow(inputID), TAG);
     return true;
   });
 }
@@ -410,8 +400,7 @@ function tag(targetID, inputID, TAG) {
  */
 function extractAllTags(inputID, tag) {
   return started.then(() => {
-    assertInLibrary(inputID);
-    return tags.extractAllTags(library[inputID]);
+    return tags.extractAllTags(getOrThrow(inputID));
   });
 }
 
@@ -425,8 +414,7 @@ function extractAllTags(inputID, tag) {
  */
 function color(targetID, inputID, color) {
   return started.then(() => {
-    assertInLibrary(inputID);
-    library[targetID] = tags.color(library[inputID], color);
+    library[targetID] = tags.color(getOrThrow(inputID), color);
     return true;
   });
 }
@@ -440,8 +428,7 @@ function color(targetID, inputID, color) {
  */
 function bom(targetID, inputID, BOM) {
   return started.then(() => {
-    assertInLibrary(inputID);
-    library[targetID] = tags.bom(library[inputID], BOM);
+    library[targetID] = tags.bom(getOrThrow(inputID), BOM);
     return true;
   });
 }
@@ -456,8 +443,7 @@ function bom(targetID, inputID, BOM) {
  */
 async function extractTag(targetID, inputID, TAG) {
   await started;
-  assertInLibrary(inputID);
-  library[targetID] = tags.extractTag(library[inputID], TAG);
+  library[targetID] = tags.extractTag(getOrThrow(inputID), TAG);
   return true;
 }
 
@@ -504,8 +490,7 @@ function molecule(targetID, inputID) {
  * @returns {Array|boolean} The BOM array if it exists, or false if BOM is undefined
  */
 function extractBomList(inputID) {
-  assertInLibrary(inputID);
-  return tags.extractBomList(library[inputID]);
+  return tags.extractBomList(getOrThrow(inputID));
 }
 
 /**
@@ -785,14 +770,9 @@ function getBoundingBox(inputID) {
  * Geometries will cut all geometries below them in the list to make sure that no parts intersect
  * If the targetID is defined, the assembly will be stored in the library under that ID, otherwise it will be returned
  */
-async function assembly(geometries, targetID = null) {
+async function assembly(inputIDs, targetID = null) {
   await started;
-  const result = await interaction.assembly(
-    geometries.map((id) => {
-      assertInLibrary(id);
-      return library[id];
-    })
-  );
+  const result = await interaction.assembly(inputIDs.map(getOrThrow));
   if (targetID != null) {
     library[targetID] = result;
     return true;
@@ -812,12 +792,7 @@ function fusion(targetID, inputIDs) {
   return started.then(async () => {
     console.log("fusion with inputs: " + inputIDs.length);
     console.log(inputIDs);
-    library[targetID] = await interaction.fusion(
-      inputIDs.map((id) => {
-        assertInLibrary(id);
-        return library[id];
-      })
-    );
+    library[targetID] = await interaction.fusion(inputIDs.map(getOrThrow));
     return true;
   });
 }

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -1044,6 +1044,7 @@ function generateDisplayMesh(id) {
     meshArray.forEach((meshgeometry) => {
       try {
         //Try extruding if there is no 3d shape
+        let sketchPlane = library[id].plane;
         if (meshgeometry.geometry.mesh == undefined) {
           const threeDShape = meshgeometry
             .sketchOnPlane(sketchPlane)

--- a/tests/actions.test.js
+++ b/tests/actions.test.js
@@ -1,0 +1,83 @@
+import { extrude, move, rotate } from "../src/worker/actions.js";
+import { rectangle } from "../src/worker/shapes.js";
+import { init, is3D, defaultColor } from "../src/worker/util.js";
+
+function vectorEquals(vector, x, y, z) {
+  expect(vector.x).toEqual(x);
+  expect(vector.y).toEqual(y);
+  expect(vector.z).toEqual(z);
+}
+
+describe("shapes.js", () => {
+  beforeAll(async () => {
+    await init();
+  });
+
+  describe("move", () => {
+    it("should move 2d shape in 3 dimensions", async () => {
+      const width = 80;
+      const height = 5;
+      const moveX = 3;
+      const moveY = 9.3;
+      const moveZ = 2;
+
+      // Create a rectangle
+      const rect = await rectangle(width, height);
+
+      // Move it
+      const result = await move(rect, moveX, moveY, moveZ);
+
+      // Verify input was not destroyed
+      expect(rect).toBeDefined();
+      expect(rect.geometry).toHaveLength(1);
+      const initialBoundingBox = rect.geometry[0].boundingBox;
+
+      // Verify move in the xy plane.
+      expect(result).toBeDefined();
+      expect(result.geometry).toHaveLength(1);
+      const movedBoundingBox = result.geometry[0].boundingBox;
+
+      expect(movedBoundingBox.width).toBeCloseTo(initialBoundingBox.width, 4);
+      expect(movedBoundingBox.height).toBeCloseTo(initialBoundingBox.height, 4);
+      expect(movedBoundingBox.center[0]).toBeCloseTo(
+        initialBoundingBox.center[0] + moveX,
+        4
+      );
+      expect(movedBoundingBox.center[1]).toBeCloseTo(
+        initialBoundingBox.center[1] + moveY,
+        4
+      );
+
+      // Verify the Z movement was applied to the plane.
+      vectorEquals(result.plane.origin, 0, 0, moveZ);
+    });
+    // TODO: add tests for moving a 3d object
+    // TODO: add test for moving a 2d object in 3 dimension after it's plane has been rotated.
+  });
+
+  describe("rotate", () => {
+    it("simple 2D rotation within plane", async () => {
+      const width = 80;
+      const height = 5;
+
+      // Create a rectangle
+      const rect = await rectangle(width, height);
+
+      // Move it
+      const result = await rotate(rect, 0, 0, 90);
+
+      // Verify input was not destroyed
+      expect(rect).toBeDefined();
+      expect(rect.geometry).toHaveLength(1);
+      const initialBoundingBox = rect.geometry[0].boundingBox;
+
+      // Verify was rotated in degrees.
+      const movedBoundingBox = result.geometry[0].boundingBox;
+
+      expect(movedBoundingBox.width).toBeCloseTo(initialBoundingBox.height, 4);
+      expect(movedBoundingBox.height).toBeCloseTo(initialBoundingBox.width, 4);
+    });
+    // TODO: add test for rotation a 2D object around other axes
+    // TODO: add test for rottating 3d object.
+  });
+});

--- a/tests/code.test.js
+++ b/tests/code.test.js
@@ -1,7 +1,7 @@
 // Test file for code.js - code execution functionality
 import { init } from "../src/worker/util.js";
 import { executeCode } from "../src/worker/code.js";
-import { rectangle, circle } from "../src/worker/shapes.js";
+import { rectangle } from "../src/worker/shapes.js";
 import { extrude } from "../src/worker/actions.js";
 
 describe("code.js", () => {

--- a/tests/code.test.js
+++ b/tests/code.test.js
@@ -1,0 +1,47 @@
+// Test file for code.js - code execution functionality
+import { init } from "../src/worker/util.js";
+import { executeCode } from "../src/worker/code.js";
+import { rectangle, circle } from "../src/worker/shapes.js";
+import { extrude } from "../src/worker/actions.js";
+
+describe("code.js", () => {
+  beforeAll(async () => {
+    await init();
+  });
+
+  describe("code execution", () => {
+    it("should allow calling of all provided helper methods", async () => {
+      const codeString = `
+        //Inputs:[inputShape, dist, height]
+        let shape = library[inputShape]
+
+        const rotated = await Rotate(shape, 5, 10, dist)
+        const moved = await Move(shape, 0, 9, height)
+        const scaled = await Scale(shape, 0.7)
+        const assembled = await Assembly([shape, moved])
+        const inter = await Intersect(shape, moved)
+        const cut = await CutAssembly(shape, [scaled, moved])
+        const modifiedAssembly = await AssemblyMap(assembled, async (s) => {return await Rotate(s, 0, 10, 90)})
+        console.log(await AssemblyAsIterable(assembled))
+        console.log(GetBounds(shape))
+        const filleted = await Fillet(shape, 0.3)
+        const chamfered = await Chamfer(shape, 1)
+
+        return Assembly([modifiedAssembly, inter, cut, filleted, chamfered])
+      `;
+      const library = {
+        input_shape_id: extrude(rectangle(10, 5), 6),
+      };
+      const args = {
+        inputShape: "input_shape_id",
+        dist: 5,
+        height: 10,
+      };
+
+      const result = await executeCode(codeString, args, library);
+
+      expect(result).toBeDefined();
+      expect(result.geometry).toHaveLength(5);
+    });
+  });
+});

--- a/tests/extrude.test.js
+++ b/tests/extrude.test.js
@@ -1,14 +1,14 @@
 // Worker.js integration tests. These tests use the real Replicad library.
-import { 
-  library, 
-  started, 
-  circle, 
-  rectangle, 
-  extrude, 
-  is3D 
-} from '../src/worker.js';
+import {
+  library,
+  started,
+  circle,
+  rectangle,
+  extrude,
+  is3D,
+} from "../src/worker/worker.js";
 
-describe('extrude', () => {
+describe("extrude", () => {
   beforeAll(async () => {
     // Wait on worker's started flag.
     await started;
@@ -21,19 +21,18 @@ describe('extrude', () => {
     }
   });
 
-
   // Assertion library is defined here: https://vitest.dev/api/expect
-  it('extrudes a rectangle sketch into a 3D box', async () => {
+  it("extrudes a rectangle sketch into a 3D box", async () => {
     // 1. Create a 2D rectangle in the library
-    const inputID = 'rect1';
-    const targetID = 'box1';
+    const inputID = "rect1";
+    const targetID = "box1";
     const width = 10;
     const height = 5;
     const extrudeHeight = 3;
 
     // Create the rectangle first
     await rectangle(inputID, width, height);
-    
+
     // Verify the rectangle was created
     expect(library[inputID]).toBeDefined();
     expect(library[inputID].geometry).toHaveLength(1);
@@ -46,11 +45,11 @@ describe('extrude', () => {
     const result = library[targetID];
     expect(result).toBeDefined();
     expect(result.geometry).toHaveLength(1);
-    
+
     const solid = result.geometry[0];
     expect(solid).toBeDefined();
     expect(is3D(result)).toBe(true); // Should now be 3D
-    
+
     // Check bounding box dimensions
     const bounds = solid.boundingBox;
     expect(bounds).toBeDefined();

--- a/tests/interaction.test.js
+++ b/tests/interaction.test.js
@@ -1,0 +1,180 @@
+// Test file for interaction.js - boolean operations and complex geometry operations
+import {
+  difference,
+  fusion,
+  intersect,
+  assembly,
+  loftShapes,
+  shrinkWrapSketches,
+  is3D,
+} from "../src/worker/interaction.js";
+import { circle, rectangle } from "../src/worker/shapes.js";
+import { extrude } from "../src/worker/actions.js";
+import { init, is3D } from "../src/worker/util.js";
+
+describe("interaction.js", () => {
+  beforeEach(async () => {
+    await init();
+  });
+
+  describe("difference (boolean subtraction)", () => {
+    it("should subtract one 3D geometry from another", async () => {
+      // Create two overlapping boxes
+      const rect1 = rectangle(10, 10);
+      const rect2 = rectangle(6, 6);
+      const box1 = await extrude(rect1, 5);
+      const box2 = await extrude(rect2, 5);
+
+      const result = await difference(box1, box2);
+
+      expect(result).toBeDefined();
+      expect(result.geometry).toHaveLength(1);
+      expect(is3D(result)).toBe(true);
+
+      // Result should be valid 3D geometry
+      const bounds = result.geometry[0].boundingBox;
+      expect(bounds).toBeDefined();
+    });
+
+    it("should subtract one 2D sketch from another", async () => {
+      // Create two overlapping circles
+      const c1 = circle(10);
+      const c2 = circle(6);
+
+      const result = await difference(c1, c2);
+
+      expect(result).toBeDefined();
+      expect(result.geometry).toHaveLength(1);
+      expect(is3D(result)).toBe(false);
+    });
+  });
+
+  describe("fusion (boolean union)", () => {
+    it("should fuse multiple 3D geometries together", async () => {
+      // Create two boxes
+      const rect1 = rectangle(10, 10);
+      const rect2 = rectangle(10, 10);
+      const box1 = await extrude(rect1, 5);
+      const box2 = await extrude(rect2, 5);
+
+      const result = await fusion([box1, box2]);
+
+      expect(result).toBeDefined();
+      expect(result.geometry).toHaveLength(1);
+      expect(is3D(result)).toBe(true);
+    });
+
+    it("should fuse multiple 2D sketches together", async () => {
+      const c1 = circle(8);
+      const c2 = circle(8);
+
+      const result = await fusion([c1, c2]);
+
+      expect(result).toBeDefined();
+      expect(result.geometry).toHaveLength(1);
+      expect(is3D(result)).toBe(false);
+    });
+  });
+
+  describe("intersect (boolean intersection)", () => {
+    it("should find intersection of two 3D geometries", async () => {
+      // Create two overlapping boxes
+      const rect1 = rectangle(10, 10);
+      const rect2 = rectangle(10, 10);
+      const box1 = await extrude(rect1, 5);
+      const box2 = await extrude(rect2, 5);
+
+      const result = await intersect(box1, box2);
+
+      expect(result).toBeDefined();
+      expect(result.geometry).toHaveLength(1);
+    });
+
+    it("should find intersection of two 2D sketches", async () => {
+      const rect1 = rectangle(10, 10);
+      const rect2 = rectangle(10, 10);
+
+      const result = await intersect(rect1, rect2);
+
+      expect(result).toBeDefined();
+      expect(result.geometry).toHaveLength(1);
+      expect(is3D(result)).toBe(false);
+    });
+  });
+
+  describe("assembly", () => {
+    it("should create an assembly from multiple 3D parts", async () => {
+      // Create two boxes
+      const rect1 = rectangle(5, 5);
+      const rect2 = rectangle(5, 5);
+      const box1 = await extrude(rect1, 3);
+      const box2 = await extrude(rect2, 3);
+
+      const result = await assembly([box1, box2]);
+
+      expect(result).toBeDefined();
+      expect(result.geometry).toBeDefined();
+      // Assembly should contain multiple parts
+      expect(Array.isArray(result.geometry)).toBe(true);
+    });
+
+    it("should create an assembly from multiple 2D sketches", async () => {
+      const c1 = circle(6);
+      const r1 = rectangle(8, 4);
+
+      const result = await assembly([c1, r1]);
+
+      expect(result).toBeDefined();
+      expect(result.geometry).toBeDefined();
+      expect(Array.isArray(result.geometry)).toBe(true);
+    });
+  });
+
+  describe("loftShapes", () => {
+    it("should create a loft between multiple 2D sketches", async () => {
+      // Create two circles of different sizes
+      const c1 = circle(10);
+      const c2 = circle(6);
+
+      const result = await loftShapes([c1, c2]);
+
+      expect(result).toBeDefined();
+      expect(result.geometry).toHaveLength(1);
+      expect(is3D(result)).toBe(true); // Loft should create 3D geometry
+    });
+
+    it("should handle lofting between different shape types", async () => {
+      const c1 = circle(8);
+      const r1 = rectangle(10, 6);
+
+      const result = await loftShapes([c1, r1]);
+
+      expect(result).toBeDefined();
+      expect(result.geometry).toHaveLength(1);
+      expect(is3D(result)).toBe(true);
+    });
+  });
+
+  describe("shrinkWrapSketches", () => {
+    it("should create a boundary around multiple 2D sketches", async () => {
+      const c1 = circle(5);
+      const r1 = rectangle(8, 6);
+
+      const result = await shrinkWrapSketches([c1, r1]);
+
+      expect(result).toBeDefined();
+      expect(result.geometry).toHaveLength(1);
+      expect(is3D(result)).toBe(false); // Should remain 2D
+    });
+
+    it("should handle single sketch input", async () => {
+      const r1 = rectangle(10, 5);
+
+      const result = await shrinkWrapSketches([r1]);
+
+      expect(result).toBeDefined();
+      expect(result.geometry).toHaveLength(1);
+      expect(is3D(result)).toBe(false);
+    });
+  });
+});

--- a/tests/shapes.test.js
+++ b/tests/shapes.test.js
@@ -1,0 +1,102 @@
+import {
+  rectangle,
+  circle,
+  regularPolygon,
+  text,
+} from "../src/worker/shapes.js";
+import { init, is3D, defaultColor } from "../src/worker/util.js";
+
+function degreesToRadians(degrees) {
+  return (degrees * Math.PI) / 180;
+}
+
+function vectorEquals(vector, x, y, z) {
+  expect(vector.x).toEqual(x);
+  expect(vector.y).toEqual(y);
+  expect(vector.z).toEqual(z);
+}
+
+describe("shapes.js", () => {
+  beforeAll(async () => {
+    await init();
+  });
+
+  describe("circle", () => {
+    it("should create a circle with specified diameter", async () => {
+      const diameter = 95;
+
+      const result = await circle(diameter);
+
+      expect(result).toBeDefined();
+      expect(result.geometry).toHaveLength(1);
+      expect(is3D(result)).toBe(false);
+      expect(result.tags).toEqual([]);
+      expect(result.color).toEqual(defaultColor);
+      expect(result.bom).toEqual([]);
+
+      vectorEquals(result.plane.zDir, 0, 0, 1);
+      vectorEquals(result.plane.origin, 0, 0, 0);
+
+      // Check bounding box dimensions
+      const bounds = result.geometry[0].boundingBox;
+      expect(bounds.width).toBeCloseTo(diameter, 4);
+      expect(bounds.height).toBeCloseTo(diameter, 4);
+    });
+  });
+
+  describe("rectangle", () => {
+    it("should create a rectangle with specified dimensions", async () => {
+      const width = 90;
+      const height = 5;
+
+      const result = await rectangle(width, height);
+
+      expect(result).toBeDefined();
+      expect(result.geometry).toHaveLength(1);
+      expect(is3D(result)).toBe(false);
+      expect(result.tags).toEqual([]);
+      expect(result.color).toEqual(defaultColor);
+      expect(result.bom).toEqual([]);
+
+      // Check plane is the default XY plane
+      vectorEquals(result.plane.zDir, 0, 0, 1);
+      vectorEquals(result.plane.origin, 0, 0, 0);
+
+      // Check bounding box dimensions
+      const bounds = result.geometry[0].boundingBox;
+      expect(bounds.width).toBeCloseTo(width, 4);
+      expect(bounds.height).toBeCloseTo(height, 4);
+    });
+  });
+
+  describe("regularPolygon", () => {
+    it("should create a triangle (3-sided polygon)", async () => {
+      const radius = 9;
+      const sides = 3;
+
+      const result = await regularPolygon(radius, sides);
+
+      expect(result).toBeDefined();
+      expect(result.geometry).toHaveLength(1);
+      expect(is3D(result)).toBe(false);
+      expect(result.tags).toEqual([]);
+      expect(result.color).toEqual(defaultColor);
+      expect(result.bom).toEqual([]);
+
+      // Check plane is the default XY plane
+      vectorEquals(result.plane.zDir, 0, 0, 1);
+      vectorEquals(result.plane.origin, 0, 0, 0);
+
+      // Check bounding box dimensions. Assumes shape is drawn with one edge parallel to the X-axis
+      const bounds = result.geometry[0].boundingBox;
+      expect(bounds.width).toBeCloseTo(
+        Math.cos(degreesToRadians(30)) * radius * 2,
+        4
+      );
+      expect(bounds.height).toBeCloseTo(
+        radius + Math.sin(degreesToRadians(30)) * radius,
+        4
+      );
+    });
+  });
+});

--- a/tests/tags.test.js
+++ b/tests/tags.test.js
@@ -1,0 +1,115 @@
+// Direct unit tests for tags.js
+import { tag, color, bom, extractAllTags } from "../src/worker/tags.js";
+
+describe("tags.js", () => {
+  let geometry;
+
+  beforeEach(() => {
+    geometry = {
+      id: "geom1",
+      // Fake geometry ok since tags don't perform any geometry operations
+      geometry: [{ type: "circle", radius: 10 }],
+      tags: [],
+      color: null,
+      bom: [],
+    };
+  });
+
+  describe("tag operations", () => {
+    it("should add tags to a geometry", () => {
+      const tags = ["important", "red"];
+      const result = tag(geometry, tags);
+
+      expect(result.tags).toContain("important");
+      expect(result.tags).toContain("red");
+      expect(result.geometry).toHaveLength(1);
+    });
+
+    it("should add single tag to geometry", () => {
+      const singleTag = ["feature"];
+      const result = tag(geometry, singleTag);
+
+      expect(result.tags).toContain("feature");
+    });
+
+    it("should preserve existing tags when adding new ones", () => {
+      geometry.tags = ["initial"];
+      const result = tag(geometry, ["additional"]);
+
+      expect(result.tags).toContain("initial");
+      expect(result.tags).toContain("additional");
+    });
+  });
+
+  describe("color operations", () => {
+    it("should apply color to geometry", () => {
+      const colorValue = "#FF0000";
+      const result = color(geometry, colorValue);
+
+      expect(result.color).toBe(colorValue);
+      expect(result.geometry).toHaveLength(1);
+    });
+
+    it("should automatically add keepout tag for specific color", () => {
+      const keepoutColor = "#D9544D";
+      const result = color(geometry, keepoutColor);
+
+      expect(result.color).toBe(keepoutColor);
+      expect(result.tags).toContain("keepout");
+    });
+
+    it("should handle different color formats", () => {
+      const blueColor = "#0000FF";
+      const result = color(geometry, blueColor);
+
+      expect(result.color).toBe(blueColor);
+    });
+  });
+
+  describe("BOM operations", () => {
+    it("should add BOM entry to geometry", () => {
+      const bomEntry = {
+        name: "Circular Part",
+        material: "Steel",
+        quantity: 2,
+        cost: 15.5,
+      };
+      const result = bom(geometry, bomEntry);
+
+      expect(result.bom).toContain(bomEntry);
+      expect(result.geometry).toHaveLength(1);
+    });
+
+    it("should handle multiple BOM entries", () => {
+      const bomEntry1 = { name: "Part A", material: "Aluminum" };
+      const bomEntry2 = { name: "Part B", material: "Plastic" };
+
+      geometry = bom(geometry, bomEntry1);
+      geometry = bom(geometry, bomEntry2);
+
+      expect(geometry.bom).toContain(bomEntry1);
+      expect(geometry.bom).toContain(bomEntry2);
+    });
+    // TODO: add tests for extracting BOM list, especially for assemblies.
+  });
+
+  describe("extractAllTags", () => {
+    it("should extract all tags from geometry", () => {
+      geometry.tags = ["tag1", "tag2", "tag3"];
+      const allTags = extractAllTags(geometry);
+
+      expect(Array.isArray(allTags)).toBe(true);
+      expect(allTags).toContain("tag1");
+      expect(allTags).toContain("tag2");
+      expect(allTags).toContain("tag3");
+    });
+
+    it("should handle geometry with no tags", () => {
+      geometry.tags = [];
+      const allTags = extractAllTags(geometry);
+
+      expect(Array.isArray(allTags)).toBe(true);
+      expect(allTags[0]).toBe("Select Tag");
+    });
+  });
+});


### PR DESCRIPTION
Moves worker.js into a folder so that it's functions can be split into multiple files.

Big picture goals here are two-fold:
1) move some of the logic of worker.js into separate files so that it's easier to tell which functions are related and what depends on what
2) set up apis which are more stateless and easier to test, eg: the new cutlayout.js file does not directly interact with the library object. All of the context (besides replicad itself) is provided as arguments and all of the effects are returned as results.

In this pr cutlayout.js is serving as an example of the kind of decomp I'd like to apply more generally. I'm not sure it's necessary to have a file for each atom. Eg: extrude so straight forward I'm not sure it helps readability to be in it's own file. There's a couple bigger groupings I would eventually like to split out:
* assembly.js - can host all the functions related to assemblies, ie making an assembly, assemblyMap, assemblyCut, flattenAssembly. ActOnLeafs probably belongs here too.
* code.js - can host the code function plus all the utility functions we define just for the user code context

General other guidelines I'm trying to adhere to under this new file structure:
1. all interaction with the library should happen directly in worker.js. Correspondingly, helper methods defined outside of worker.js should generally return a library-entry type object.
2. the `started` state and check should be managed exclusively in worker.js (ie, `await started` or `started.then` should be avoided outside of the worker.js file.
3. all the comlink code should be handled in worker.js (tho I've already created an exception to this with the proxied nested callback in cutlayout.js)

@alzatin let me know what you think of this refactor of worker.js. I'd love to hear any feedback you've got. Intending this PR to be primarily a discussion prompt, and we can merge it eventually if we both feel like it's a positive change.

