### PR TITLE
Collapse Side menu

### DIFF
--- a/src/components/main-routes/CreateMode.jsx
+++ b/src/components/main-routes/CreateMode.jsx
@@ -940,6 +940,7 @@ function CreateMode({
               importNotification,
               errorNotification,
               setErrorNotification,
+              setExpandedMenu,
             }}
           />
           <div className="parent flex-parent" id="lowerHalf">

--- a/src/components/main-routes/flowCanvas.jsx
+++ b/src/components/main-routes/flowCanvas.jsx
@@ -32,6 +32,7 @@ export default memo(function FlowCanvas({
   importNotification,
   errorNotification,
   setErrorNotification,
+  setExpandedMenu,
 }) {
   /** State for github molecule search input */
   const [searchingGitHub, setSearchingGitHub] = useState(false);
@@ -394,6 +395,7 @@ export default memo(function FlowCanvas({
 
       // Set the active atom after all atoms have been processed
       if (activeAtom) {
+        setExpandedMenu("params");
         setActiveAtom(activeAtom);
       }
 
@@ -419,6 +421,7 @@ export default memo(function FlowCanvas({
       if (!clickHandledByMolecule) {
         /* Background click - molecule is active atom */
         setActiveAtom(GlobalVariables.currentMolecule);
+        setExpandedMenu("params");
         GlobalVariables.currentMolecule.selected = true;
         GlobalVariables.currentMolecule.sendToRender();
       }


### PR DESCRIPTION
- Collapse any side menu and expand param menu if active atom is set or if there's a background click on canvas.

@BarbourSmith My guess on the molecule and tag bug you saw is that the gitsearch menu was open but you were actively trying to edit the params menu to edit the molecule and tag names.