### PR TITLE
console alert when zoom is not working

### DIFF
--- a/src/components/main-routes/RunMode.jsx
+++ b/src/components/main-routes/RunMode.jsx
@@ -113,9 +113,16 @@ function runMode() {
       console.log("Puppeteer element created for run mode");
     }
   };
+  useEffect(() => {
+    /*Reset the camera zoom to 1 when a new molecule is loaded*/
+    setCameraZoom(1);
+  }, [GlobalVariables.currentAWSnode]);
 
   useEffect(() => {
-    setCameraZoom(mesh[0] ? mesh[0].cameraZoom : 1);
+    if (cameraZoom == 1 && mesh[0]) {
+      console.log("Setting camera zoom", mesh[0].cameraZoom);
+      setCameraZoom(mesh[0].cameraZoom);
+    }
   }, [mesh]);
 
   // Create Puppeteer element when render is complete

--- a/src/components/main-routes/lowerHalf.jsx
+++ b/src/components/main-routes/lowerHalf.jsx
@@ -14,12 +14,12 @@ export default memo(function LowerHalf({ windowSize }) {
   useEffect(() => {
     /*Reset the camera zoom to 1 when a new molecule is loaded*/
     setCameraZoom(1);
-  }, [globalvariables.topLevelMolecule]);
+  }, [globalvariables.currentAWSnode]);
 
   useEffect(() => {
     if (cameraZoom == 1 && mesh[0]) {
+      console.log("mesh[0].cameraZoom", mesh[0].cameraZoom);
       setCameraZoom(mesh[0].cameraZoom);
-      console.log("cameraZoom", cameraZoom);
     }
   }, [mesh]);
 

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -489,48 +489,64 @@ function getLargestBoundingBox(meshArray: ReplicadObject[]): {
   let overallMin: [number, number, number] = [Infinity, Infinity, Infinity];
   let overallMax: [number, number, number] = [-Infinity, -Infinity, -Infinity];
 
-  if (!Array.isArray(meshArray)) {
-    throw new Error("meshArray is not defined or not an array");
+  try {
+    if (!Array.isArray(meshArray)) {
+      throw new Error("meshArray is not defined or not an array");
+    }
+    meshArray.forEach((mesh, idx) => {
+      //console.log(mesh.boundingBox.bounds);
+      if (!mesh.boundingBox || !Array.isArray(mesh.boundingBox.bounds)) {
+        console.error(
+          `mesh[${idx}] missing boundingBox or bounds:`,
+          mesh.boundingBox
+        );
+        throw new Error("Invalid mesh geometry or boundingBox structure");
+      }
+
+      if (mesh.boundingBox.bounds instanceof Error) {
+        throw new Error("Bounding box calculation error");
+        // handle or skip this mesh
+      }
+      const boundingBox = mesh.boundingBox.bounds;
+      if (
+        boundingBox.length < 2 ||
+        !Array.isArray(boundingBox[0]) ||
+        !Array.isArray(boundingBox[1])
+      ) {
+        console.error(
+          `mesh[${idx}] boundingBox bounds not properly defined:`,
+          boundingBox
+        );
+        throw new Error("boundingBox bounds are not properly defined");
+      }
+
+      let min = boundingBox[0];
+      let max = boundingBox[1];
+
+      // Update overall minimum coordinates
+      overallMin[0] = Math.min(overallMin[0], min[0]);
+      overallMin[1] = Math.min(overallMin[1], min[1]);
+      if (min[2] != undefined) {
+        overallMin[2] = Math.min(overallMin[2], min[2]);
+      }
+      // Update overall maximum coordinates
+      overallMax[0] = Math.max(overallMax[0], max[0]);
+      overallMax[1] = Math.max(overallMax[1], max[1]);
+      if (max[2] != undefined) {
+        overallMax[2] = Math.max(overallMax[2], max[2]);
+      }
+    });
+
+    return {
+      width: overallMax[0] - overallMin[0],
+      height: overallMax[1] - overallMin[1],
+      depth: overallMax[2] - overallMin[2],
+    };
+  } catch (error) {
+    console.error("Error in getLargestBoundingBox:", error);
+    // Return a default bounding box if error occurs
+    //return { width: 0, height: 0, depth: 0 };
   }
-
-  meshArray.forEach((mesh) => {
-    if (!mesh.boundingBox || !Array.isArray(mesh.boundingBox.bounds)) {
-      throw new Error("Invalid mesh geometry or boundingBox structure");
-    }
-
-    let boundingBox = mesh.boundingBox.bounds;
-    if (
-      boundingBox.length < 2 ||
-      !Array.isArray(boundingBox[0]) ||
-      !Array.isArray(boundingBox[1])
-    ) {
-      throw new Error("boundingBox bounds are not properly defined");
-    }
-
-    let min = boundingBox[0];
-    let max = boundingBox[1];
-
-    // Update overall minimum coordinates
-    overallMin[0] = Math.min(overallMin[0], min[0]);
-    overallMin[1] = Math.min(overallMin[1], min[1]);
-    if (min[2] != undefined) {
-      overallMin[2] = Math.min(overallMin[2], min[2]);
-    }
-
-    // Update overall maximum coordinates
-    overallMax[0] = Math.max(overallMax[0], max[0]);
-    overallMax[1] = Math.max(overallMax[1], max[1]);
-    if (max[2] != undefined) {
-      overallMax[2] = Math.max(overallMax[2], max[2]);
-    }
-  });
-
-  // Calculate the width, height, and depth
-  let width = overallMax[0] - overallMin[0];
-  let height = overallMax[1] - overallMin[1];
-  let depth = overallMax[2] - overallMin[2];
-
-  return { width, height, depth };
 }
 
 function calculateZoom(boundingBox: {
@@ -573,7 +589,7 @@ function generateCameraPosition(meshArray: ReplicadObject[]): number {
   // Get the largest bounding box from the mesh array
   let largestBoundingBox = getLargestBoundingBox(meshArray);
   let zoom = calculateZoom(largestBoundingBox);
-
+  console.log("Generated camera zoom:", zoom);
   return zoom;
 }
 
@@ -626,6 +642,7 @@ async function generateDisplayMesh(
   try {
     cameraZoom = generateCameraPosition(meshArray.map((m) => m.geometry));
   } catch (e) {
+    console.error("Error generating camera position:", e);
     cameraZoom = 1;
   }
 


### PR DESCRIPTION
Update runMode to set Zoom like createmode does. Do not rely on a changing toplevel molecule, only regenerate the zoom when the node changes. Some projects are causing an error in the zoom generation as a result of the boundingbox receiving erroneous bounds, I'll have to dig more on this to figure out why some meshes are being processed in the worker without proper bounds.