### PR TITLE
Fix unlike redirect and searchfield error

### DIFF
--- a/src/components/secondary/RunNavigation.jsx
+++ b/src/components/secondary/RunNavigation.jsx
@@ -225,7 +225,7 @@ function RunNavigation({
       const apiUpdateUserUrl =
         "https://hg5gsgv9te.execute-api.us-east-2.amazonaws.com/abundance-stage/USER-TABLE";
       let searchField = (
-        GlobalVariables.currentAWSnode.name +
+        GlobalVariables.currentAWSnode.repoName +
         " " +
         GlobalVariables.currentAWSnode.owner
       ).toLowerCase();
@@ -234,7 +234,7 @@ function RunNavigation({
         ranking: GlobalVariables.currentRepo.stargazers_count,
         description: GlobalVariables.currentAWSnode.description,
         searchField: searchField,
-        repoName: GlobalVariables.currentRepo.name,
+        repoName: GlobalVariables.currentAWSnode.repoName,
         forks: 0,
         topMoleculeID: GlobalVariables.topLevelMolecule.uniqueID,
         topics: [],
@@ -242,7 +242,7 @@ function RunNavigation({
           "https://raw.githubusercontent.com/" +
           GlobalVariables.currentUser +
           "/" +
-          GlobalVariables.currentRepo.name +
+          GlobalVariables.currentAWSnode.repoName +
           "/master/README.md?sanitize=true",
         contentURL:
           "https://raw.githubusercontent.com/" +


### PR DESCRIPTION
- Changes where the redirect follow up happens in run mode and adds a dependency to the AWS user table fetch to make sure we have the user information before trying to like or unlike a project therefore preventing multiple likes on the same project.