### PR TITLE
Github Actions Concurrency changes

### DIFF
--- a/.github/workflows/Actions.yaml
+++ b/.github/workflows/Actions.yaml
@@ -17,8 +17,8 @@ permissions:
 
 # Allow one concurrent deployment
 concurrency:
-  group: "deploy-to-github-pages"
-  cancel-in-progress: true
+  group: "deploy-to-abundance-github-io {{ github.ref }}"
+  cancel-in-progress: true # Cancel any in-progress deploys if a new one is triggered
 
 jobs:
   # Single deploy job since we're just deploying

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ permissions:
 # Allow one concurrent deployment
 concurrency:
   group: "puppeteer-screenshot-tests"
-  cancel-in-progress: false
+  cancel-in-progress: false # Do not cancel in-progress tests if a new one is triggered
 
 jobs:
   cleanup:


### PR DESCRIPTION
- If a pull request was merged and the puppeteer actions had not finished running, the deploy action was cancelled because the puppeteer action assumed higher priority. This PR separates the two actions into separate concurrency groups so that puppeteer requests will not cancel each other and if a second deploy workflow tries to run while one is running the new workflow takes priority. 