### PR TITLE
CANVAS icons fix

### DIFF
--- a/src/molecules/BOM.js
+++ b/src/molecules/BOM.js
@@ -89,11 +89,11 @@ export default class AddBOMTag extends Atom {
     GlobalVariables.c.beginPath();
     GlobalVariables.c.fillStyle = "#484848";
     GlobalVariables.c.font = `${pixelsRadius / 1.5}px Work Sans Bold`;
-    GlobalVariables.c.fillText(
-      String.fromCharCode(0x0024, 0x0024, 0x0024),
-      pixelsX - pixelsRadius / 2,
-      pixelsY + this.height / 3
-    );
+    const text = String.fromCharCode(0x0024, 0x0024, 0x0024);
+    const textWidth = GlobalVariables.c.measureText(text).width;
+    const textX = pixelsX - textWidth / 2;
+    const textY = pixelsY + this.height / 3;
+    GlobalVariables.c.fillText(text, textX, textY);
     GlobalVariables.c.fill();
     GlobalVariables.c.closePath();
   }

--- a/src/molecules/constant.js
+++ b/src/molecules/constant.js
@@ -82,12 +82,10 @@ export default class Constant extends Atom {
     GlobalVariables.c.fillStyle = "#484848";
     GlobalVariables.c.font = `${pixelsRadius}px Work Sans Bold`;
     const text = String.fromCharCode(0x039b);
-    const textHeight = pixelsRadius / 1.5;
     const textWidth = GlobalVariables.c.measureText(text).width;
     const textX = pixelsX - textWidth / 2;
-    const textY = pixelsY + this.height / 2 - textHeight / 2;
+    const textY = pixelsY + pixelsRadius / 2;
     GlobalVariables.c.fillText(text, textX, textY);
-
     GlobalVariables.c.fill();
     GlobalVariables.c.closePath();
   }

