### PR TITLE
Equation and variable eval in atom inputs

### DIFF
--- a/src/molecules/equation.js
+++ b/src/molecules/equation.js
@@ -199,8 +199,7 @@ export default class Equation extends Atom {
       // Evaluate the substituted equation
       return GlobalVariables.limitedEvaluate(substitutedEquation);
     } catch (error) {
-      console.error("Error evaluating equation:", error);
-      this.setError(error);
+      this.alertingErrorHandler(error);
       return NaN;
     }
   }

--- a/src/molecules/equation.js
+++ b/src/molecules/equation.js
@@ -199,7 +199,8 @@ export default class Equation extends Atom {
       // Evaluate the substituted equation
       return GlobalVariables.limitedEvaluate(substitutedEquation);
     } catch (error) {
-      this.alertingErrorHandler(error);
+      console.error("Error evaluating equation:", error);
+      this.setError(error);
       return NaN;
     }
   }

--- a/src/molecules/molecule.js
+++ b/src/molecules/molecule.js
@@ -605,6 +605,27 @@ export default class Molecule extends Atom {
         atom.updateValue(); //Tell that input to update it's value
       }
     });
+    // Propagate input change to dependent IOs
+    if (targetName) {
+      this.propagateInputChange(targetName);
+    }
+  }
+  /**
+   * Propagate input value changes to all IOs whose currentEquation references the changed input name
+   */
+  async propagateInputChange(inputName) {
+    for (const atom of this.nodesOnTheScreen) {
+      for (const io of atom.inputs) {
+        if (io.currentEquation && io.currentEquation.includes(inputName)) {
+          try {
+            const result = await atom.evaluateEquation(io.currentEquation);
+            io.setValue(result);
+          } catch (e) {
+            // Error already handled in evaluateEquation
+          }
+        }
+      }
+    }
   }
 
   compileBom() {

--- a/src/molecules/rectangle.js
+++ b/src/molecules/rectangle.js
@@ -80,6 +80,6 @@ export default class Rectangle extends Atom {
       .then(() => {
         this.basicThreadValueProcessing();
       })
-      .catch(this.alertingErrorHandler());
+      .catch((err) => this.alertingErrorHandler(err));
   }
 }

--- a/src/molecules/rectangle.js
+++ b/src/molecules/rectangle.js
@@ -80,6 +80,6 @@ export default class Rectangle extends Atom {
       .then(() => {
         this.basicThreadValueProcessing();
       })
-      .catch((err) => this.alertingErrorHandler(err));
+      .catch((err) => this.alertingErrorHandler());
   }
 }

--- a/src/prototypes/atom.js
+++ b/src/prototypes/atom.js
@@ -166,6 +166,9 @@ export default class Atom {
           //Find the matching IO and set it to be the saved value
           if (ioValue.name == io.name && io.type == "input") {
             io.value = ioValue.ioValue;
+            if ("currentEquation" in ioValue) {
+              io.currentEquation = ioValue.currentEquation;
+            }
           }
         });
       });
@@ -603,6 +606,7 @@ export default class Atom {
         var saveIO = {
           name: io.name,
           ioValue: io.getValue(),
+          currentEquation: io.currentEquation || null,
         };
         ioValues.push(saveIO);
       }
