### PR TITLE
Reintroduce progress callback to slicer

### DIFF
--- a/KirimotoUpdate.js
+++ b/KirimotoUpdate.js
@@ -14,28 +14,74 @@ const generateGcode = (
   passes,
   speed,
   extra,
-  gcodeCallback
+  gcodeCallback,
+  progressCallback
 ) => {
-  console.log("passes", passes);
   if (!stlUrl) {
     console.error("STL URL is not available.");
     return;
   }
 
+  // Track slicing progress with a timer
+  let slicingTimer = null;
+  let slicingStartTime = null;
+  let slicingProgressStart = 0.6;
+  let slicingProgressEnd = 0.8;
+
+  const startSlicingProgress = () => {
+    slicingStartTime = Date.now();
+    let currentProgress = slicingProgressStart;
+
+    slicingTimer = setInterval(() => {
+      const elapsed = Date.now() - slicingStartTime;
+      // Gradually increase progress over time, with diminishing returns
+      // This creates a more realistic progress feel during slicing
+      const timeBasedProgress = Math.min(
+        0.18,
+        0.18 * (1 - Math.exp(-elapsed / 10000))
+      ); // Exponential approach to 0.18 (80%-60%)
+      currentProgress = slicingProgressStart + timeBasedProgress;
+
+      if (progressCallback && currentProgress < slicingProgressEnd) {
+        progressCallback(currentProgress);
+      }
+    }, 500); // Update every 500ms during slicing
+  };
+
+  const stopSlicingProgress = () => {
+    if (slicingTimer) {
+      clearInterval(slicingTimer);
+      slicingTimer = null;
+    }
+  };
+
   kiriEngine
     .setListener((message) => {
       console.log("Kiri:Moto Message:", message);
+      // Check if message contains slicing progress information
+      if (message && typeof message === "object") {
+        if (message.progress !== undefined && slicingStartTime) {
+          // If Kiri:Moto provides progress during slicing, use it
+          const slicingProgress =
+            slicingProgressStart +
+            (slicingProgressEnd - slicingProgressStart) * message.progress;
+          if (progressCallback) progressCallback(slicingProgress);
+        }
+      }
     })
     .load(stlUrl)
     .then((eng) => {
-      console.log(centerPos);
+      if (progressCallback) progressCallback(0.1); // 10% - STL loaded
       return eng.move(centerPos[0], centerPos[1], 0); //Move the model to line up with where the parts were before
     })
     .then((eng) => {
+      if (progressCallback) progressCallback(0.15); // 15% - Model moved
       return eng.setMode("CAM");
     })
     .then((eng) => {
       const bounds = eng.widget.getBoundingBox();
+
+      if (progressCallback) progressCallback(0.2); // 20% - Mode set
       const x = bounds.max.x - bounds.min.x;
       const y = bounds.max.y - bounds.min.y;
       const z = bounds.max.z - bounds.min.z;
@@ -68,6 +114,7 @@ const generateGcode = (
       ])
     )
     .then((eng) => {
+      if (progressCallback) progressCallback(0.3); // 30% - Tools set
       const bounds = eng.widget.getBoundingBox();
       const z = bounds.max.z - bounds.min.z;
       eng.setProcess({
@@ -323,14 +370,29 @@ const generateGcode = (
         useLaser: false,
       })
     )
+    .then((eng) => {
+      if (progressCallback) progressCallback(0.5); // 50% - Process set
+      startSlicingProgress();
+      return eng;
+    })
     .then((eng) => eng.slice())
+    .then((eng) => {
+      if (progressCallback) progressCallback(0.8); // 80% - Slicing done
+      stopSlicingProgress(); // Stop the slicing progress timer
+      return eng;
+    })
     .then((eng) => eng.prepare())
+    .then((eng) => {
+      if (progressCallback) progressCallback(0.9); // 90% - Preparation done
+      return eng;
+    })
     .then((eng) => eng.export())
     .then((gcode) => {
       gcodeCallback(gcode); // Only call the callback, don't download
-      console.log(gcode);
+      if (progressCallback) progressCallback(1.0); // 100% - Export complete
     })
     .catch((error) => {
+      stopSlicingProgress(); // Ensure timer is cleaned up on error
       console.error("Kiri:Moto Error:", error);
     })
     .finally(() => {


### PR DESCRIPTION
Reintroduce preexisting slicer and progress callback to the kiri file which got omitted to clean up the update. 