### PR TITLE
Single state for expanded menu

### DIFF
--- a/src/components/main-routes/CreateMode.jsx
+++ b/src/components/main-routes/CreateMode.jsx
@@ -71,15 +71,8 @@ function CreateMode({
   const lastSaveData = useRef({}); // The object saved last time the project was saved...used for comparison
 
   /** State for menu content collapsing */
-  const [contentCollapsed, setContentCollapsed] = useState(true);
-  const [bomContentCollapsed, setBomContentCollapsed] = useState(true);
-  const [paramContentCollapsed, setParamContentCollapsed] = useState(false);
-  /*Collapses param content when other menus are expanded */
-  useEffect(() => {
-    if (!contentCollapsed || !bomContentCollapsed) {
-      setParamContentCollapsed(true);
-    }
-  }, [contentCollapsed, bomContentCollapsed]);
+  // Which menu is expanded: "params", "render", "bom", or "none"
+  const [expandedMenu, setExpandedMenu] = useState("params");
 
   /**
    * Object containing letters and values used for keyboard shortcuts
@@ -674,8 +667,8 @@ function CreateMode({
             activeAtom={activeAtom}
             position={{ top: screenHeight / 2 - 10, left: 55 }}
             id={"atom-create-params-panel"}
-            contentCollapsed={paramContentCollapsed}
-            setContentCollapsed={setParamContentCollapsed}
+            contentCollapsed={expandedMenu !== "params"}
+            setContentCollapsed={() => setExpandedMenu("params")}
           />
           <RenderMenu
             {...{
@@ -691,8 +684,8 @@ function CreateMode({
               backgroundUsdzFile,
               showBackgroundModel,
               setShowBackgroundModel,
-              contentCollapsed,
-              setContentCollapsed,
+              contentCollapsed: expandedMenu !== "render",
+              setContentCollapsed: () => setExpandedMenu("render"),
               position: { top: screenHeight / 2 - 10, left: 10 },
               collapsedOffset: [45, 0],
             }}
@@ -702,8 +695,8 @@ function CreateMode({
             {...{
               activeAtom,
               id: "atom-bom-panel",
-              contentCollapsed: bomContentCollapsed,
-              setContentCollapsed: setBomContentCollapsed,
+              contentCollapsed: expandedMenu !== "bom",
+              setContentCollapsed: () => setExpandedMenu("bom"),
               position: { top: screenHeight / 2 + 35, left: 10 },
               collapsedOffset: [45, -45],
             }}

--- a/src/components/main-routes/RunMode.jsx
+++ b/src/components/main-routes/RunMode.jsx
@@ -78,20 +78,8 @@ function runMode({
   }, [mesh]);
 
   /** State for menu content collapsing */
-  const [renderContentCollapsed, setRenderContentCollapsed] = useState(true);
-  const [bomContentCollapsed, setBomContentCollapsed] = useState(true);
-  const [paramContentCollapsed, setParamContentCollapsed] = useState(false);
-  const [exportContentCollapsed, setExportContentCollapsed] = useState(true);
-  /*Collapses param content when other menus are expanded */
-  useEffect(() => {
-    if (
-      !renderContentCollapsed ||
-      !bomContentCollapsed ||
-      !exportContentCollapsed
-    ) {
-      setParamContentCollapsed(true);
-    }
-  }, [renderContentCollapsed, bomContentCollapsed, exportContentCollapsed]);
+  // Which menu is expanded: "params", "render", "bom", or "none"
+  const [expandedMenu, setExpandedMenu] = useState("params");
 
   useEffect(() => {
     GlobalVariables.canvas = canvasRef;
@@ -159,15 +147,15 @@ function runMode({
         activeAtom={activeAtom}
         position={{ top: 30, left: screenWidth - 320 }}
         id={"atom-run-params-panel"}
-        contentCollapsed={paramContentCollapsed}
-        setContentCollapsed={setParamContentCollapsed}
+        contentCollapsed={expandedMenu !== "params"}
+        setContentCollapsed={() => setExpandedMenu("params")}
       />
       <ExportMenu
         activeAtom={activeAtom}
         position={{ top: 75, left: screenWidth - 365 }}
         id={"atom-run-export-panel"}
-        contentCollapsed={exportContentCollapsed}
-        setContentCollapsed={setExportContentCollapsed}
+        contentCollapsed={expandedMenu !== "export"}
+        setContentCollapsed={() => setExpandedMenu("export")}
       />
       <RenderMenu
         {...{
@@ -180,8 +168,8 @@ function runMode({
           setAxes,
           setWire,
           setSolid,
-          contentCollapsed: renderContentCollapsed,
-          setContentCollapsed: setRenderContentCollapsed,
+          contentCollapsed: expandedMenu !== "render",
+          setContentCollapsed: () => setExpandedMenu("render"),
           position: { top: 30, left: screenWidth - 365 },
         }}
         id={"atom-run-render-panel"}
@@ -190,8 +178,8 @@ function runMode({
         {...{
           activeAtom,
           id: "atom-run-bom-panel",
-          contentCollapsed: bomContentCollapsed,
-          setContentCollapsed: setBomContentCollapsed,
+          contentCollapsed: expandedMenu !== "bom",
+          setContentCollapsed: () => setExpandedMenu("bom"),
           position: { top: 120, left: screenWidth - 365 },
         }}
         collapsedOffset={[45, -90]}

--- a/src/components/secondary/SimpleControlPanel.jsx
+++ b/src/components/secondary/SimpleControlPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useControls } from "../../hooks/useControls";
 import { color } from "@uiw/react-codemirror";
 
@@ -243,6 +243,13 @@ export function SimpleControlPanel({
   contentCollapsed,
   setContentCollapsed,
 }) {
+  // Sync collapsed state with contentCollapsed if initialCollapsed is true
+  useEffect(() => {
+    if (initialCollapsed) {
+      setCollapsed(contentCollapsed);
+    }
+  }, [contentCollapsed, initialCollapsed]);
+
   const [controlValues, setControlValue, { controls: registeredControls }] =
     useControls(controls);
 

--- a/src/components/secondary/SimpleControlPanel.jsx
+++ b/src/components/secondary/SimpleControlPanel.jsx
@@ -361,7 +361,7 @@ export function SimpleControlPanel({
             alignItems: "center",
             justifyContent: "center",
           }}
-          onClick={() => (setCollapsed(false), setContentCollapsed((c) => !c))}
+          onClick={() => (setCollapsed(false), setContentCollapsed())}
           title="Open Panel"
         >
           {React.createElement(collapsedIcon, { size: 18 })}
@@ -387,13 +387,21 @@ export function SimpleControlPanel({
               <button
                 style={arrowButtonStyle}
                 onClick={() => {
-                  initialCollapsed &&
-                  !contentCollapsed /*if panel is initially collapsed set both content and collapse to expanded */
-                    ? (setCollapsed((c) => !c), setContentCollapsed((c) => !c))
-                    : setContentCollapsed((c) => !c);
+                  if (contentCollapsed) {
+                    // Make this the active panel
+                    setContentCollapsed();
+                    if (initialCollapsed) setCollapsed(false);
+                  } else if (initialCollapsed) {
+                    // Allow collapsing to icon only for panels that start collapsed
+                    setCollapsed(true);
+                  }
                 }}
                 title={
-                  contentCollapsed ? "Expand controls" : "Collapse controls"
+                  contentCollapsed
+                    ? "Open controls"
+                    : initialCollapsed
+                    ? "Collapse panel"
+                    : "Active"
                 }
               >
                 <CaretDownIcon size={14} collapsed={contentCollapsed} />

--- a/src/components/secondary/SimpleControlPanel.jsx
+++ b/src/components/secondary/SimpleControlPanel.jsx
@@ -243,6 +243,8 @@ export function SimpleControlPanel({
   contentCollapsed,
   setContentCollapsed,
 }) {
+  // Collapsed panel state
+  const [collapsed, setCollapsed] = useState(initialCollapsed);
   // Sync collapsed state with contentCollapsed if initialCollapsed is true
   useEffect(() => {
     if (initialCollapsed) {
@@ -257,9 +259,6 @@ export function SimpleControlPanel({
   const controlKeys = Object.keys(controls);
   const [focusedIndex, setFocusedIndex] = useState(0);
   const inputRefs = React.useRef([]);
-
-  // Collapsed panel state
-  const [collapsed, setCollapsed] = useState(initialCollapsed);
 
   // Debounce timer for input changes
   const debounceTimeout = React.useRef();


### PR DESCRIPTION
This PR syncs uncollapsed/collapse states for all the new menu dropdowns so only one panel can be open at a time. 