### PR TITLE
Fixes issue with gcode generation

### DIFF
--- a/src/molecules/gcode.js
+++ b/src/molecules/gcode.js
@@ -170,11 +170,12 @@ export default class Gcode extends Atom {
    * @returns {Function} The gcode callback function
    */
   _createGcodeCallback() {
-    return (gcode) => {
+    return async (gcode) => {
       this.gcodeString = gcode;
       this.gcodeGenerated = true;
       this.progress = 1.0; // Complete progress
-      this.setReady(GlobalVariables.cad.visualizeGcode(this.uniqueID, gcode));
+      await GlobalVariables.cad.visualizeGcode(this.uniqueID, gcode);
+      this.setReady(this.uniqueID);
     };
   }
 
@@ -449,7 +450,8 @@ export default class Gcode extends Atom {
 
     // Generate visualization for the final G-code and store in library under
     // this.uniqueID
-    return GlobalVariables.cad.visualizeGcode(this.uniqueID, this.gcodeString);
+    await GlobalVariables.cad.visualizeGcode(this.uniqueID, this.gcodeString);
+    return this.uniqueID;
   }
 
   /**

--- a/src/worker/util.ts
+++ b/src/worker/util.ts
@@ -71,7 +71,7 @@ async function getBounds(
       maxY = -Infinity,
       maxZ = -Infinity;
 
-    actOnLeafs(geometry, async (leaf: AbundanceLeaf) => {
+    for await (const leaf of flattenAssembly(geometry)) {
       const replicadbox = (await geometryProvider!.get(leaf.geometry))
         .boundingBox;
       let bbox = replicadbox.bounds;
@@ -86,8 +86,7 @@ async function getBounds(
         minZ = Math.min(minZ, bbox[0][2]);
         maxZ = Math.max(maxZ, bbox[1][2]);
       }
-      return leaf;
-    });
+    }
 
     return {
       min: [minX, minY, minZ],

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -870,24 +870,13 @@ async function extractParts(assemblyID: string): Promise<string[]> {
   await started;
   const assembly = getOrThrow(assemblyID);
 
-  if (!util.isAssembly(assembly)) {
-    // If it's not an assembly, return the original ID
-    return [assemblyID];
-  }
-
   const parts: string[] = [];
   let partIndex = 0;
-
-  // Extract each part from the assembly and store it in the library
-  util.actOnLeafs(assembly, (leaf) => {
-    if (leaf.geometry && leaf.geometry.length > 0) {
-      const partID = `${assemblyID}_part_${partIndex++}`;
-      library[partID] = leaf;
-      parts.push(partID);
-    }
-    return leaf;
-  });
-
+  for await (const leaf of util.flattenAssembly(assembly)) {
+    const partID = `${assemblyID}_part_${partIndex++}`;
+    library[partID] = leaf;
+    parts.push(partID);
+  }
   return parts;
 }
 
@@ -1214,8 +1203,43 @@ if (
 
 // Export functions for testing and ES module environments
 export {
-  assembly, bom, chamfer, circle, code, color, createMesh, deleteFromLibrary, difference, displayLayout, downExport, extractAllTags, extractParts, extractTag, extrude, fillet, generateThumbnail, getBoundingBox, importingSTEP,
+  assembly,
+  bom,
+  chamfer,
+  circle,
+  code,
+  color,
+  createMesh,
+  deleteFromLibrary,
+  difference,
+  displayLayout,
+  downExport,
+  extractAllTags,
+  extractParts,
+  extractTag,
+  extrude,
+  fillet,
+  generateThumbnail,
+  getBoundingBox,
+  importingSTEP,
   importingSTL,
-  importingSVG, intersect, isAssembly, layout, library, loftShapes, molecule, move, output, rectangle, regularPolygon, rotate,
-  scale, shrinkWrapSketches, started, tag, text, visExport, visualizeGcode
+  importingSVG,
+  intersect,
+  isAssembly,
+  layout,
+  library,
+  loftShapes,
+  molecule,
+  move,
+  output,
+  rectangle,
+  regularPolygon,
+  rotate,
+  scale,
+  shrinkWrapSketches,
+  started,
+  tag,
+  text,
+  visExport,
+  visualizeGcode,
 };


### PR DESCRIPTION
A couple small code changes with were causing weird gcode behavior. Both had the same root cause which is that PR #897 made actOnLeafs more async. Which in turn caused some accumulator style code to misbehave in the gcode generation. Eg: actOnLeafs would be trying to accumulate all bounding boxes but would return before all leafs had been visited.