### PR TITLE
Fix issue where inputs got stuck in "waiting" state

### DIFF
--- a/src/molecules/extracttag.js
+++ b/src/molecules/extracttag.js
@@ -52,7 +52,7 @@ export default class ExtractTag extends Atom {
     this.tagList = { source: undefined, tags: [] };
 
     this.addAllIOs([
-      { name: "input", valueType: "geometry" },
+      { name: "geometry", valueType: "geometry" },
       { name: "output", valueType: "geometry", type: "output" },
     ]);
 

--- a/src/molecules/input.js
+++ b/src/molecules/input.js
@@ -115,10 +115,11 @@ export default class Input extends Atom {
     }
     if (!didPropagateUpstream) {
       if (this.parentAP) {
-        this.setStatus(
-          this.parentAP.getState().status,
-          this.parentAP.getValue()
-        );
+        const apState = this.parentAP.getState();
+        if (apState.value !== null && apState.value !== undefined) {
+          this.setStatus(Status.READY, apState.value);
+          return true;
+        }
       } else {
         this.setWaiting();
       }

--- a/src/molecules/input.js
+++ b/src/molecules/input.js
@@ -114,8 +114,11 @@ export default class Input extends Atom {
       }
     }
     if (!didPropagateUpstream) {
-      if (this.parentAP?.getValue()) {
-        this.setReady(this.parentAP.getValue());
+      if (this.parentAP) {
+        this.setStatus(
+          this.parentAP.getState().status,
+          this.parentAP.getValue()
+        );
       } else {
         this.setWaiting();
       }


### PR DESCRIPTION
If an input's default value was falsey it would get stuck in "waiting". We now refer to the parent AP's status to determine the input status instead of checking the truthiness of it's value