### PR TITLE
Updated grid gizmo/Center helper

### DIFF
--- a/src/components/render/ThreeContext.jsx
+++ b/src/components/render/ThreeContext.jsx
@@ -1,10 +1,6 @@
 import React, { Suspense, useRef, useEffect, useState } from "react";
 import { Canvas } from "@react-three/fiber";
-import {
-  Wireframe,
-  Grid,
-  OrthographicCamera,
-} from "@react-three/drei";
+import { Wireframe, Grid, OrthographicCamera } from "@react-three/drei";
 import * as THREE from "three";
 import Controls from "./ThreeControls.jsx";
 import BackgroundModel from "./BackgroundModel.jsx";
@@ -17,12 +13,12 @@ import { useRendering, useAuth } from "../../contexts/index.js";
 THREE.Object3D.DEFAULT_UP.set(0, 0, 1);
 
 export default function ext({ children, cameraZoom, ...otherProps }) {
-  const { 
-    outdatedMesh, 
-    gridParam, 
-    axesParam, 
-    backgroundUsdzFile, 
-    showBackgroundModel 
+  const {
+    outdatedMesh,
+    gridParam,
+    axesParam,
+    backgroundUsdzFile,
+    showBackgroundModel,
   } = useRendering();
   const { authorizedUserOcto } = useAuth();
 
@@ -87,8 +83,9 @@ export default function ext({ children, cameraZoom, ...otherProps }) {
             args={[10000, 10000]}
             cellColor={"#726482"}
             fadeFrom={0}
-            lineColor={"#BFA301"}
-            sectionColor={"#BFA301"}
+            lineColor={"#3b3a39"}
+            sectionColor={"#3b3a39"}
+            sectionThickness={0.5}
             fadeDistance={9000}
             rotation={[Math.PI / 2, 0, 0]}
             sectionSize={cellSection * 10}
@@ -101,16 +98,16 @@ export default function ext({ children, cameraZoom, ...otherProps }) {
         ) : (
           <ambientLight intensity={0.4} />
         )}
-        
+
         {/* Background USDZ model - rendered behind CAD models */}
         {backgroundUsdzFile && showBackgroundModel ? (
-          <BackgroundModel 
+          <BackgroundModel
             fileName={backgroundUsdzFile}
             showModel={showBackgroundModel}
             authorizedUserOcto={authorizedUserOcto}
           />
         ) : null}
-        
+
         {children}
       </Canvas>
     </Suspense>

--- a/src/components/render/ThreeControls.jsx
+++ b/src/components/render/ThreeControls.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { OrbitControls, GizmoHelper, GizmoViewport } from "@react-three/drei";
+import * as THREE from "three";
 
 const Controls = React.memo(
   React.forwardRef(function Controls(
@@ -14,21 +15,24 @@ const Controls = React.memo(
           zoomSpeed={0.5}
           enableDamping={enableDamping}
         />
+
+        {/* Mark the origin with a small sphere */}
+        <mesh position={[0, 0, 0]}>
+          <sphereGeometry args={[0.1, 32, 32]} />
+          <meshBasicMaterial color="gray" />
+        </mesh>
+
         {axesParam && (
-          <GizmoHelper
-            alignment={"bottom-right"}
-            margin={window.innerWidth < 768 ? [50, 50] : [70, 100]}
-            onTarget={() => {
-              return controlsRef?.current?.target;
-            }}
-            onUpdate={() => {
-              controlsRef.current?.update();
-            }}
-          >
-            <mesh scale={window.innerWidth < 768 ? 0.5 : 1}>
-              <GizmoViewport font="18px Inter var, HKGrotesk, sans-serif" />
-            </mesh>
-          </GizmoHelper>
+          <>
+            <GizmoHelper alignment="bottom-right" margin={[80, 100]}>
+              <GizmoViewport
+                axisColors={["#9d4b4b", "#2f7f4f", "#3b5b9d"]}
+                labelColor="white"
+              />
+            </GizmoHelper>
+
+            <primitive object={new THREE.AxesHelper(300)} />
+          </>
         )}
       </>
     );


### PR DESCRIPTION
Fixes #997

- Update to a new version of the drei Gizmo Helper which can snap to different views and has a clearer indicator of X+ or Y+ direction.

<img width="255" height="174" alt="Screenshot 2025-10-06 at 10 13 51 AM" src="https://github.com/user-attachments/assets/98d9bf2d-4e74-4d2e-9364-b2f14695ec27" />
- Adds center marker and axes helper to demarcate the x/y/z plane

<img width="542" height="272" alt="Screenshot 2025-10-06 at 10 15 29 AM" src="https://github.com/user-attachments/assets/b2b42582-cf21-426a-b729-c70cae31f543" />
