### PR TITLE
Update vitest.browser.config.ts

### DIFF
--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -1,17 +1,16 @@
-import { defineConfig } from 'vitest/config'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
   test: {
+    exclude: ["tests/patchDependencies.mjs", "tests/setupVitestMocks.mjs"],
     browser: {
       enabled: true,
       //headless: true,
-      provider: 'playwright',
+      provider: "playwright",
       // https://vitest.dev/guide/browser/playwright
-      instances: [
-        { browser: 'chromium' }
-      ],
+      instances: [{ browser: "chromium" }],
     },
   },
-})
+});


### PR DESCRIPTION
In our deployed abundance version (which is currently broken) we are getting a node module error: 

Loading module from “https://esm.sh/node/chunk-VJACTU3S.mjs” was blocked because of a disallowed MIME type (“text/plain”)

There seem to be two test files which import modules:
[patchDependencies.mjs](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): imports fs and [path](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[setupVitestMocks.mjs](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): imports [path](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and url

I'm excluding them from our browser test runs config to see if that resolves our deployment issue.