### PR TITLE
fix lamda bug

### DIFF
--- a/Lambda AWS Functions/update-AP-rankings/lambda_function.py
+++ b/Lambda AWS Functions/update-AP-rankings/lambda_function.py
@@ -3,14 +3,22 @@ import boto3
 from boto3.dynamodb.conditions import Key
 from decimal import Decimal
 
+
 def compute_molecule_usage_counts(items):
     """Returns a dict mapping repo_id to usage count."""
     usage_counts = {}
     for item in items:
-        molecules = item.get("githubMolecules", [])
-        for repo_id in molecules:
-            usage_counts[repo_id] = usage_counts.get(repo_id, 0) + 1
+        print(item)
+        molecules = item.get("githubMoleculesUsed", [])
+        print(molecules)
+        for molecule in molecules:
+            print(molecule)
+            if molecule:
+                repo_id = f"{molecule['owner']}/{molecule['repoName']}"
+                usage_counts[repo_id] = usage_counts.get(repo_id, 0) + 1
     return usage_counts
+
+
 def tally_likes_from_user_table(dynamodb, user_table_name):
     user_table = dynamodb.Table(user_table_name)
     likes_count = {}
@@ -32,7 +40,7 @@ def tally_likes_from_user_table(dynamodb, user_table_name):
                 repo_name = proj.get("repoName")
             elif isinstance(proj, str) and "/" in proj:
                 owner, repo_name = proj.split("/", 1)
-            
+
             if not owner or not repo_name:
                 missing = []
                 if not owner:
@@ -40,20 +48,24 @@ def tally_likes_from_user_table(dynamodb, user_table_name):
                 if not repo_name:
                     missing.append("repoName")
 
-                print(f"Skipping invalid liked project (missing {', '.join(missing)}): {proj}")
+                print(
+                    f"Skipping invalid liked project (missing {', '.join(missing)}): {proj}")
                 continue
             key = (owner, repo_name)
             likes_count[key] = likes_count.get(key, 0) + 1
     # After likes_count is built
-    top_liked = sorted(likes_count.items(), key=lambda x: x[1], reverse=True)[:3]
+    top_liked = sorted(likes_count.items(),
+                       key=lambda x: x[1], reverse=True)[:3]
     print("Top 3 liked projects:")
     for (owner, repo_name), count in top_liked:
         print(f"{owner}/{repo_name}: {count} likes")
     return likes_count
 
+
 def get_molecule_usage_for_project(owner, repo_name, usage_counts):
     repo_id = f"{owner}/{repo_name}"
     return usage_counts.get(repo_id, 0)
+
 
 def calculate_ranking(item, molecule_usage):
     # Ensure all values are Decimal for DynamoDB compatibility
@@ -61,8 +73,10 @@ def calculate_ranking(item, molecule_usage):
     forks = Decimal(str(item.get("forks", 0)))
     molecule_usage = Decimal(str(molecule_usage))
     # Use Decimal for all constants and new formula
-    ranking = Decimal('4') * likes + Decimal('3') * molecule_usage + Decimal('0.2') * forks
+    ranking = Decimal('2') * likes + Decimal('0.3') * \
+        molecule_usage + Decimal('0.2') * forks
     return ranking
+
 
 def lambda_handler(event, context):
     dynamodb = boto3.resource("dynamodb")
@@ -92,7 +106,8 @@ def lambda_handler(event, context):
         if owner == "alzatin" and repo_name == "My-First-Project":
             print(f"Skipping project {owner}/{repo_name} as requested.")
             continue
-        molecule_usage = get_molecule_usage_for_project(owner, repo_name, molecule_usage_counts)
+        molecule_usage = get_molecule_usage_for_project(
+            owner, repo_name, molecule_usage_counts)
         # Use the tally from the user table
         likes = likes_count.get((owner, repo_name), 0)
         forks = item.get("forks", 0)
@@ -100,8 +115,6 @@ def lambda_handler(event, context):
         molecule_usage = float(molecule_usage)
         item_for_ranking = {"likes": likes, "forks": forks}
         ranking = calculate_ranking(item_for_ranking, molecule_usage)
-
-        
 
         if ranking > 0:
             print(f"Would update ranking for {owner}/{repo_name} to {ranking}")
@@ -112,7 +125,7 @@ def lambda_handler(event, context):
                 ExpressionAttributeValues={":r": ranking, ":l": likes},
             )
         updated += 1
-        
+
     print(f"Updated ranking for {updated} projects.")
     return {
         "statusCode": 200,

--- a/src/components/main-routes/CreateMode.jsx
+++ b/src/components/main-routes/CreateMode.jsx
@@ -403,6 +403,7 @@ function CreateMode() {
           molecule.nodesOnTheScreen.forEach((node) => {
             if (node.atomType === "GitHubMolecule") {
               // Add to the githubMoleculeUsedList if atomType is "Github molecule"
+              if (node.parentRepo == null) return; // Safety check if parentRepo is null
               githubMoleculeUsedList.push({
                 owner: node.parentRepo.owner,
                 repoName: node.parentRepo.repoName,


### PR DESCRIPTION
Fix lambda bug which improperly retrieved github molecule list in the ranking function due to a misuse of a dict and adds a failsafe for github molecules which don't have parentRepo info stored. Also updates ranking points to lower value of gitmolecule usage and avoid all ranking molecules being abundance tools.