### PR TITLE
Doubling top molecules on reload github fix

### DIFF
--- a/src/molecules/molecule.js
+++ b/src/molecules/molecule.js
@@ -251,13 +251,14 @@ export default class Molecule extends Atom {
             path: "project.abundance",
           })
           .then((response) => {
-            // Delete nodes so deserialize doesn't repeat, could be useful to not delete for a diff in the future
-
+            // Clear the nodesOnTheScreen array before deserialization to avoid doubling
             GlobalVariables.topLevelMolecule.nodesOnTheScreen.forEach(
               (atom) => {
                 atom.deleteNode();
               }
             );
+            GlobalVariables.topLevelMolecule.nodesOnTheScreen = []; // <-- clear the array
+
             let rawFile = JSON.parse(atob(response.data.content));
 
             if (rawFile.filetypeVersion == 1) {


### PR DESCRIPTION
Fixes #666 

This fixes the doubling issue when reloading forked molecules from their parent repository. It does so by making sure the nodesOnTheScreen array is cleared before deserialization of github version.