### PR TITLE
Fix overlap

### DIFF
--- a/src/molecules/input.js
+++ b/src/molecules/input.js
@@ -122,7 +122,7 @@ export default class Input extends Atom {
     const totalInputs = existingInputs.length + 1;
 
     // Default spacing and starting position
-    const defaultSpacing = GlobalVariables.atomSize * 5;
+    const defaultSpacing = GlobalVariables.atomSize * 6;
     const defaultStartY = GlobalVariables.atomSize * 10;
 
     // Calculate available canvas height (in fractional units, where 1.0 = full height)


### PR DESCRIPTION
Input overlap was creating some dragging connector issues in which multiple connectors were being dragged together. I changed the spacing to mitigate this.