### PR TITLE
Kirimoto op missing speed settings on gcode fix

### DIFF
--- a/KirimotoUpdate.js
+++ b/KirimotoUpdate.js
@@ -145,7 +145,6 @@ const generateGcode = (
         camZBottom: -zBottom, // temp hack to get around setTopZ bug
         camToolInit: true,
         camOutlineSpeed: speed,
-        // Minimal required settings
         camRapidFeed: 3000,
         camPlungeFeed: 300,
         camCutFeed: 1000,

--- a/KirimotoUpdate.js
+++ b/KirimotoUpdate.js
@@ -144,6 +144,15 @@ const generateGcode = (
         camZTop: 0, // top of stock
         camZBottom: -zBottom, // temp hack to get around setTopZ bug
         camToolInit: true,
+        camOutlineSpeed: speed,
+        // Minimal required settings
+        camRapidFeed: 3000,
+        camPlungeFeed: 300,
+        camCutFeed: 1000,
+        camRetractFeed: 300,
+        camSpindleSpeed: speed,
+        camFastFeed: 6000,
+        camFastFeedZ: 300,
         ops: [
           {
             type: "outline",


### PR DESCRIPTION
I had removed these settings trying to minimize the number of variables i was working with. I'm adding these in our default process settings but they can be configured for each unique operation if needed.