### PR TITLE
Minimize cut through - gcode 

### DIFF
--- a/KirimotoUpdate.js
+++ b/KirimotoUpdate.js
@@ -18,7 +18,7 @@ const generateGcode = (
   progressCallback
 ) => {
   const STOCK_MARGIN = 10;
-  const CUT_THROUGH = 1.524;
+  const CUT_THROUGH = 0.3;
 
   if (!stlUrl) {
     console.error("STL URL is not available.");
@@ -89,7 +89,7 @@ const generateGcode = (
       return eng.setStock({
         x: x + STOCK_MARGIN,
         y: y + STOCK_MARGIN,
-        z: z + STOCK_MARGIN + CUT_THROUGH, // stock thickness = part thickness + margin + cut-through
+        z: z + CUT_THROUGH, // stock thickness = part thickness + cut-through
         center: {
           x: x / 2,
           y: y / 2,


### PR DESCRIPTION
@BarbourSmith  Ok, so we had guessed correctly that the extra pass was the cutthrough finishing pass. I'm not totally sure how to turn it off because when i set it to zero it begins generating an extra pass up top. I set it to a small cutthrough number which you'll be able to see more consistently as an extra pass below your selected number of passes. I reset the default stock so that it's value is the part's height + cutthrough instead of having a larger margin which was causing extra passes as the gcode was also cutting through the extra stock. 