### PR TITLE
Fix render issue generated by auto generate gcode

### DIFF
--- a/src/molecules/gcode.js
+++ b/src/molecules/gcode.js
@@ -157,7 +157,6 @@ export default class Gcode extends Atom {
       this.progress = 1.0; // Complete progress
       GlobalVariables.cad.visualizeGcode(this.uniqueID, gcode);
       this.basicThreadValueProcessing();
-      this.sendToRender();
     };
   }
 
@@ -647,7 +646,7 @@ export default class Gcode extends Atom {
         geometryInputConnected = true;
       }
     });
-    
+
     // Only trigger if geometry is connected (main input for gcode generation)
     if (geometryInputConnected && !this.gcodeGenerated) {
       this.updateValue();

--- a/src/molecules/gcode.js
+++ b/src/molecules/gcode.js
@@ -197,6 +197,7 @@ export default class Gcode extends Atom {
           this.findIOValue("Speed"),
           this.findIOValue("Cut Through"),
           gcodeCallback
+          //progressCallback
         );
       }
     } catch (err) {

--- a/src/molecules/gcode.js
+++ b/src/molecules/gcode.js
@@ -187,7 +187,7 @@ export default class Gcode extends Atom {
         const progressCallback = (progress) => {
           this.progress = progress;
           // Force a redraw to show progress update
-          this.sendToRender();
+          //this.sendToRender();
         };
         window.generateGcode(
           this.stlURL,
@@ -204,7 +204,7 @@ export default class Gcode extends Atom {
       this.setError(err);
       this.progress = 1.0;
       this.processing = false;
-      this.sendToRender();
+      //this.sendToRender();
     }
   }
 
@@ -396,7 +396,7 @@ export default class Gcode extends Atom {
       try {
         // Update progress
         this.progress = partProgress;
-        this.sendToRender();
+        //this.sendToRender();
 
         const idForVisExport = GlobalVariables.generateUniqueID();
         // Generate STL for this part
@@ -443,7 +443,6 @@ export default class Gcode extends Atom {
     // Visualize the concatenated G-code
     GlobalVariables.cad.visualizeGcode(this.uniqueID, this.gcodeString);
     this.basicThreadValueProcessing();
-    this.sendToRender();
   }
 
   /**


### PR DESCRIPTION
This should fix the extra sendtorender calls that made the interface look glitchy after the gcode was automatically generated