### PR TITLE
GCODE - right # passes 

### DIFF
--- a/KirimotoUpdate.js
+++ b/KirimotoUpdate.js
@@ -124,23 +124,28 @@ const generateGcode = (
       if (progressCallback) progressCallback(0.25); // 25% - Tools set
       const bounds = eng.widget.getBoundingBox();
       const z = bounds.max.z - bounds.min.z;
+      const zBottom = z + CUT_THROUGH; // ensure cut through stock bottom
       // Add small epsilon to avoid floating point errors causing extra pass
       const epsilon = 0.0001;
-      const validPasses = Math.max(1, Math.floor(Number(passes) || 1));
-      const down =
-        validPasses == 1 ? 1000 : Math.abs(z) / validPasses + epsilon; // positive value per pass
+      const validPasses = Math.max(1, Math.floor(Number(passes - 1) || 1));
+
+      const down = validPasses == 1 ? 1000 : Math.abs(zBottom) / validPasses;
 
       // Debug logging for pass calculation
+      console.log("Valid passes:", validPasses);
+      console.log("z:", z);
+      console.log("zBottom:", zBottom);
+      console.log("down:", down);
 
       return eng.setProcess({
         camEaseAngle: 10,
         camEaseDown: true,
         camZAnchor: "bottom",
         camDepthFirst: false,
-        camZThru: CUT_THROUGH,
+        camZThru: 0.01,
         camZClearance: 3,
         camZTop: 0, // top of stock
-        camZBottom: -z, // temp hack to get around setTopZ bug
+        camZBottom: -zBottom, // temp hack to get around setTopZ bug
         camToolInit: true,
         ops: [
           {
@@ -163,7 +168,7 @@ const generateGcode = (
             ov_botz: 0,
             ov_conv: true,
           },
-          {
+          /*{
             type: "outline",
             tool: 1000,
             spindle: speed,
@@ -182,7 +187,7 @@ const generateGcode = (
             ov_topz: 0,
             ov_botz: 0,
             ov_conv: true,
-          },
+          },*/
           /*{
             type: "rough",
             tool: 1000,

--- a/KirimotoUpdate.js
+++ b/KirimotoUpdate.js
@@ -161,7 +161,7 @@ const generateGcode = (
             omitvoid: false,
             omitthru: false,
             outside: false,
-            inside: true,
+            inside: false,
             wide: false,
             top: false,
             ov_topz: 0,
@@ -187,7 +187,7 @@ const generateGcode = (
             ov_topz: 0,
             ov_botz: 0,
             ov_conv: true,
-          },*/
+          },*
           /*{
             type: "rough",
             tool: 1000,

--- a/KirimotoUpdate.js
+++ b/KirimotoUpdate.js
@@ -90,7 +90,7 @@ const generateGcode = (
       return eng.setStock({
         x: x + STOCK_MARGIN,
         y: y + STOCK_MARGIN,
-        z: z, // stock thickness = part thickness + cut-through
+        z: z + CUT_THROUGH, // stock thickness = part thickness + cut-through
         center: {
           x: x / 2,
           y: y / 2,
@@ -127,7 +127,7 @@ const generateGcode = (
       const zBottom = z + CUT_THROUGH; // ensure cut through stock bottom
       // Add small epsilon to avoid floating point errors causing extra pass
       const epsilon = 0.0001;
-      const validPasses = Math.max(1, Math.floor(Number(passes - 1) || 1));
+      const validPasses = Math.max(1, Math.floor(Number(passes) || 1));
 
       const down = validPasses == 1 ? 1000 : Math.abs(zBottom) / validPasses;
 


### PR DESCRIPTION
Fiddling some more with kirimoto settings. 
@BarbourSmith 
- These settings result in the right piece depth and correct number of passes. I added the cut through to the stock depth which seems to allow us to compute the right down value with no extra passes but i don't see the cut through value reflected in the visualizer so not sure what's up with that.
- Although the operation that is uncommented gives the correct number of passes, i haven't been able to separate the operations into interior and exterior because for some reason the "ouside only" setting forces a bunch of extra passes 👎 . So the current operation does both, which i'm guessing is not ideal.
- I think there's currently an issue with multiple parts but i think this is related to the new atom computing changes and where the stl handling gets called for multiple parts and not related to kirimoto, so i'll adress that separately.
