### PR TITLE
Gcode fix move bug spikes and double outline 

### DIFF
--- a/KirimotoUpdate.js
+++ b/KirimotoUpdate.js
@@ -84,9 +84,14 @@ const generateGcode = (
       return eng.setMode("CAM");
     })
     .then((eng) => {
+      if (progressCallback) progressCallback(0.15); // 15% - Mode set
       const bounds = eng.widget.getBoundingBox();
       const z = bounds.max.z - bounds.min.z;
-      return eng.setOrigin(0, 0, 0);
+      if (GlobalVariables.topLevelMolecule?.unitsKey === "Inches") {
+        eng.widget.scale(25.4, 25.4, 25.4); // Scale from mm to inches (1 inch = 25.4 mm)
+        return eng.setOrigin(centerPos[0] * 25.4, centerPos[1] * 25.4, 0); // move part so top is at Z=0
+      }
+      return eng.setOrigin(centerPos[0], centerPos[1], 0); // move part so top is at Z=0
     })
     .then((eng) =>
       eng.setStock({
@@ -95,16 +100,6 @@ const generateGcode = (
         z: 0.1,
       })
     )
-    .then((eng) => {
-      if (progressCallback) progressCallback(0.2); // 20% - Stock set
-      if (GlobalVariables.topLevelMolecule?.unitsKey === "Inches") {
-        eng.widget.scale(25.4, 25.4, 25.4); // Scale from mm to inches (1 inch = 25.4 mm)
-        eng.moveTo(centerPos[0] * 25.4, centerPos[1] * 25.4, 0); // move part so top is at Z=0
-        return eng;
-      }
-      eng.moveTo(centerPos[0], centerPos[1], 0); // move part so top is at Z=0
-      return eng;
-    })
     .then((eng) => {
       // Determine if project uses metric units
       const projectUnits = GlobalVariables.topLevelMolecule?.unitsKey || "MM";


### PR DESCRIPTION
- Fixes bugs for gcode processes: 
- Replaces moveTo with setOrigin for every part 
- Turns off interior outline and relies on rough process to take care of drilling and thru holes.