### PR TITLE
Unit correction for STL generation and unit pregcode change

### DIFF
--- a/KirimotoUpdate.js
+++ b/KirimotoUpdate.js
@@ -233,7 +233,6 @@ const generateGcode = (
     })
     .then((gcode) => {
       console.log("G-code generated successfully.");
-      console.log(gcode);
       gcodeCallback(gcode); // Only call the callback, don't download
       if (progressCallback) progressCallback(1.0); // 100% - Export complete
     })

--- a/KirimotoUpdate.js
+++ b/KirimotoUpdate.js
@@ -160,14 +160,35 @@ const generateGcode = (
             ov_botz: 0,
             ov_conv: true,
           },
+          /*{
+            type: "outline",
+            tool: 1000,
+            spindle: 13000,
+            step: 0.4,
+            steps: 1,
+            down: down, // correct depth per pass
+            rate: 635,
+            plunge: 51,
+            dogbones: false,
+            omitvoid: false,
+            omitthru: false,
+            outside: false,
+            inside: false,
+            wide: false,
+            top: false,
+            ov_topz: 0,
+            ov_botz: 0,
+            ov_conv: true,
+          },*/
         ],
       });
     })
     .then((eng) => {
       // Set G-code units based on project units
-      const unitsCommand = GlobalVariables.topLevelMolecule.unitsKey === "MM" 
-        ? "G21 ; set units to MM (required)"
-        : "G20 ; set units to inches (required)";
+      const unitsCommand =
+        GlobalVariables.topLevelMolecule.unitsKey === "MM"
+          ? "G21 ; set units to MM (required)"
+          : "G20 ; set units to Inches (required)";
 
       return eng.setDevice({
         mode: "CAM",
@@ -179,7 +200,7 @@ const generateGcode = (
         originCenter: false,
         spindleMax: 24000,
         gcodePre: [
-          unitsCommand,
+          "G21 ; set units to MM (required)",
           "G90 ; absolute position mode (required)",
         ],
         gcodePost: ["M05 ; spindle off", "M30 ; program end"],

--- a/src/molecules/gcode.js
+++ b/src/molecules/gcode.js
@@ -396,7 +396,8 @@ export default class Gcode extends Atom {
         );
         const stlBlob = await GlobalVariables.cad.downExport(
           this.uniqueID + 100 + i,
-          "STL"
+          "STL",
+          GlobalVariables.topLevelMolecule.unitsKey
         );
         const stlURL = URL.createObjectURL(stlBlob);
 


### PR DESCRIPTION
Ok so this is not right but it makes it so that the visualizer loads at the correct scale. Projects in MM were loading correctly with the copilot unit changes but soon after I merged it realized that projects in inches were still loading incorrectly (too small). I'm not sure why this is. I corrected the missing units parameter in the stl generation and hoped that would fix it but this change to MM in the pregcode setting seems to generate the same size as the piece. 