### PR TITLE
Bug fix: when the user deletes value, param throws nan error

### DIFF
--- a/src/prototypes/atom.js
+++ b/src/prototypes/atom.js
@@ -873,6 +873,7 @@ export default class Atom extends ObservableEntity {
 
     // Handle empty or whitespace-only equations gracefully
     if (!substitutedEquation) {
+      // If the equation is empty, treat it as zero
       substitutedEquation = "0";
     }
 


### PR DESCRIPTION
If evaluateEquation can't find an expression to evaluate replace with 0 instead of throwing an error that breaks the computation. 