### PR TITLE
Fix: outdated values were shown in ParamMenu

### DIFF
--- a/src/prototypes/atom.js
+++ b/src/prototypes/atom.js
@@ -152,7 +152,11 @@ export default class Atom extends ObservableEntity {
           //Find the matching IO and set it to be the saved value
           if (ioValue.name == ap.name && ap.type == "input") {
             ap.value = ioValue.ioValue;
-            if ("currentEquation" in ioValue) {
+            if (
+              "currentEquation" in ioValue &&
+              !Number.isFinite(Number(ioValue.currentEquation))
+            ) {
+              // only load currentEquation if it exists and isn't a numeric literal
               ap.currentEquation = ioValue.currentEquation;
             }
           }

--- a/src/prototypes/attachmentpoint.js
+++ b/src/prototypes/attachmentpoint.js
@@ -82,6 +82,8 @@ export default class AttachmentPoint extends ObservableEntity {
      */
     this.defaultValue = this.valueType == "number" ? 10 : null;
 
+    this.currentEquation = undefined;
+
     /**
      * This atom's parent, usually the molecule which contains this atom...how is this different from this.parent?
      * @type {object}


### PR DESCRIPTION
@alzatin This fixes part of the issue we were texting about!

The new menu is looking sick! And that change fixed the issue where default values were getting propagated instead of the real value from a const or input (in fact this affected all connected numeric attachmentPoints).

This PR fixes the last part of the issue which is that we could end up in this weird state where the correct value is being used but the outdated "currentEquation" value (in these cases a numeric literal) was being displayed. We now disregard the saved `currentEquation` if it's a numeric literal and just display the value itself.

There is still one related issue which will be a more involved fix. Specifically if an input holds an equation and one of the inputs to that equation is changed it doesn't recompute the equation (at least in some cases). I have some ideas about how to fix this, eg: when the equation is parsed start subscribing to each input or constant that it references. But that'll take a bit more time and I want to get this smaller UI fix in first.