### PR TITLE
Fix import bug IO missing

### DIFF
--- a/src/molecules/import.js
+++ b/src/molecules/import.js
@@ -53,13 +53,19 @@ export default class Import extends Atom {
      */
     this.sha = null;
 
-    this.SVGwidth = 10;
-
     this.addIO("output", "geometry", this, "geometry", "");
 
     this.importOptions = ["SVG", "STL", "STEP"];
 
     this.importIndex = 0;
+
+    //This loads any inputs which this atom had when last saved.
+    if (typeof this.ioValues !== "undefined") {
+      this.ioValues.forEach((ioValue) => {
+        //for each saved value
+        this.addIO("input", ioValue.name, this, "geometry", "");
+      });
+    }
 
     this.setValues(values);
   }
@@ -127,7 +133,8 @@ export default class Import extends Atom {
           throw new Error("Invalid file type");
         }
 
-        funcToCall(this.uniqueID, file, this.SVGwidth)
+        let svgWidthIO = this.findIOValue("SVG Width");
+        funcToCall(this.uniqueID, file, svgWidthIO ? svgWidthIO : 1)
           .then((result) => {
             this.basicThreadValueProcessing();
             this.sendToRender();
@@ -136,6 +143,9 @@ export default class Import extends Atom {
             alert(`Error processing file: ${error.message || error}`);
             this.alertingErrorHandler();
           });
+        if (this.type == "SVG") {
+          this.addIO("input", "SVG Width", this, "number", 5, true);
+        }
       });
     }
   }
@@ -185,16 +195,29 @@ export default class Import extends Atom {
         },
       };
     } else {
-      if (this.type == "SVG") {
-        inputParams["Width"] = {
-          value: this.SVGwidth, //href to the file
-          label: "Width",
-          step: 0.01,
-          onChange: (value) => {
-            this.SVGwidth = value;
-            this.updateValue();
-          },
-        };
+      if (this.inputs) {
+        this.inputs.map((input) => {
+          const checkConnector = () => {
+            return input.connectors.length > 0;
+          };
+
+          /* Makes inputs for Io's other than geometry */
+          if (input.valueType !== "geometry") {
+            inputParams[this.uniqueID + input.name] = {
+              value: input.value,
+              label: input.name,
+              step: 0.25,
+              disabled: checkConnector(),
+              onChange: (value) => {
+                if (input.value !== value) {
+                  input.setValue(value);
+                  this.updateValue();
+                }
+              },
+            };
+          }
+        });
+        return inputParams;
       }
     }
     return inputParams;
@@ -269,7 +292,6 @@ export default class Import extends Atom {
     superSerialObject.fileName = this.fileName; // might delete, maybe we just save as library object
     superSerialObject.name = this.name;
     superSerialObject.type = this.type;
-    superSerialObject.SVGwidth = this.SVGwidth;
     superSerialObject.repoOwner = this.repoOwner;
     superSerialObject.repoName = this.repoName;
 


### PR DESCRIPTION
Fixes import atom bug on svg mode which prevented the import atom from receiving the svg width as an input and therefore making it impossible to use as part of dynamic molecules. 

- Adds svg width as an io for the import atom when there's an svg file uploaded. 