### PR TITLE
Small fix for thumbnail generation

### DIFF
--- a/src/components/main-routes/CreateMode.jsx
+++ b/src/components/main-routes/CreateMode.jsx
@@ -788,13 +788,14 @@ function CreateMode() {
       );
       return null;
     }
-    return await GlobalVariables.cad
-      .generateDisplayMesh(
+
+    return GlobalVariables.pool.proxy().then((worker) => {
+      return worker.generateDisplayMesh(
         GlobalVariables.topLevelMolecule.value,
         GlobalVariables.topLevelMolecule.getContext()
-      )
+      )})
       .then(async (m) => {
-        const svg = await meshRef.current.buildThumbnail(m);
+        const svg = await meshRef.current.buildThumbnail(m.mesh);
         console.log("Project thumbnail generated.");
         return svg;
       });


### PR DESCRIPTION
turns out I broke this last week with the dedicated mesh generation thread PR. The signature for generateDisplayMesh has changed, so this PR updates the call inside of generate thumbnail accordingly. Further optimization might be possible by re-using the saved output atom mesh (if any).