### PR TITLE
Fix evaluate equation bug

### DIFF
--- a/src/molecules/equation.js
+++ b/src/molecules/equation.js
@@ -2,7 +2,6 @@ import Atom from "../prototypes/atom";
 import GlobalVariables from "../js/globalvariables.js";
 import { parse } from "mathjs";
 import { Status } from "../prototypes/observableEntity.js";
-import on from "../js/circular-menu/src/on.js";
 
 /**
  * This class creates the Equation atom.


### PR DESCRIPTION
- Refactored equation evaluation logic in the Equation atom:
- Removed the custom evaluateEquation method from Equation. Now uses the robust evaluateEquation implementation from the base Atom class for all equation evaluation.
- Ensures consistent variable extraction, substitution, and error handling across all atoms.
- Updated the compute method in Equation to call super.evaluateEquation(this.currentEquation).
- Fixed missing result input, due to type mismatch