### PR TITLE
Fix equation stuck with numeric value

### DIFF
--- a/src/components/secondary/ParameterEditor.jsx
+++ b/src/components/secondary/ParameterEditor.jsx
@@ -1,7 +1,14 @@
 import React, { useState, useEffect, useMemo } from "react";
 import globalvariables from "../../js/globalvariables";
 
-import { useControls, useCreateStore, LevaPanel, button } from "leva";
+import {
+  useControls,
+  useCreateStore,
+  LevaPanel,
+  button,
+  Leva,
+  LevaInputs,
+} from "leva";
 
 /**Creates new collapsible sidebar with Leva - edited from Replicad's ParamsEditor.jsx */
 export default (function ParamsEditor({
@@ -66,6 +73,7 @@ export default (function ParamsEditor({
       value: activeAtom.currentEquation,
       label: "Current Equation",
       disabled: false,
+      type: LevaInputs.STRING,
       onChange: (value) => {
         if (activeAtom.currentEquation !== value) {
           activeAtom.setEquation(value);
@@ -77,6 +85,7 @@ export default (function ParamsEditor({
       },
       order: -3,
     };
+
     inputParamsConfig[activeAtom.uniqueID + "result"] = {
       label: "Result",
       value: 3,


### PR DESCRIPTION
Fixes #500 

When you type a single number into the input field for current equation the input type remains a string instead of resetting to a number type which caused the currentEquation input to break. 
There is still an issue where if there's no variables the equation will not compute the correct result. 