@@ -737,17 +741,16 @@ export default class Atom {
         /* Makes inputs for Io's other than geometry */
         if (input.valueType !== "geometry") {
           inputParams[this.uniqueID + input.name] = {
-            value: input.value,
+            value: input.currentEquation ? input.currentEquation : input.value,
             label: input.name,
             step: 0.25,
             type: LevaInputs.STRING,
             disabled: checkConnector(),
             onChange: async (value) => {
               let currentEquation = String(value).trim();
-              this.currentEquation = currentEquation;
+              input.currentEquation = currentEquation;
               // Evaluate the equation and wait for the result
               let result = await this.evaluateEquation(currentEquation);
-              console.log("Evaluated result:", result);
               input.setValue(result);
               //this.sendToRender();
             },

--- a/src/prototypes/atom.js
+++ b/src/prototypes/atom.js
@@ -766,45 +766,70 @@ export default class Atom {
    */
   async evaluateEquation(equation) {
     try {
-      // Substitute numbers into the string
-      var substitutedEquation = equation;
-      // Use AST-based variable extraction for consistency
-      const variables = await this.extractVariablesFromEquation(equation);
+      let substitutedEquation = String(equation ?? "").trim();
+      const variables = await this.extractVariablesFromEquation(
+        substitutedEquation
+      );
+      const unresolved = [];
+      const resolvedValues = {};
       if (variables.length > 0) {
-        for (var variable of variables) {
-          // First, try to find in parent molecule's inputs
+        const parentInputs =
+          (this.parent && this.parent.inputs) ||
+          (this.parentMolecule && this.parentMolecule.inputs) ||
+          [];
+        for (const variable of variables) {
           let value = null;
-          console.log(this);
-          if (this.parent && this.parent.inputs) {
-            for (var j = 0; j < this.parent.inputs.length; j++) {
-              // If the variable matches a parent input, use its value
-              if (this.parent.inputs[j].name == variable) {
-                value = this.parent.inputs[j].value;
-                break;
-              }
+          // Try parent inputs first
+          for (let j = 0; j < parentInputs.length; j++) {
+            if (parentInputs[j].name === variable) {
+              value = parentInputs[j].value;
+              break;
             }
           }
-          // If not found, try to find in this atom's inputs
-          if (value === null) {
-            for (var i = 0; i < this.inputs.length; i++) {
-              if (this.inputs[i].name == variable) {
+          // Then this atom's inputs
+          if (value === null || value === undefined) {
+            for (let i = 0; i < this.inputs.length; i++) {
+              if (this.inputs[i].name === variable) {
                 value = this.findIOValue(this.inputs[i].name);
                 break;
               }
             }
           }
-          // If still not found, skip substitution (or set to 0)
-          if (value === null) value = 0;
-          // Use word boundaries in replacement to avoid partial matches
-          const variablePattern = new RegExp(`\\b${variable}\\b`, "g");
-          substitutedEquation = substitutedEquation.replace(
-            variablePattern,
-            value
-          );
+          let num = Number(value);
+          if (
+            value === null ||
+            value === undefined ||
+            (typeof value === "string" && value.trim() === "") ||
+            !Number.isFinite(num)
+          ) {
+            unresolved.push(variable);
+          } else {
+            resolvedValues[variable] = num;
+          }
         }
       }
-      // Evaluate the substituted equation
-      return GlobalVariables.limitedEvaluate(substitutedEquation);
+      if (unresolved.length) {
+        const msg = `Variable(s) not found: ${unresolved.join(
+          ", "
+        )}. Make sure the variables you are using exist as inputs`;
+        console.warn(msg);
+        throw new Error(msg);
+      } else {
+        this.clearAlert();
+        // Substitute all resolved variables
+        for (const variable of Object.keys(resolvedValues)) {
+          const safeVar = variable.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+          const variablePattern = new RegExp(`\\b${safeVar}\\b`, "gu");
+          substitutedEquation = substitutedEquation.replace(
+            variablePattern,
+            String(resolvedValues[variable])
+          );
+        }
+        const result = await GlobalVariables.limitedEvaluate(
+          substitutedEquation
+        );
+        return result;
+      }
     } catch (error) {
       console.error("Error evaluating equation:", error);
       this.setError(error);

--- a/src/prototypes/atom.js
+++ b/src/prototypes/atom.js
@@ -770,20 +770,13 @@ export default class Atom {
       var substitutedEquation = equation;
       // Use AST-based variable extraction for consistency
       const variables = await this.extractVariablesFromEquation(equation);
-      console.log("Extracted variables:", variables);
       if (variables.length > 0) {
         for (var variable of variables) {
           // First, try to find in parent molecule's inputs
           let value = null;
           console.log(this);
           if (this.parent && this.parent.inputs) {
-            console.log("this.parent exists, checking inputs");
             for (var j = 0; j < this.parent.inputs.length; j++) {
-              console.log(
-                "Checking parent molecule input:",
-                this.parent.inputs[j].name
-              );
-              console.log("Against variable:", variable);
               // If the variable matches a parent input, use its value
               if (this.parent.inputs[j].name == variable) {
                 value = this.parent.inputs[j].value;
@@ -802,7 +795,6 @@ export default class Atom {
           }
           // If still not found, skip substitution (or set to 0)
           if (value === null) value = 0;
-          console.log("Substituting variable:", variable, "with value:", value);
           // Use word boundaries in replacement to avoid partial matches
           const variablePattern = new RegExp(`\\b${variable}\\b`, "g");
           substitutedEquation = substitutedEquation.replace(
@@ -811,7 +803,6 @@ export default class Atom {
           );
         }
       }
-
       // Evaluate the substituted equation
       return GlobalVariables.limitedEvaluate(substitutedEquation);
     } catch (error) {

--- a/src/prototypes/atom.js
+++ b/src/prototypes/atom.js
@@ -2,6 +2,16 @@ import AttachmentPoint from "./attachmentpoint";
 import GlobalVariables from "../js/globalvariables.js";
 import showdown from "showdown";
 import globalvariables from "../js/globalvariables.js";
+import { parse } from "mathjs";
+
+import {
+  useControls,
+  useCreateStore,
+  LevaPanel,
+  button,
+  Leva,
+  LevaInputs,
+} from "leva";
 
 // Make this an enum once we're using typescript
 const AlertType = Object.freeze({
@@ -730,18 +740,112 @@ export default class Atom {
             value: input.value,
             label: input.name,
             step: 0.25,
+            type: LevaInputs.STRING,
             disabled: checkConnector(),
-            onChange: (value) => {
-              if (input.value !== value) {
-                input.setValue(value);
-                //this.sendToRender();
-              }
+            onChange: async (value) => {
+              let currentEquation = String(value).trim();
+              this.currentEquation = currentEquation;
+              // Evaluate the equation and wait for the result
+              let result = await this.evaluateEquation(currentEquation);
+              console.log("Evaluated result:", result);
+              input.setValue(result);
+              //this.sendToRender();
             },
           };
         }
       });
       return inputParams;
     }
+  }
+
+  /**
+   * Evaluate the equation
+   */
+  async evaluateEquation(equation) {
+    try {
+      // Substitute numbers into the string
+      var substitutedEquation = equation;
+      // Use AST-based variable extraction for consistency
+      const variables = await this.extractVariablesFromEquation(equation);
+      console.log("Extracted variables:", variables);
+      if (variables.length > 0) {
+        for (var variable of variables) {
+          // First, try to find in parent molecule's inputs
+          let value = null;
+          console.log(this);
+          if (this.parent && this.parent.inputs) {
+            console.log("this.parent exists, checking inputs");
+            for (var j = 0; j < this.parent.inputs.length; j++) {
+              console.log(
+                "Checking parent molecule input:",
+                this.parent.inputs[j].name
+              );
+              console.log("Against variable:", variable);
+              // If the variable matches a parent input, use its value
+              if (this.parent.inputs[j].name == variable) {
+                value = this.parent.inputs[j].value;
+                break;
+              }
+            }
+          }
+          // If not found, try to find in this atom's inputs
+          if (value === null) {
+            for (var i = 0; i < this.inputs.length; i++) {
+              if (this.inputs[i].name == variable) {
+                value = this.findIOValue(this.inputs[i].name);
+                break;
+              }
+            }
+          }
+          // If still not found, skip substitution (or set to 0)
+          if (value === null) value = 0;
+          console.log("Substituting variable:", variable, "with value:", value);
+          // Use word boundaries in replacement to avoid partial matches
+          const variablePattern = new RegExp(`\\b${variable}\\b`, "g");
+          substitutedEquation = substitutedEquation.replace(
+            variablePattern,
+            value
+          );
+        }
+      }
+
+      // Evaluate the substituted equation
+      return GlobalVariables.limitedEvaluate(substitutedEquation);
+    } catch (error) {
+      console.error("Error evaluating equation:", error);
+      this.setError(error);
+      return NaN;
+    }
+  }
+
+  /**
+   * Extracts variable names from the current equation using mathjs AST parsing.
+   * Only true variables (not function names) are returned.
+   * @returns {string[]} Array of variable names
+   */
+  async extractVariablesFromEquation(equation) {
+    let variables = [];
+    try {
+      const node = parse(equation);
+      node.traverse(function (n, path, parent) {
+        if (
+          n.isSymbolNode &&
+          !(
+            parent &&
+            parent.isFunctionNode &&
+            parent.fn &&
+            parent.fn.name === n.name
+          )
+        ) {
+          variables.push(n.name);
+        }
+      });
+      // Remove duplicates
+      variables = [...new Set(variables)];
+    } catch (e) {
+      variables = [];
+    }
+    return variables;
   }
   /**
    * Find the value of an input for with a given name.

--- a/src/prototypes/atom.js
+++ b/src/prototypes/atom.js
@@ -749,10 +749,18 @@ export default class Atom {
             onChange: async (value) => {
               let currentEquation = String(value).trim();
               input.currentEquation = currentEquation;
-              // Evaluate the equation and wait for the result
-              let result = await this.evaluateEquation(currentEquation);
-              input.setValue(result);
-              //this.sendToRender();
+              try {
+                const result = await this.evaluateEquation(
+                  currentEquation,
+                  input.name
+                );
+                if (Number.isFinite(result)) {
+                  input.setValue(result);
+                }
+              } catch (err) {
+                input.setValue(NaN);
+                this.alertingErrorHandler()(err);
+              }
             },
           };
         }
@@ -765,75 +773,67 @@ export default class Atom {
    * Evaluate the equation
    */
   async evaluateEquation(equation) {
-    try {
-      let substitutedEquation = String(equation ?? "").trim();
-      const variables = await this.extractVariablesFromEquation(
-        substitutedEquation
-      );
-      const unresolved = [];
-      const resolvedValues = {};
-      if (variables.length > 0) {
-        const parentInputs =
-          (this.parent && this.parent.inputs) ||
-          (this.parentMolecule && this.parentMolecule.inputs) ||
-          [];
-        for (const variable of variables) {
-          let value = null;
-          // Try parent inputs first
-          for (let j = 0; j < parentInputs.length; j++) {
-            if (parentInputs[j].name === variable) {
-              value = parentInputs[j].value;
+    let substitutedEquation = String(equation ?? "").trim();
+    const variables = await this.extractVariablesFromEquation(
+      substitutedEquation
+    );
+    const unresolved = [];
+    const resolvedValues = {};
+    if (variables.length > 0) {
+      const parentInputs =
+        (this.parent && this.parent.inputs) ||
+        (this.parentMolecule && this.parentMolecule.inputs) ||
+        [];
+      for (const variable of variables) {
+        let value = null;
+        // Try parent inputs first
+        for (let j = 0; j < parentInputs.length; j++) {
+          if (parentInputs[j].name === variable) {
+            value = parentInputs[j].value;
+            break;
+          }
+        }
+        // Then this atom's inputs
+        if (value === null || value === undefined) {
+          for (let i = 0; i < this.inputs.length; i++) {
+            if (this.inputs[i].name === variable) {
+              value = this.findIOValue(this.inputs[i].name);
               break;
             }
           }
-          // Then this atom's inputs
-          if (value === null || value === undefined) {
-            for (let i = 0; i < this.inputs.length; i++) {
-              if (this.inputs[i].name === variable) {
-                value = this.findIOValue(this.inputs[i].name);
-                break;
-              }
-            }
-          }
-          let num = Number(value);
-          if (
-            value === null ||
-            value === undefined ||
-            (typeof value === "string" && value.trim() === "") ||
-            !Number.isFinite(num)
-          ) {
-            unresolved.push(variable);
-          } else {
-            resolvedValues[variable] = num;
-          }
+        }
+        let num = Number(value);
+        if (
+          value === null ||
+          value === undefined ||
+          (typeof value === "string" && value.trim() === "") ||
+          !Number.isFinite(num)
+        ) {
+          unresolved.push(variable);
+        } else {
+          resolvedValues[variable] = num;
         }
       }
-      if (unresolved.length) {
-        const msg = `Variable(s) not found: ${unresolved.join(
-          ", "
-        )}. Make sure the variables you are using exist as inputs`;
-        console.warn(msg);
-        throw new Error(msg);
-      } else {
-        this.clearAlert();
-        // Substitute all resolved variables
-        for (const variable of Object.keys(resolvedValues)) {
-          const safeVar = variable.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-          const variablePattern = new RegExp(`\\b${safeVar}\\b`, "gu");
-          substitutedEquation = substitutedEquation.replace(
-            variablePattern,
-            String(resolvedValues[variable])
-          );
-        }
-        const result = await GlobalVariables.limitedEvaluate(
-          substitutedEquation
+    }
+    if (unresolved.length) {
+      const msg = `Variable(s) not found: ${unresolved.join(
+        ", "
+      )}. Make sure the variables you are using exist as inputs`;
+      console.warn(msg);
+      throw new Error(msg);
+    } else {
+      this.clearAlert();
+      // Substitute all resolved variables
+      for (const variable of Object.keys(resolvedValues)) {
+        const safeVar = variable.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const variablePattern = new RegExp(`\\b${safeVar}\\b`, "gu");
+        substitutedEquation = substitutedEquation.replace(
+          variablePattern,
+          String(resolvedValues[variable])
         );
-        return result;
       }
-    } catch (error) {
-      console.error("Error evaluating equation:", error);
-      this.setError(error);
-      return NaN;
+      const result = await GlobalVariables.limitedEvaluate(substitutedEquation);
+      return result;
     }
   }
 


### PR DESCRIPTION
@tristan-huber and @BarbourSmith I wanted to get your eye on this feature. It implements an enhancement we discussed: molecule inputs can now be referenced as variables in any atom input. For example, if a molecule has inputs named "thickness1" and "tolerance", you can set an Extrude atom’s height to thickness1 / tolerance, and it will be evaluated as an equation.

Inputs now serialize both the equation and its result, so the original equation is displayed and re-evaluated, not just the computed value.

One downside is that, since all inputs are now treated as strings, you lose the ability to increment/decrement numeric values with the arrow keys—you’ll need to type them out manually.

Most basic atoms should work with this update. Please try it out and let me know your thoughts!
