### PR TITLE
Color code inputs

### DIFF
--- a/src/molecules/input.js
+++ b/src/molecules/input.js
@@ -148,6 +148,25 @@ export default class Input extends Atom {
     }
   }
 
+  /**
+   * Get a color based on the input type for visual differentiation
+   * @returns {string} Color hex code for the input type
+   */
+  getTypeBasedColor() {
+    switch (this.type) {
+      case "number":
+        return "#feed7bff"; // Light yellow - associated with numbers/data
+      case "string":
+        return "#f3a830ff"; // Bright orange - warm color for text
+      case "geometry":
+        return "#e27bfeff"; // Light purple - for complex 3D objects
+      case "array":
+        return "#b6f8b6ff"; // Light green - for collections/lists
+      default:
+        return Atom.DEFAULT_COLOR; // Fallback to default
+    }
+  }
+
   /** Solution to canvas overflow https://stackoverflow.com/questions/10508988/html-canvas-text-overflow-ellipsis*/
   fittingString(c, str, maxWidth) {
     if (!str) {
@@ -199,9 +218,16 @@ export default class Input extends Atom {
       this.updateParentName();
     }
 
-    //Set colors
+    //Set colors - use type-based color when ready and not selected, otherwise use status-based color
     GlobalVariables.c.fillStyle = Atom.DEFAULT_COLOR;
-    this.color = Atom.statusAsColor(this.status, this.selected);
+
+    // Use type-based color when the input is ready and not selected to show type visually
+    if (this.status === Status.READY && !this.selected) {
+      this.color = this.getTypeBasedColor();
+    } else {
+      this.color = Atom.statusAsColor(this.status, this.selected);
+    }
+
     GlobalVariables.c.strokeStyle = this.selected
       ? Atom.DEFAULT_COLOR
       : Atom.SELECTED_COLOR;

--- a/src/prototypes/atom.js
+++ b/src/prototypes/atom.js
@@ -24,7 +24,7 @@ export default class Atom extends ObservableEntity {
     }
     switch (status) {
       case Status.DISABLED:
-        return "#CC00CC"; // light purple
+        return "#b3b2b3ff"; // light-Grey
       case Status.WAITING:
         return "#6bcfd6"; // light-blue
       case Status.PROCESSING:


### PR DESCRIPTION
Added and documented type-based color coding for input atoms which don't conflict with ready colors:
number: light yellow (#feed7bff)
string: bright orange (#f3a830ff)
geometry: light purple (#e27bfeff)
array: light green (#b6f8b6ff)
Default: uses Atom’s default color
Refactored the Input atom to use getTypeBasedColor() for visual differentiation when status is READY.

Changed DISABLED color from magenta to gray.