### PR TITLE
zthru fix - cut through pass for 1 pass

### DIFF
--- a/KirimotoUpdate.js
+++ b/KirimotoUpdate.js
@@ -127,7 +127,7 @@ const generateGcode = (
       /*End Hack for kiri 4.3.0, add cut through in down value and set camzThru to 0 to avoid extra pass, set camZBottom to real value (not 1000)*/
       const down = (zBottom + CUT_THROUGH) / passes;
       const camZBottom = -zBottom - CUT_THROUGH;
-      const camZThru = passes > 1 ? -1 : CUT_THROUGH - 1;
+      const camZThru = passes > 1 ? 0 : CUT_THROUGH - 1;
       const roughingStepOver = 0.6;
 
       /*


### PR DESCRIPTION
Hacky fix for cutthrough pass fix. To get Gcode to work we have set the `camZTop: -1` since 0 does not seem to work. In this PR we compensate for that change in the cutThru `const camZThru = passes > 1 ? -1 : CUT_THROUGH - 1;` which seems to create the correct results for single passes and multiple passes.

@BarbourSmith Maybe give this a go.