### PR TITLE
Gcode 1 pass fix - temporary dependent on kiri fixes 

### DIFF
--- a/KirimotoUpdate.js
+++ b/KirimotoUpdate.js
@@ -18,7 +18,7 @@ const generateGcode = (
   progressCallback
 ) => {
   const STOCK_MARGIN = 10;
-  const CUT_THROUGH = cutThrough || 2.5; // Default cut-through thickness if not provided
+  const CUT_THROUGH = 0.25; // Default cut-through thickness if not provided
 
   if (!stlUrl) {
     console.error("STL URL is not available.");
@@ -89,11 +89,11 @@ const generateGcode = (
       return eng.setStock({
         x: x + STOCK_MARGIN,
         y: y + STOCK_MARGIN,
-        z: z + CUT_THROUGH, // stock thickness = part thickness + cut-through
+        z: z, // stock thickness = part thickness + cut-through
         center: {
           x: x / 2,
           y: y / 2,
-          z: z + STOCK_MARGIN / 2 + CUT_THROUGH / 2, // correct center for full stock thickness
+          z: z / 2, // correct center for full stock thickness
         },
       });
     })
@@ -109,10 +109,10 @@ const generateGcode = (
           number: 1,
           type: "endmill",
           name: "end 1/4",
-          metric: true,
-          shaft_diam: toolSize,
+          metric: false,
+          shaft_diam: 0.1,
           shaft_len: 1,
-          flute_diam: toolSize,
+          flute_diam: 0.1,
           flute_len: 2,
           taper_tip: 0,
           order: 5,
@@ -127,7 +127,8 @@ const generateGcode = (
       // Add small epsilon to avoid floating point errors causing extra pass
       const epsilon = 0.0001;
       const validPasses = Math.max(1, Math.floor(Number(passes) || 1));
-      const down = Math.abs(zBottom) / validPasses + epsilon; // positive value per pass
+      const down =
+        validPasses == 1 ? 1000 : Math.abs(zBottom) / validPasses + epsilon; // positive value per pass
 
       // Debug logging for pass calculation
       console.log("CAM pass debug:", { passes, z, zBottom, down });
@@ -137,7 +138,9 @@ const generateGcode = (
         camZAnchor: "bottom",
         camDepthFirst: false,
         camZThru: CUT_THROUGH,
-        camZBottom: zBottom, // temp hack to get around setTopZ bug
+        camZClearance: 3,
+        camZTop: 0, // top of stock
+        camZBottom: -z, // temp hack to get around setTopZ bug
         camToolInit: true,
         ops: [
           {
@@ -146,13 +149,33 @@ const generateGcode = (
             spindle: speed,
             step: 0.4,
             steps: 1,
-            down: down, // correct depth per pass
+            down: down, // https://forum.grid.space/t/cam-kirimoto-api-help/2511/22
             rate: 635,
             plunge: 51,
             dogbones: false,
             omitvoid: false,
             omitthru: false,
             outside: false,
+            inside: true,
+            wide: false,
+            top: false,
+            ov_topz: 0,
+            ov_botz: 0,
+            ov_conv: true,
+          },
+          {
+            type: "outline",
+            tool: 1000,
+            spindle: speed,
+            step: 0.4,
+            steps: 1,
+            down: 10000, // https://forum.grid.space/t/cam-kirimoto-api-help/2511/22
+            rate: 635,
+            plunge: 51,
+            dogbones: false,
+            omitvoid: false,
+            omitthru: true,
+            outside: true,
             inside: false,
             wide: false,
             top: false,
@@ -160,26 +183,6 @@ const generateGcode = (
             ov_botz: 0,
             ov_conv: true,
           },
-          /*{
-            type: "outline",
-            tool: 1000,
-            spindle: 13000,
-            step: 0.4,
-            steps: 1,
-            down: down, // correct depth per pass
-            rate: 635,
-            plunge: 51,
-            dogbones: false,
-            omitvoid: false,
-            omitthru: false,
-            outside: false,
-            inside: false,
-            wide: false,
-            top: false,
-            ov_topz: 0,
-            ov_botz: 0,
-            ov_conv: true,
-          },*/
         ],
       });
     })

--- a/KirimotoUpdate.js
+++ b/KirimotoUpdate.js
@@ -14,11 +14,12 @@ const generateGcode = (
   passes,
   speed,
   cutThrough,
+  tool,
   gcodeCallback,
   progressCallback
 ) => {
   const STOCK_MARGIN = 10;
-  const CUT_THROUGH = 0.25; // Default cut-through thickness if not provided
+  const CUT_THROUGH = cutThrough || 0.25; // Default cut-through thickness if not provided
 
   if (!stlUrl) {
     console.error("STL URL is not available.");
@@ -110,9 +111,9 @@ const generateGcode = (
           type: "endmill",
           name: "end 1/4",
           metric: false,
-          shaft_diam: 0.1,
+          shaft_diam: toolSize,
           shaft_len: 1,
-          flute_diam: 0.1,
+          flute_diam: toolSize,
           flute_len: 2,
           taper_tip: 0,
           order: 5,
@@ -123,15 +124,14 @@ const generateGcode = (
       if (progressCallback) progressCallback(0.25); // 25% - Tools set
       const bounds = eng.widget.getBoundingBox();
       const z = bounds.max.z - bounds.min.z;
-      const zBottom = -z - CUT_THROUGH; // cut through part thickness plus cut-through
       // Add small epsilon to avoid floating point errors causing extra pass
       const epsilon = 0.0001;
       const validPasses = Math.max(1, Math.floor(Number(passes) || 1));
       const down =
-        validPasses == 1 ? 1000 : Math.abs(zBottom) / validPasses + epsilon; // positive value per pass
+        validPasses == 1 ? 1000 : Math.abs(z) / validPasses + epsilon; // positive value per pass
 
       // Debug logging for pass calculation
-      console.log("CAM pass debug:", { passes, z, zBottom, down });
+
       return eng.setProcess({
         camEaseAngle: 10,
         camEaseDown: true,
@@ -169,7 +169,7 @@ const generateGcode = (
             spindle: speed,
             step: 0.4,
             steps: 1,
-            down: 10000, // https://forum.grid.space/t/cam-kirimoto-api-help/2511/22
+            down: down, // https://forum.grid.space/t/cam-kirimoto-api-help/2511/22
             rate: 635,
             plunge: 51,
             dogbones: false,

--- a/src/molecules/gcode.js
+++ b/src/molecules/gcode.js
@@ -195,6 +195,7 @@ export default class Gcode extends Atom {
           // Force a redraw to show progress update
           //this.sendToRender();
         };
+        console.log(this.stlURL);
         window.generateGcode(
           this.stlURL,
           this.center,
@@ -223,12 +224,13 @@ export default class Gcode extends Atom {
     try {
       // Check if the input is an assembly
       const isAssembly = await this._checkIfAssembly(inputID);
-
+      console.log("handle geometry input:", inputID);
       if (isAssembly) {
         // Process as assembly - extract parts and generate G-code sequentially
         await this._processAssembly(inputID);
       } else {
         // Process as single part (original behavior)
+
         await this._processSinglePart(inputID);
       }
     } catch (err) {
@@ -252,6 +254,7 @@ export default class Gcode extends Atom {
    * @param {string} inputID - The input geometry ID
    */
   async _processSinglePart(inputID) {
+    console.log("Processing single part:", inputID);
     this._isProcessingAssembly = false;
     const idForVisExport = GlobalVariables.generateUniqueID();
     GlobalVariables.cad
@@ -526,6 +529,14 @@ export default class Gcode extends Atom {
 
   onUpstreamChange() {
     this.setWaiting();
+    try {
+      let inputID = this.findIOValue("geometry");
+
+      // Check if input is an assembly and handle accordingly
+      this._handleGeometryInput(inputID);
+    } catch (err) {
+      this.setError(err);
+    }
   }
 
   createInputParams() {
@@ -629,31 +640,6 @@ export default class Gcode extends Atom {
 
     const blob = new Blob([gcode], { type: "text/plain" });
     saveAs(blob, filename);
-  }
-
-  /**
-   * Begin propagation from this gcode atom.
-   * Like other atoms, trigger updateValue when inputs are not connected.
-   */
-  beginPropagation() {
-    // If there are no inputs (shouldn't happen for gcode, but for consistency)
-    if (this.inputs.length == 0) {
-      this.updateValue();
-      return;
-    }
-
-    // If none of the geometry inputs are connected, don't auto-generate
-    var geometryInputConnected = false;
-    this.inputs.forEach((input) => {
-      if (input.name === "Geometry" && input.connectors.length > 0) {
-        geometryInputConnected = true;
-      }
-    });
-
-    // Only trigger if geometry is connected (main input for gcode generation)
-    if (geometryInputConnected && !this.gcodeGenerated) {
-      this.updateValue();
-    }
   }
 
   /**

--- a/src/molecules/gcode.js
+++ b/src/molecules/gcode.js
@@ -61,6 +61,21 @@ export default class Gcode extends Atom {
     this.progress = 1.0;
     this.parent = values?.parent;
     this.partName = this.parent?.name ?? "output";
+    this.tools = [
+      {
+        id: 1000,
+        number: 1,
+        type: "endmill",
+        name: "end 1/4",
+        metric: false,
+        shaft_diam: 0.25,
+        shaft_len: 1,
+        flute_diam: 0.25,
+        flute_len: 2,
+        taper_tip: 0,
+        order: 5,
+      },
+    ];
 
     this.addAllIOs([
       { name: "geometry", valueType: "geometry" },
@@ -195,7 +210,11 @@ export default class Gcode extends Atom {
           // Force a redraw to show progress update
           //this.sendToRender();
         };
-        console.log(this.stlURL);
+        // Find the selected tool object by name
+        const selectedToolName = this.findIOValue("Tool");
+        const selectedToolObj =
+          this.tools.find((tool) => tool.name === selectedToolName) ||
+          this.tools[0];
         window.generateGcode(
           this.stlURL,
           this.center,
@@ -203,6 +222,7 @@ export default class Gcode extends Atom {
           this.findIOValue("Passes"),
           this.findIOValue("Speed"),
           this.findIOValue("Cut Through"),
+          selectedToolObj,
           gcodeCallback
           //progressCallback
         );
@@ -542,14 +562,22 @@ export default class Gcode extends Atom {
   createInputParams() {
     let inputParams = {};
 
+    /*inputParams[this.uniqueID + "Tool"] = {
+      type: "select",
+      value: this.findIOValue("Tool") || "end 1/4",
+      options: this.tools.map((tool) => tool.name),
+      label: "Tool",
+      onChange: (value) => {
+        this.setIOValue("Tool", value);
+      },
+    };*/
+
     /** Runs through active atom inputs and adds IO parameters to default param*/
     if (this.inputs) {
       this.inputs.map((input) => {
         const checkConnector = () => {
           return input.connectors.length > 0;
         };
-
-        /* Some input parameters (inlcuding equation and result) live in the parameter editor file so they can use the set, get functions */
 
         /* Makes inputs for Io's other than geometry */
         if (input.valueType !== "geometry") {

--- a/src/molecules/gcode.js
+++ b/src/molecules/gcode.js
@@ -85,7 +85,7 @@ export default class Gcode extends Atom {
         defaultValue:
           GlobalVariables.topLevelMolecule?.unitsKey === "MM" ? 6.35 : 0.25,
       },
-      { name: "Passes", valueType: "number", defaultValue: 3 },
+      { name: "Passes", valueType: "number", defaultValue: 1 },
       { name: "Speed", valueType: "number", defaultValue: 1500 },
       {
         name: "Cut Through",


### PR DESCRIPTION
@BarbourSmith  !!!!!!!!  I found a fix to the gcode 1 pass issue, at least a temporary one. What seemed to fix it was buried in a response to one of our first kirimoto forum posts, and is indeed caused by the setZtop issue. 
This is the blog post where BakedPotato outlines a hack to get rid of the extra pass: https://forum.grid.space/t/cam-kirimoto-api-help/2511/21

<img width="807" height="525" alt="Screenshot 2025-08-29 at 6 22 56 PM" src="https://github.com/user-attachments/assets/548d9f99-e36e-4470-be2d-4e419357fd79" />

So for now what I'm doing is hardcoding a really high value to "down" when 1 pass is selected. I also separated the outside and inside passes so the inside runs first. 
This PR also sets gcode to have a tool array from which the user can select from but I have left it disabled for now.