### PR TITLE
Fix codewindow keydown focus and code input valuetype bug

### DIFF
--- a/src/components/main-routes/CreateMode.jsx
+++ b/src/components/main-routes/CreateMode.jsx
@@ -143,6 +143,9 @@ function CreateMode({
     if (e.key == "Control" || e.key == "Meta") {
       GlobalVariables.ctrlDown = true;
     }
+    // Prevent forwarding if code atom is active, we don't want to interfere with code editing
+    if (activeAtom.type === "Code") return;
+
     if (e.key == "Shift" && !GlobalVariables.ctrlDown) {
       // Trigger GitSearch Panel when Shift is pressed
       setExpandedMenu(

--- a/src/components/main-routes/CreateMode.jsx
+++ b/src/components/main-routes/CreateMode.jsx
@@ -144,7 +144,8 @@ function CreateMode({
       GlobalVariables.ctrlDown = true;
     }
     // Prevent forwarding if code atom is active, we don't want to interfere with code editing
-    if (activeAtom.type === "Code") return;
+    if (!document.getElementById("code-window").classList.contains("code-off"))
+      return;
 
     if (e.key == "Shift" && !GlobalVariables.ctrlDown) {
       // Trigger GitSearch Panel when Shift is pressed

--- a/src/molecules/code.js
+++ b/src/molecules/code.js
@@ -153,25 +153,8 @@ export default class Code extends Atom {
   }
 
   createInputParams(setInputChanged) {
-    let inputParams = {};
+    let inputParams = super.createInputParams(setInputChanged);
     /** Runs through active atom inputs and adds IO parameters to default param*/
-    this.inputs.map((input) => {
-      const checkConnector = () => {
-        return input.connectors.length > 0;
-      };
-      inputParams[this.uniqueID + input.name] = {
-        type: input.valueType ? input.valueType : "string",
-        value: input.value,
-        label: input.name,
-        disabled: checkConnector(),
-        step: 0.01,
-        onChange: (value) => {
-          if (input.value !== value) {
-            input.setValue(value);
-          }
-        },
-      };
-    });
 
     inputParams["Edit Code"] = {
       type: "button",
@@ -284,10 +267,8 @@ export default class Code extends Atom {
                 "input"
               );
             } else {
-              // Update type and defaultValue if changed
-              if (existingInput.valueType !== type) {
-                existingInput.valueType = type;
-              }
+              existingInput.valueType = type;
+              existingInput.defaultValue = defaultValue;
             }
           });
           // Remove any inputs not in the new array
@@ -325,6 +306,9 @@ export default class Code extends Atom {
                 defaultValue,
                 "input"
               );
+            } else {
+              existingInput.valueType = type;
+              existingInput.defaultValue = defaultValue;
             }
           });
           // Remove any inputs not in the new array

--- a/src/prototypes/atom.js
+++ b/src/prototypes/atom.js
@@ -151,6 +151,7 @@ export default class Atom extends ObservableEntity {
         this.inputs.forEach((ap) => {
           //Find the matching IO and set it to be the saved value
           if (ioValue.name == ap.name && ap.type == "input") {
+            console.log(ap);
             ap.value = ioValue.ioValue;
             if (
               "currentEquation" in ioValue &&
@@ -870,12 +871,14 @@ export default class Atom extends ObservableEntity {
    */
   evaluateEquation(equation) {
     let substitutedEquation = String(equation ?? "").trim();
-    
+
     // Handle empty or whitespace-only equations gracefully
     if (!substitutedEquation) {
-      throw new Error("Empty mathematical expression. Please enter a valid expression.");
+      throw new Error(
+        "Empty mathematical expression. Please enter a valid expression."
+      );
     }
-    
+
     const variables = this.extractVariablesFromEquation(substitutedEquation);
     const unresolved = [];
     const resolvedValues = {};
@@ -939,7 +942,7 @@ export default class Atom extends ObservableEntity {
           String(resolvedValues[variable])
         );
       }
-      
+
       // Safely evaluate the mathematical expression with error handling
       try {
         const result = GlobalVariables.limitedEvaluate(substitutedEquation);


### PR DESCRIPTION
Focus code window issue fix: 

New panels were forwarding keydown to panel even if code window was open which made the codewindow uneditable. This prevents the ref forwarding if window by checking the window styling. Considering that code can and will often have editable inputs and we want it to behave the same as other atoms, i will in the future switch code window opening and closing to be set by state management instead of styling which would let us forward the key to the panel is the code window is not open. 

Code Input issues: 

Input valueType and defaultValue for code inputs were not being respected if the inputs already existed. Switches to using atoms createInputParams function instead of repeating in code atom. 