--- a/src/molecules/difference.js
+++ b/src/molecules/difference.js
@@ -43,12 +43,17 @@ export default class Difference extends Atom {
   draw() {
     super.draw(); //Super call to draw the rest
 
+    // Draw filled circle at the atom's center
+    const centerX = GlobalVariables.widthToPixels(this.x);
+    const centerY = GlobalVariables.heightToPixels(this.y);
+    const circleRadius = GlobalVariables.widthToPixels(this.radius / 3);
+
     GlobalVariables.c.beginPath();
     GlobalVariables.c.fillStyle = "#949294";
     GlobalVariables.c.arc(
-      GlobalVariables.widthToPixels(this.x),
-      GlobalVariables.heightToPixels(this.y),
-      GlobalVariables.widthToPixels(this.radius / 3),
+      centerX,
+      centerY,
+      circleRadius,
       0,
       Math.PI * 2,
       false
@@ -57,15 +62,15 @@ export default class Difference extends Atom {
     GlobalVariables.c.stroke();
     GlobalVariables.c.closePath();
 
+    // Draw rectangle centered on the circle
+    const rectSize = GlobalVariables.widthToPixels(this.radius); // width and height in px
+    const rectX = centerX - rectSize / 2;
+    const rectY = centerY - rectSize / 2;
+
     GlobalVariables.c.beginPath();
     GlobalVariables.c.fillStyle = "#949294";
-    GlobalVariables.c.rect(
-      GlobalVariables.widthToPixels(this.x - this.radius / 2),
-      GlobalVariables.heightToPixels(this.y - this.radius * 2),
-      GlobalVariables.widthToPixels(this.radius),
-      GlobalVariables.widthToPixels(this.radius)
-    );
-    //GlobalVariables.c.fill()
+    GlobalVariables.c.rect(rectX, rectY, rectSize, rectSize);
+    //GlobalVariables.c.fill();
     GlobalVariables.c.stroke();
     GlobalVariables.c.closePath();
   }

--- a/src/molecules/extrude.js
+++ b/src/molecules/extrude.js
@@ -42,29 +42,36 @@ export default class Extrude extends Atom {
   draw() {
     super.draw(); //Super call to draw the rest
 
+    // Draw the bottom rectangle (extrusion indicator), centered horizontally below the atom center
+    const centerX = GlobalVariables.widthToPixels(this.x);
+    const centerY = GlobalVariables.heightToPixels(this.y);
+    const rectWidth = GlobalVariables.widthToPixels(this.radius);
+    const rectHeight = GlobalVariables.widthToPixels(this.radius / 3);
+    const mainRectHeight = GlobalVariables.widthToPixels(this.radius / 2);
+
+    // Bottom rectangle (extrusion indicator)
     GlobalVariables.c.beginPath();
     GlobalVariables.c.fillStyle = "#949294";
-    // Draw the bottom rectangle (extrusion indicator)
     GlobalVariables.c.rect(
-      GlobalVariables.widthToPixels(this.x - this.radius / 2),
-      GlobalVariables.heightToPixels(this.y + this.radius / 4),
-      GlobalVariables.widthToPixels(this.radius),
-      GlobalVariables.widthToPixels(this.radius / 3)
+      centerX - rectWidth / 2,
+      centerY + mainRectHeight / 2,
+      rectWidth,
+      rectHeight
     );
     GlobalVariables.c.fill();
     GlobalVariables.c.stroke();
     GlobalVariables.c.closePath();
 
+    // Main rectangle centered on the atom
     GlobalVariables.c.beginPath();
     GlobalVariables.c.fillStyle = "#949294";
-    // Draw the main rectangle centered within the atom circle
     GlobalVariables.c.rect(
-      GlobalVariables.widthToPixels(this.x - this.radius / 2),
-      GlobalVariables.heightToPixels(this.y - this.radius / 4),
-      GlobalVariables.widthToPixels(this.radius),
-      GlobalVariables.widthToPixels(this.radius / 2)
+      centerX - rectWidth / 2,
+      centerY - mainRectHeight / 2,
+      rectWidth,
+      mainRectHeight
     );
-    //GlobalVariables.c.fill()
+    //GlobalVariables.c.fill();
     GlobalVariables.c.stroke();
     GlobalVariables.c.closePath();
   }

--- a/src/molecules/gcode.js
+++ b/src/molecules/gcode.js
@@ -130,20 +130,18 @@ export default class Gcode extends Atom {
   draw() {
     super.draw(); //Super call to draw the rest
 
-    const xInPixels = GlobalVariables.widthToPixels(this.x);
-    const yInPixels = GlobalVariables.heightToPixels(this.y);
+    const centerX = GlobalVariables.widthToPixels(this.x);
+    const centerY = GlobalVariables.heightToPixels(this.y);
     const radiusInPixels = GlobalVariables.widthToPixels(this.radius);
 
     GlobalVariables.c.beginPath();
     GlobalVariables.c.fillStyle = "#484848";
-    GlobalVariables.c.font = `${GlobalVariables.widthToPixels(
-      this.radius
-    )}px Work Sans Bold`;
-    GlobalVariables.c.fillText(
-      "G",
-      GlobalVariables.widthToPixels(this.x - this.radius / 3),
-      GlobalVariables.heightToPixels(this.y) + this.height / 3
-    );
+    GlobalVariables.c.font = `${radiusInPixels}px Work Sans Bold`;
+    const text = "G";
+    const textWidth = GlobalVariables.c.measureText(text).width;
+    const textX = centerX - textWidth / 2;
+    const textY = centerY + radiusInPixels / 2.8; // visually center the G
+    GlobalVariables.c.fillText(text, textX, textY);
     GlobalVariables.c.fill();
     GlobalVariables.c.closePath();
 
@@ -151,10 +149,10 @@ export default class Gcode extends Atom {
     if (this.progress < 1.0) {
       GlobalVariables.c.beginPath();
       GlobalVariables.c.fillStyle = this.centerColor;
-      GlobalVariables.c.moveTo(xInPixels, yInPixels);
+      GlobalVariables.c.moveTo(centerX, centerY);
       GlobalVariables.c.arc(
-        xInPixels,
-        yInPixels,
+        centerX,
+        centerY,
         radiusInPixels / 1.5,
         0,
         this.progress * Math.PI * 2,

--- a/src/molecules/loft.js
+++ b/src/molecules/loft.js
@@ -63,12 +63,19 @@ export default class Loft extends Atom {
   draw() {
     super.draw(); //Super call to draw the rest
 
+    // Center in pixel space
+    const centerX = GlobalVariables.widthToPixels(this.x);
+    const centerY = GlobalVariables.heightToPixels(this.y);
+    const circleOffset = GlobalVariables.widthToPixels(this.radius / 4);
+    const circleRadius = GlobalVariables.widthToPixels(this.radius / 2.5);
+
+    // Right circle
     GlobalVariables.c.beginPath();
     GlobalVariables.c.fillStyle = "#949294";
     GlobalVariables.c.arc(
-      GlobalVariables.widthToPixels(this.x + this.radius / 4),
-      GlobalVariables.heightToPixels(this.y),
-      GlobalVariables.widthToPixels(this.radius / 2.5),
+      centerX + circleOffset,
+      centerY,
+      circleRadius,
       0,
       Math.PI * 2,
       false
@@ -76,12 +83,13 @@ export default class Loft extends Atom {
     GlobalVariables.c.fill();
     GlobalVariables.c.closePath();
 
+    // Left circle
     GlobalVariables.c.beginPath();
     GlobalVariables.c.fillStyle = "#949294";
     GlobalVariables.c.arc(
-      GlobalVariables.widthToPixels(this.x - this.radius / 4),
-      GlobalVariables.heightToPixels(this.y),
-      GlobalVariables.widthToPixels(this.radius / 2.5),
+      centerX - circleOffset,
+      centerY,
+      circleRadius,
       0,
       Math.PI * 2,
       false
@@ -89,14 +97,14 @@ export default class Loft extends Atom {
     GlobalVariables.c.fill();
     GlobalVariables.c.closePath();
 
+    // Rectangle centered between the two circles
+    const rectSize = GlobalVariables.widthToPixels(this.radius / 2);
+    const rectX = centerX - rectSize / 2;
+    const rectY = centerY - rectSize / 2;
+
     GlobalVariables.c.beginPath();
     GlobalVariables.c.fillStyle = "#949294";
-    GlobalVariables.c.rect(
-      GlobalVariables.widthToPixels(this.x - this.radius / 4),
-      GlobalVariables.heightToPixels(this.y - this.radius),
-      GlobalVariables.widthToPixels(this.radius / 2),
-      GlobalVariables.widthToPixels(this.radius / 2)
-    );
+    GlobalVariables.c.rect(rectX, rectY, rectSize, rectSize);
     GlobalVariables.c.fill();
     GlobalVariables.c.closePath();
   }

--- a/src/molecules/shrinkWrap.js
+++ b/src/molecules/shrinkWrap.js
@@ -53,12 +53,18 @@ export default class shrinkWrap extends Atom {
   draw() {
     super.draw(); //Super call to draw the rest
 
+    // Draw two circles, left and right, centered horizontally on the atom
+    const centerX = GlobalVariables.widthToPixels(this.x);
+    const centerY = GlobalVariables.heightToPixels(this.y);
+    const circleOffset = GlobalVariables.widthToPixels(this.radius / 4);
+    const circleRadius = GlobalVariables.widthToPixels(this.radius / 2.5);
+
     GlobalVariables.c.beginPath();
     GlobalVariables.c.fillStyle = "#949294";
     GlobalVariables.c.arc(
-      GlobalVariables.widthToPixels(this.x + this.radius / 4),
-      GlobalVariables.heightToPixels(this.y),
-      GlobalVariables.widthToPixels(this.radius / 2.5),
+      centerX + circleOffset,
+      centerY,
+      circleRadius,
       0,
       Math.PI * 2,
       false
@@ -69,9 +75,9 @@ export default class shrinkWrap extends Atom {
     GlobalVariables.c.beginPath();
     GlobalVariables.c.fillStyle = "#949294";
     GlobalVariables.c.arc(
-      GlobalVariables.widthToPixels(this.x - this.radius / 4),
-      GlobalVariables.heightToPixels(this.y),
-      GlobalVariables.widthToPixels(this.radius / 2.5),
+      centerX - circleOffset,
+      centerY,
+      circleRadius,
       0,
       Math.PI * 2,
       false
@@ -79,14 +85,14 @@ export default class shrinkWrap extends Atom {
     GlobalVariables.c.fill();
     GlobalVariables.c.closePath();
 
+    // Draw rectangle centered between the two circles
+    const rectSize = GlobalVariables.widthToPixels(this.radius / 2);
+    const rectX = centerX - rectSize / 2;
+    const rectY = centerY - rectSize / 2;
+
     GlobalVariables.c.beginPath();
     GlobalVariables.c.fillStyle = "#949294";
-    GlobalVariables.c.rect(
-      GlobalVariables.widthToPixels(this.x - this.radius / 4),
-      GlobalVariables.heightToPixels(this.y - this.radius),
-      GlobalVariables.widthToPixels(this.radius / 2),
-      GlobalVariables.widthToPixels(this.radius / 2)
-    );
+    GlobalVariables.c.rect(rectX, rectY, rectSize, rectSize);
     GlobalVariables.c.fill();
     GlobalVariables.c.closePath();
   }
@@ -103,9 +109,7 @@ export default class shrinkWrap extends Atom {
       .map((io) => inputs[io.name])
       .filter(Boolean);
 
-    return GlobalVariables.cad.shrinkWrapSketches(
-      nonnullInputIds
-    );
+    return GlobalVariables.cad.shrinkWrapSketches(nonnullInputIds);
   }
 
   /**

--- a/src/molecules/shrinkWrap.js
+++ b/src/molecules/shrinkWrap.js
@@ -53,12 +53,13 @@ export default class shrinkWrap extends Atom {
   draw() {
     super.draw(); //Super call to draw the rest
 
-    // Draw two circles, left and right, centered horizontally on the atom
+    // Center in pixel space
     const centerX = GlobalVariables.widthToPixels(this.x);
     const centerY = GlobalVariables.heightToPixels(this.y);
     const circleOffset = GlobalVariables.widthToPixels(this.radius / 4);
     const circleRadius = GlobalVariables.widthToPixels(this.radius / 2.5);
 
+    // Right circle
     GlobalVariables.c.beginPath();
     GlobalVariables.c.fillStyle = "#949294";
     GlobalVariables.c.arc(
@@ -72,6 +73,7 @@ export default class shrinkWrap extends Atom {
     GlobalVariables.c.fill();
     GlobalVariables.c.closePath();
 
+    // Left circle
     GlobalVariables.c.beginPath();
     GlobalVariables.c.fillStyle = "#949294";
     GlobalVariables.c.arc(
@@ -82,17 +84,6 @@ export default class shrinkWrap extends Atom {
       Math.PI * 2,
       false
     );
-    GlobalVariables.c.fill();
-    GlobalVariables.c.closePath();
-
-    // Draw rectangle centered between the two circles
-    const rectSize = GlobalVariables.widthToPixels(this.radius / 2);
-    const rectX = centerX - rectSize / 2;
-    const rectY = centerY - rectSize / 2;
-
-    GlobalVariables.c.beginPath();
-    GlobalVariables.c.fillStyle = "#949294";
-    GlobalVariables.c.rect(rectX, rectY, rectSize, rectSize);
     GlobalVariables.c.fill();
     GlobalVariables.c.closePath();
   }


### PR DESCRIPTION
Fixes #957

Draw erroneous icons relative to the atom's center in pixel space so that they keep their position and size as the screen resizes.