### PR TITLE
Fix cutlayout missing ID

### DIFF
--- a/src/worker/cutlayout.ts
+++ b/src/worker/cutlayout.ts
@@ -365,7 +365,8 @@ async function rotateForLayout(
       ...leaf,
       geometry: await util.geometryProvider!.addSingularToCache(
         newGeom,
-        context
+        context,
+        leafID.toString()
       ),
       id: leafID,
       referencePoint: selected.face.center,


### PR DESCRIPTION
Missing id in rotateForLayout which was causing errors in cutLayout atom. Added an ID parameter to addSingularToCache call in rotateForLayout.