### PR TITLE
Don't attempt thumbnail generation for projects with > 100 parts.

### DIFF
--- a/src/worker/geometryProvider.ts
+++ b/src/worker/geometryProvider.ts
@@ -1,6 +1,7 @@
 import * as replicad from "replicad";
 import shrinkWrap from "replicad-shrink-wrap";
-import { asReplicadPlane, SimplePlane } from "./util";
+import { asReplicadPlane, SimplePlane, flattenAssembly } from "./util";
+import type { AbundanceObject } from "./util";
 
 type ReplicadObject = replicad.Shape3D | replicad.Drawing | replicad.Wire;
 
@@ -14,7 +15,7 @@ type ReplicadObject = replicad.Shape3D | replicad.Drawing | replicad.Wire;
  * or retrieve the geometry via `get(id)`.
  */
 class GeometryProvider {
-  private cache = new Map<string, ReplicadObject>();
+  private geometryCache = new Map<string, ReplicadObject>();
   private cacheHitMetrics: Record<string, [number, number]>;
   private nextId: number;
 
@@ -48,9 +49,9 @@ class GeometryProvider {
     id: string,
     builder: () => Promise<ReplicadObject>
   ): Promise<string> {
-    if (!this.cache.has(id)) {
+    if (!this.geometryCache.has(id)) {
       let value = await builder();
-      this.cache.set(id, value);
+      this.geometryCache.set(id, value);
       this.cacheMiss(id);
     } else {
       this.cacheHit(id);
@@ -70,7 +71,7 @@ class GeometryProvider {
    * @returns The geometry object itself (ie ReplicadObject)
    */
   async get(id: string): Promise<ReplicadObject> {
-    const value = this.cache.get(id);
+    const value = this.geometryCache.get(id);
     if (value == undefined) {
       console.trace("Cache miss for id:", id);
       throw new Error(`Geometry with ID ${id} not found in cache`);
@@ -293,6 +294,43 @@ class GeometryProvider {
       }
     });
     return resultId;
+  }
+
+  async assemblyFuse(assembly: AbundanceObject): Promise<string> {
+    const partIds = flattenAssembly(assembly).map((part) => part.geometry);
+    if (partIds.length === 1) {
+      return partIds[0];
+    }
+    const id = this._makeId("assemblyFuse", ...partIds.sort());
+    await this.createIfAbsent(id, async () => {
+      const shapes = await Promise.all(
+        partIds.map((partId) => this.get(partId))
+      );
+
+      let result = undefined;
+      for (let i = 0; i < shapes.length; i++) {
+        const shape = shapes[i];
+        if (shape instanceof replicad.Wire) {
+          continue; // fusing a wire is a no-op.
+        }
+        if (!result) {
+          result = shape;
+        } else {
+          if (this.isShape3D(result) && this.isShape3D(shape)) {
+            // Optimized fuse since we know assembly components don't intersect
+            result = result.fuse(shape, { optimisation: "commonFace" });
+          } else {
+            //@ts-ignore
+            result = result.fuse(shape); // both drawings
+          }
+        }
+      }
+      if (!result) {
+        throw new Error("assembly was all wires. Cannot be fused");
+      }
+      return result;
+    });
+    return id;
   }
 
   async cut(toCut: string, cutter: string): Promise<string> {

--- a/src/worker/geometryProvider.ts
+++ b/src/worker/geometryProvider.ts
@@ -15,7 +15,7 @@ type ReplicadObject = replicad.Shape3D | replicad.Drawing | replicad.Wire;
  * or retrieve the geometry via `get(id)`.
  */
 class GeometryProvider {
-  private geometryCache = new Map<string, ReplicadObject>();
+  private cache = new Map<string, ReplicadObject>();
   private cacheHitMetrics: Record<string, [number, number]>;
   private nextId: number;
 
@@ -49,9 +49,9 @@ class GeometryProvider {
     id: string,
     builder: () => Promise<ReplicadObject>
   ): Promise<string> {
-    if (!this.geometryCache.has(id)) {
+    if (!this.cache.has(id)) {
       let value = await builder();
-      this.geometryCache.set(id, value);
+      this.cache.set(id, value);
       this.cacheMiss(id);
     } else {
       this.cacheHit(id);
@@ -71,7 +71,7 @@ class GeometryProvider {
    * @returns The geometry object itself (ie ReplicadObject)
    */
   async get(id: string): Promise<ReplicadObject> {
-    const value = this.geometryCache.get(id);
+    const value = this.cache.get(id);
     if (value == undefined) {
       console.trace("Cache miss for id:", id);
       throw new Error(`Geometry with ID ${id} not found in cache`);

--- a/src/worker/interaction.ts
+++ b/src/worker/interaction.ts
@@ -22,7 +22,7 @@ async function loftShapes(
       if (util.is3D(sketch)) {
         throw new Error("Parts to be lofted must be sketches");
       }
-      let partToLoft = await digFuse(sketch);
+      let partToLoft = await fuseAssembly(sketch);
       let partObj = (await util.geometryProvider!.get(
         partToLoft.geometry
       )) as Drawing;
@@ -91,9 +91,9 @@ async function shrinkWrapSketches(
     throw new Error("No sketches provided for shrink wrap");
   }
 
-  let geometryToWrap = await digFuse(sketches[0]);
+  let geometryToWrap = await fuseAssembly(sketches[0]);
   for (let i = 1; i < sketches.length; i++) {
-    let fusedInput = await digFuse(sketches[i]);
+    let fusedInput = await fuseAssembly(sketches[i]);
     let fusedObj = (await util.geometryProvider!.get(
       fusedInput.geometry
     )) as Drawing;
@@ -131,7 +131,7 @@ async function intersect(
 ): Promise<AbundanceObject> {
   await util.init();
   return util.actOnLeafs(shape1, async (leaf: AbundanceLeaf) => {
-    const shapeToIntersectWith = await digFuse(shape2);
+    const shapeToIntersectWith = await fuseAssembly(shape2);
     return {
       geometry: await util.geometryProvider!.intersect(
         leaf.geometry,
@@ -162,14 +162,14 @@ async function fusion(shapes: AbundanceObject[]): Promise<AbundanceLeaf> {
   if (shapes.length === 0) {
     throw new Error("No shapes provided for fusion");
   }
-  const digFused = await digFuse(shapes[0]);
+  const digFused = await fuseAssembly(shapes[0]);
   let fusedGeometry = digFused.geometry;
   let bomAssembly = shapes[0].bom ? shapes[0].bom.slice() : [];
   for (let i = 1; i < shapes.length; i++) {
     fusedGeometry = await util.geometryProvider!.fuse(
       fusedGeometry,
       (
-        await digFuse(shapes[i])
+        await fuseAssembly(shapes[i])
       ).geometry
     );
     bomAssembly.push(...(shapes[i].bom || []));
@@ -245,24 +245,17 @@ async function assembly(
  * @param {Object} assembly - The assembly or leaf geometry to process
  * @returns {Object} A single fused geometry combining all leaves in the assembly
  */
-async function digFuse(assembly: AbundanceObject): Promise<AbundanceLeaf> {
+async function fuseAssembly(assembly: AbundanceObject): Promise<AbundanceLeaf> {
   await util.init();
-  var flattened = util.flattenAssembly(assembly);
+  const flattened = util.flattenAssembly(assembly);
   if (flattened.length === 0) {
-    throw new Error("No geometries found to fuse");
+    throw new Error("No geometries found in assembly");
   }
-  let result = flattened[0].geometry;
-  for (let i = 1; i < flattened.length; i++) {
-    result = await util.geometryProvider!.fuse(result, flattened[i].geometry);
-  }
-  // TODO(tristan): should this be the union of all tags on all leafs?
+  // TODO: should be union of tags and bom?
   return {
-    geometry: result,
+    ...assembly,
+    geometry: await util.geometryProvider!.assemblyFuse(assembly),
     dimension: flattened[0].dimension,
-    tags: assembly.tags,
-    plane: assembly.plane,
-    color: assembly.color,
-    bom: assembly.bom,
   };
 }
 
@@ -412,7 +405,7 @@ export {
   assembly,
   cutAssembly,
   difference,
-  digFuse,
+  fuseAssembly,
   fusion,
   intersect,
   loftShapes,

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -9,7 +9,7 @@ import { ReplicadObject } from "./geometryProvider";
 import {
   assembly,
   difference,
-  digFuse,
+  fuseAssembly,
   fusion,
   intersect,
   loftShapes,
@@ -83,7 +83,7 @@ function visExport(
         "Geometry To Export has no geometry after keepout is applied"
       );
     }
-    let fusedGeometry = await digFuse(geometryToExport);
+    let fusedGeometry = await fuseAssembly(geometryToExport);
     let displayColor =
       fileType == "STL"
         ? "#91C8D5"
@@ -140,7 +140,7 @@ function downExport(
         "Geometry To Export has no geometry after keepout is applied"
       );
     }
-    let fusedGeometry = await digFuse(geometryToExport);
+    let fusedGeometry = await fuseAssembly(geometryToExport);
     const geom = await util.geometryProvider!.get(fusedGeometry.geometry);
     let scaleUnit = units == "Inches" ? 1 : units == "MM" ? 25.4 : 1;
     let scaling = svgResolution / scaleUnit;
@@ -343,9 +343,24 @@ const prettyProjection = (shape: Shape3D | replicad.Wire) => {
  * @returns {Promise<string>} A promise that resolves to an SVG string representing the thumbnail
  * @throws {Error} Throws an error if the geometry is undefined or thumbnail generation fails
  */
-async function generateThumbnail(input: AbundanceObject): Promise<string> {
+async function generateThumbnail(
+  input: AbundanceObject
+): Promise<string | undefined> {
   return started.then(async () => {
-    const fusedAssembly = await digFuse(input);
+    if (input === undefined || input.geometry === undefined) {
+      return undefined;
+    }
+    if (util.flattenAssembly(input).length > 100) {
+      // Fusing is too expensive for large projects for now.
+      return undefined;
+    }
+    console.log("Fusing assembly of size:", util.flattenAssembly(input).length);
+    const startTime = performance.now();
+
+    const fusedAssembly = await fuseAssembly(input);
+    console.log(
+      `Fusing assembly took ${performance.now() - startTime} milliseconds`
+    );
     const fusedGeometry = await util.geometryProvider!.get(
       fusedAssembly.geometry
     );


### PR DESCRIPTION
This is a stop-gap to avoid crashing. Longer term we should move to a thumbnail strategy which doesn't require fusing.

This PR also introduces an optimized fuse for assemblies, though the performance improvement is only moderate.