### PR TITLE
Fix crash when intersect found any subcomponent with no overlap.

### DIFF
--- a/src/worker/geometryProvider.ts
+++ b/src/worker/geometryProvider.ts
@@ -99,8 +99,8 @@ class GeometryProvider {
   private async createIfAbsent(
     id: string,
     context: RequestContext,
-    builder: () => Promise<ReplicadObject>
-  ): Promise<string> {
+    builder: () => Promise<ReplicadObject | undefined>
+  ): Promise<string | undefined> {
     this.updateLRU(context.project);
     if (
       this.getFromWarmCache(id, context) ||
@@ -110,6 +110,11 @@ class GeometryProvider {
     } else {
       const start = performance.now();
       const geometry = await builder();
+      if (geometry === undefined) {
+        // builder produced nonexistent geometry (eg: intersect of nonoverlapping shapes)
+        console.log("Geometry builder returned undefined for id:", id);
+        return undefined;
+      }
       if (context.operationId) {
         this.putInWarmCache(id, context.operationId, geometry);
         if (context.persistIntermediates) {
@@ -420,9 +425,9 @@ class GeometryProvider {
     input1ID: string,
     inputID2: string,
     context: RequestContext
-  ): Promise<string> {
+  ): Promise<string | undefined> {
     const id = this._makeId("intersect", input1ID, inputID2);
-    await this.createIfAbsent(id, context, async () => {
+    return await this.createIfAbsent(id, context, async () => {
       const args = [
         await this.get(input1ID, context),
         await this.get(inputID2, context),
@@ -430,7 +435,12 @@ class GeometryProvider {
       // Intersect only allowed between matching types. 2 drawings or 2 3d shapes.
 
       if (this.areAllDrawings(args)) {
-        return args[0].intersect(args[1]);
+        const result = args[0].intersect(args[1]);
+        //@ts-ignore - no other way to check if the generated shape is nonexistent
+        if (!result.innerShape) {
+          return undefined;
+        }
+        return result;
       } else if (this.areAll3DShapes(args)) {
         return this.as3dShapeOrThrow(args[0].intersect(args[1]));
       } else {
@@ -442,7 +452,6 @@ class GeometryProvider {
         );
       }
     });
-    return id;
   }
 
   // Fuse 1 or more geometries together.

--- a/src/worker/interaction.ts
+++ b/src/worker/interaction.ts
@@ -134,12 +134,16 @@ async function intersect(
   await util.init();
   return util.actOnLeafs(shape1, async (leaf: AbundanceLeaf) => {
     const shapeToIntersectWith = await fuseAssembly(shape2, context);
+    const resultGeom = await util.geometryProvider!.intersect(
+      leaf.geometry,
+      shapeToIntersectWith.geometry,
+      context
+    );
+    if (resultGeom === undefined) {
+      return undefined;
+    }
     return {
-      geometry: await util.geometryProvider!.intersect(
-        leaf.geometry,
-        shapeToIntersectWith.geometry,
-        context
-      ),
+      geometry: resultGeom,
       tags: leaf.tags,
       color: leaf.color,
       plane: leaf.plane,

--- a/src/worker/util.ts
+++ b/src/worker/util.ts
@@ -131,7 +131,9 @@ function actOnLeafsSync(
 
 async function actOnLeafs(
   assembly: AbundanceObject,
-  action: (leaf: AbundanceLeaf) => AbundanceLeaf | Promise<AbundanceLeaf>,
+  action: (
+    leaf: AbundanceLeaf
+  ) => AbundanceLeaf | Promise<AbundanceLeaf | undefined>,
   plane?: SimplePlane
 ): Promise<AbundanceObject> {
   if (!isAbundanceObject(assembly)) {
@@ -140,13 +142,23 @@ async function actOnLeafs(
   plane = plane || assembly.plane;
 
   if (isLeaf(assembly)) {
-    return await action(assembly);
+    const result = await action(assembly);
+    if (result != undefined) {
+      return result;
+    } else {
+      // Empty geometry represented as branch with no leafs
+      return {
+        ...assembly,
+        plane: plane,
+        geometry: [],
+      };
+    }
   } else {
     let children = assembly.geometry as AbundanceObject[];
     let transformedAssembly: any[] = [];
     for (const subAssembly of children) {
       const result = await actOnLeafs(subAssembly, action);
-      if (result != undefined) {
+      if (result != undefined && result.geometry?.length > 0) {
         transformedAssembly.push(result);
       }
     }

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -606,7 +606,7 @@ async function generateDisplayMesh(
   await started;
   console.log("Generating display mesh for ID:", JSON.stringify(id));
   let geom = undefined;
-  if (util.isAbundanceObject(id)) {
+  if (util.isAbundanceObject(id) && id.geometry.length !== 0) {
     geom = id;
   } else {
     return generateDefaultMesh(context);


### PR DESCRIPTION
This also introduces a representation for an empty AbundanceObject ie: an AbundanceBranch with empty list of leafs.