### PR TITLE
Simplify gcode for display

### DIFF
--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -741,7 +741,6 @@ function visualizeGcode(targetID, gcode) {
   });
 
   // Create a wire from the edges
-  const wireStartTime = performance.now();
   const wire = util.replicad.assembleWire(edges);
   library[targetID] = {
     geometry: [wire],


### PR DESCRIPTION
Large gcode files were not able to display correctly (or took forever) because they had too many edges. This PR reduces the number of edges to let them load in reasonable amounts of time