### PR TITLE
Switch trigger for gitsearch to alt/option keydown

### DIFF
--- a/src/components/main-routes/CreateMode.jsx
+++ b/src/components/main-routes/CreateMode.jsx
@@ -147,8 +147,11 @@ function CreateMode({
     if (!document.getElementById("code-window").classList.contains("code-off"))
       return;
 
-    if (e.key == "Shift" && !GlobalVariables.ctrlDown) {
-      // Trigger GitSearch Panel when Shift is pressed
+    if (
+      (e.key === "Alt" || e.key === "AltGraph") &&
+      !GlobalVariables.ctrlDown
+    ) {
+      // Trigger GitSearch Panel when Option/Alt is pressed
       setExpandedMenu(
         expandedMenuRef.current === "git-search" ? "params" : "git-search"
       );


### PR DESCRIPTION
- Shift keydown trigger was causing conflicts when trying to access special characters. Switching the git search menu toggle to alt/option key to evaluate user flow. 