### PR TITLE
kirimoto zbottom issue and bounding box update

### DIFF
--- a/KirimotoUpdate.js
+++ b/KirimotoUpdate.js
@@ -121,7 +121,13 @@ const generateGcode = (
       const bounds = eng.widget.getBoundingBox();
       const z = bounds.max.z - bounds.min.z;
       const zBottom = -z - 1.524; // cut through part thickness plus cut-through
-      const down = Math.abs(zBottom) / passes; // positive value per pass
+      // Add small epsilon to avoid floating point errors causing extra pass
+      const epsilon = 0.0001;
+      const validPasses = Math.max(1, Math.floor(Number(passes) || 1));
+      const down = Math.abs(zBottom) / validPasses + epsilon; // positive value per pass
+
+      // Debug logging for pass calculation
+      console.log("CAM pass debug:", { passes, z, zBottom, down });
       return eng.setProcess({
         camEaseAngle: 10,
         camEaseDown: true,

--- a/KirimotoUpdate.js
+++ b/KirimotoUpdate.js
@@ -6,7 +6,6 @@ const display_message = (message) => {
 };
 
 const kiriEngine = new Engine({ workURL: "./worker.js" });
-console.log(kiriEngine);
 
 const generateGcode = (
   stlUrl,
@@ -120,8 +119,6 @@ const generateGcode = (
     .then((eng) => {
       if (progressCallback) progressCallback(0.25); // 25% - Tools set
       const bounds = eng.widget.getBoundingBox();
-      const x = bounds.max.x - bounds.min.x;
-      const y = bounds.max.y - bounds.min.y;
       const z = bounds.max.z - bounds.min.z;
       const zBottom = -z - 1.524; // cut through part thickness plus cut-through
       const down = Math.abs(zBottom) / passes; // positive value per pass

--- a/KirimotoUpdate.js
+++ b/KirimotoUpdate.js
@@ -17,6 +17,9 @@ const generateGcode = (
   gcodeCallback,
   progressCallback
 ) => {
+  const STOCK_MARGIN = 10;
+  const CUT_THROUGH = 1.524;
+
   if (!stlUrl) {
     console.error("STL URL is not available.");
     return;
@@ -84,13 +87,13 @@ const generateGcode = (
       const y = bounds.max.y - bounds.min.y;
       const z = bounds.max.z - bounds.min.z;
       return eng.setStock({
-        x: x + 10,
-        y: y + 10,
-        z: z + 10 + 1.524, // stock thickness = part thickness + margin + cut-through
+        x: x + STOCK_MARGIN,
+        y: y + STOCK_MARGIN,
+        z: z + STOCK_MARGIN + CUT_THROUGH, // stock thickness = part thickness + margin + cut-through
         center: {
           x: x / 2,
           y: y / 2,
-          z: (z + 5 + 1.524) / 2, // correct center for full stock thickness
+          z: z + STOCK_MARGIN / 2 + CUT_THROUGH / 2, // correct center for full stock thickness
         },
       });
     })
@@ -120,7 +123,7 @@ const generateGcode = (
       if (progressCallback) progressCallback(0.25); // 25% - Tools set
       const bounds = eng.widget.getBoundingBox();
       const z = bounds.max.z - bounds.min.z;
-      const zBottom = -z - 1.524; // cut through part thickness plus cut-through
+      const zBottom = -z - CUT_THROUGH; // cut through part thickness plus cut-through
       // Add small epsilon to avoid floating point errors causing extra pass
       const epsilon = 0.0001;
       const validPasses = Math.max(1, Math.floor(Number(passes) || 1));
@@ -133,7 +136,7 @@ const generateGcode = (
         camEaseDown: true,
         camZAnchor: "bottom",
         camDepthFirst: false,
-        camZThru: 1.524,
+        camZThru: CUT_THROUGH,
         camZBottom: zBottom, // temp hack to get around setTopZ bug
         camToolInit: true,
         ops: [

--- a/KirimotoUpdate.js
+++ b/KirimotoUpdate.js
@@ -56,6 +56,8 @@ const generateGcode = (
     }
   };
 
+  console.log(kiriEngine);
+
   kiriEngine
     .setListener((message) => {
       // Check if message contains slicing progress information
@@ -72,6 +74,7 @@ const generateGcode = (
     .load(stlUrl)
     // should to call widget.setTopZ here ideally
     .then((eng) => {
+      eng.widget.boundingBoxNeedsUpdate = true; // Ensure bounding box is updated
       if (progressCallback) progressCallback(0.1); // 10% - STL loaded
       return eng.setMode("CAM");
     })
@@ -84,17 +87,18 @@ const generateGcode = (
       return eng.setStock({
         x: x + 10,
         y: y + 10,
-        z: 100,
+        z: z + 10 + 1.524, // stock thickness = part thickness + margin + cut-through
         center: {
           x: x / 2,
           y: y / 2,
-          z: 12.5,
+          z: (z + 5 + 1.524) / 2, // correct center for full stock thickness
         },
       });
     })
     .then((eng) => {
       if (progressCallback) progressCallback(0.2); // 20% - Stock set
-      return eng.moveTo(centerPos[0], centerPos[1], 0); //Move the model to line up with where the parts were before
+      eng.moveTo(centerPos[0], centerPos[1], 0); // move part so top is at Z=0
+      return eng;
     })
     .then((eng) =>
       eng.setTools([
@@ -119,13 +123,15 @@ const generateGcode = (
       const x = bounds.max.x - bounds.min.x;
       const y = bounds.max.y - bounds.min.y;
       const z = bounds.max.z - bounds.min.z;
+      const zBottom = -z - 1.524; // cut through part thickness plus cut-through
+      const down = Math.abs(zBottom) / passes; // positive value per pass
       return eng.setProcess({
         camEaseAngle: 10,
         camEaseDown: true,
         camZAnchor: "bottom",
         camDepthFirst: false,
         camZThru: 1.524,
-        camZBottom: -25, // temp hack to get around setTopZ bug
+        camZBottom: zBottom, // temp hack to get around setTopZ bug
         camToolInit: true,
         ops: [
           {
@@ -134,7 +140,7 @@ const generateGcode = (
             spindle: 13000,
             step: 0.4,
             steps: 1,
-            down: z / passes,
+            down: down, // correct depth per pass
             rate: 635,
             plunge: 51,
             dogbones: false,


### PR DESCRIPTION
Still have some issues with pass count but this should fix one major issue in generating gcode where although a new stl was being passed to the engine, the bounding box was not updated.

- The boundingbox method is now updated and should retrieve the correct box.
- Resets stock thickness and center to account for a margin and the cut through. 
- Sets ZcamBottom as the total part depth plus cutthru
- Sets down to use zbottom as the total depth from which passes are calculated.