### PR TITLE
Add alternate fetch to reload forks for large projects

### DIFF
--- a/src/molecules/molecule.js
+++ b/src/molecules/molecule.js
@@ -251,9 +251,7 @@ export default class Molecule extends Atom {
             repo: response.data.name,
             path: "project.abundance",
           })
-          .then((response) => {
-            console.log("Reloading project.abundance from parent repository");
-            console.log(response.data.content);
+          .then(async (response) => {
             // Clear the nodesOnTheScreen array before deserialization to avoid doubling
             GlobalVariables.topLevelMolecule.nodesOnTheScreen.forEach(
               (atom) => {
@@ -261,20 +259,45 @@ export default class Molecule extends Atom {
               }
             );
             GlobalVariables.topLevelMolecule.nodesOnTheScreen = []; // <-- clear the array
-
-            let rawFile = JSON.parse(
-              GlobalVariables.fromBinaryStr(atob(response.data.content))
-            );
-            console.log("Raw file content:", rawFile);
-            if (rawFile.filetypeVersion == 1) {
-              console.log(
-                "Deserializing project.abundance into topLevelMolecule"
+            let rawFileContent;
+            // Handle large files (>1MB) using download_url
+            if (!response.data.content || response.data.content.length === 0) {
+              const fileResponse = await fetch(response.data.download_url);
+              rawFileContent = await fileResponse.text();
+            } else {
+              // Handle small files using base64 content with UTF-8 encoding
+              rawFileContent = GlobalVariables.fromBinaryStr(
+                atob(response.data.content)
               );
-              GlobalVariables.topLevelMolecule.deserialize(rawFile);
+            }
+
+            console.log("Fetched project.abundance content:", rawFileContent);
+            let rawFile;
+            try {
+              rawFile = await this.asyncJsonParse(rawFileContent); // Use the async parser from previous answer
+            } catch (err) {
+              console.error("Failed to parse project.abundance:", err);
+              return;
+            }
+            // Only call deserialize after rawFile is ready
+            if (rawFile.filetypeVersion == 1) {
+              await GlobalVariables.topLevelMolecule.deserialize(rawFile);
             }
             GlobalVariables.currentMolecule.selected = true;
           });
       });
+  }
+
+  asyncJsonParse(str) {
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        try {
+          resolve(JSON.parse(str));
+        } catch (e) {
+          reject(e);
+        }
+      }, 0); // Defer to next tick
+    });
   }
 
   /**


### PR DESCRIPTION
Projects larger than 100mb can't be retrieved using the github getcontent API which is why some projects like "Sauna-Trailer" were failing to reload. This PR adds a fetch alternative to fetch from the download_url instead of using the restAPI which is how we load large projects as well.  