### PR TITLE
Fix puppeteer - still one PR delay

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,7 @@
 name: Puppeteer Tests
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [opened, synchronize, closed]
 


### PR DESCRIPTION
This returns puppeteer to working as it had before. I had changed it because I realized that the tests are running on the base branch instead of the PR branch which makes them inaccurate and if there's an error you would not catch it until the following PR. I'm restoring them as they are because it seems still useful to track the tests this way until i figure out how to get them to run on the PR branch, which seems to cause the screenshot comment to fail despite the tests running. 

@BarbourSmith fyi 