### PR TITLE
Upstream optimization

### DIFF
--- a/src/molecules/molecule.js
+++ b/src/molecules/molecule.js
@@ -869,7 +869,12 @@ export default class Molecule extends Atom {
 
       GlobalVariables.currentMolecule = GlobalVariables.currentMolecule.parent; //set parent this to be the currently displayed molecule
       GlobalVariables.currentMolecule.enableAllChildren();
-      super.propagateChange();
+
+      // Force propagation upstream since intermediate changes have been
+      // withheld
+      const value = this.value;
+      this.setWaiting();
+      this.setReady(value);
     }
   }
 


### PR DESCRIPTION
When focused on a sub-molecule, changes aren't propagated downstream to atoms which aren't on screen. When the user navigates up to a higher level molecule a single change is dispatched from the formerly-focused molecule.

There's a related optimization which isn't added in this PR: before the project is finished initial loading, if a user navigates down a level the other atoms which in-progress but now off-screen should be disabled.