### PR TITLE
Fixes x,y position issue for assembly gcode

### DIFF
--- a/KirimotoUpdate.js
+++ b/KirimotoUpdate.js
@@ -54,10 +54,8 @@ const generateGcode = (
       slicingTimer = null;
     }
   };
-
   kiriEngine
     .setListener((message) => {
-      console.log("Kiri:Moto Message:", message);
       // Check if message contains slicing progress information
       if (message && typeof message === "object") {
         if (message.progress !== undefined && slicingStartTime) {
@@ -72,7 +70,7 @@ const generateGcode = (
     .load(stlUrl)
     .then((eng) => {
       if (progressCallback) progressCallback(0.1); // 10% - STL loaded
-      return eng.move(centerPos[0], centerPos[1], 0); //Move the model to line up with where the parts were before
+      return eng.moveTo(centerPos[0], centerPos[1], 0); //Move the model to line up with where the parts were before
     })
     .then((eng) => {
       if (progressCallback) progressCallback(0.15); // 15% - Model moved
@@ -92,7 +90,7 @@ const generateGcode = (
         center: {
           x: x / 2,
           y: y / 2,
-          z: z / 2,
+          z: z,
         },
       });
       return eng;
@@ -133,8 +131,8 @@ const generateGcode = (
         camRoughPlunge: 250,
         camRoughStock: 0,
         camRoughStockZ: 0,
-        camRoughAll: false,
-        camRoughVoid: true,
+        camRoughAll: true,
+        camRoughVoid: false,
         camRoughFlat: true,
         camRoughTop: true,
         camRoughIn: true,
@@ -143,10 +141,10 @@ const generateGcode = (
         camOutlineTool: 1000,
         camOutlineSpindle: 1000,
         camOutlineTop: true,
-        camOutlineDown: 3,
+        camOutlineDown: z / passes,
         camOutlineOver: 0.4,
         camOutlineOverCount: 1,
-        camOutlineSpeed: 800,
+        camOutlineSpeed: speed,
         camOutlinePlunge: 250,
         camOutlineWide: false,
         camOutlineDogbone: true,
@@ -203,16 +201,13 @@ const generateGcode = (
         camPocketOutline: false,
         camPocketZTop: 0,
         camPocketZBottom: 0,
-        camDrillTool: 1006,
+        camDrillTool: 1000,
         camDrillSpindle: 1000,
         camDrillDownSpeed: 250,
         camDrillDown: 5,
         camDrillDwell: 250,
         camDrillLift: 2,
         camDrillMark: false,
-        camDrillFromStockTop: false,
-        camDrillThru: 5,
-        camDrillPrecision: 1,
         camDrillingOn: false,
         camRegisterSpeed: 1000,
         camRegisterThru: 5,
@@ -268,9 +263,6 @@ const generateGcode = (
         outputInvertY: false,
         camExpertFast: false,
         camTrueShadow: false,
-        camArcEnabled: false,
-        camArcTolerance: 0.15,
-        camArcResolution: 5,
         camForceZMax: false,
         camFirstZMax: false,
         camToolInit: true,


### PR DESCRIPTION
<img width="533" height="188" alt="PNG image" src="https://github.com/user-attachments/assets/a52b0c1d-85e9-46c3-a982-aae4260b1da6" />
Fixes bug which positioned pieces wrongly in gcode when working with assemblies. Ends up the wrong method was being used and instead of moving to the location of each piece, with each pass we were moving the entire engine further from center. 