### PR TITLE
1 Pass cutthrough bypass - (GCODE, KIRI, cutthru, zthru)

### DIFF
--- a/KirimotoUpdate.js
+++ b/KirimotoUpdate.js
@@ -15,8 +15,7 @@ const generateGcode = (
   partProgressCallback,
   tool
 ) => {
-  const STOCK_MARGIN = 10;
-  const CUT_THROUGH = cutThrough || 0; // Default cut-through thickness if not provided
+  const CUT_THROUGH = cutThrough;
 
   if (!stlUrl) {
     console.error("STL URL is not available.");
@@ -120,14 +119,12 @@ const generateGcode = (
       const z = bounds.max.z - bounds.min.z;
       const zBottom = z; // ensure cut through stock bottom
 
-      /*Hack for kiri 4.3.0*/
-      //const validPasses = passes;
-      //const down = validPasses == 1 ? 1000 : zBottom / (validPasses - 1);
-
-      /*End Hack for kiri 4.3.0, add cut through in down value and set camzThru to 0 to avoid extra pass, set camZBottom to real value (not 1000)*/
+      // camCutthrough by pass for 1 pass, sets down to large value to avoid cutthrough extra pass/ extra pass is added for multi pass
       const down = passes > 1 ? (zBottom + CUT_THROUGH) / passes : 10000;
+      // -1 to account for topZ -1 hack
       const camZBottom = -zBottom - CUT_THROUGH - 1;
-      const camZThru = CUT_THROUGH;
+      // single pass needs a cutthrough to generate correctly
+      const camZThru = passes <= 1 && !cutThrough ? 0.01 : CUT_THROUGH;
       const roughingStepOver = 0.6;
 
       console.log("Down per pass:", down);
@@ -141,7 +138,7 @@ const generateGcode = (
         camOriginCenter: false,
         camRoughAll: false,
         camZOffset: 0,
-        camZTop: -1, //top of stock
+        camZTop: -1, //top of stock hack has to be set to negative
         camRoughDown: 2,
         camRoughFlat: true,
         camRoughIn: true,
@@ -165,6 +162,7 @@ const generateGcode = (
         camSpindleSpeed: speed,
         camFastFeed: 6000,
         camFastFeedZ: speed, // Match Z feed to speed to maintain feedrate during ramp down
+        cutThruBypass: true,
         ops: [
           {
             type: "rough",


### PR DESCRIPTION
-Running kiri 4.4-
Gridspace implemented a fix for being able to make a single pass with cutthrough to an outline operation if the down pass value is larger than the value of the piece. This allows us to add  cutthrough value to a single pass gcode without adding any extra passes. This however does not allow us to avoid the extra pass for multipass operations which if the cutthrough is larger than 0 will have a pass added automatically to them. 

`// camCutthrough by pass for 1 pass, sets down to large value to avoid cutthrough extra pass/ extra pass is added for multi pass
      const down = passes > 1 ? (zBottom + CUT_THROUGH) / passes : 10000;`

Even though the gridspace fix implemented in this commit https://github.com/GridSpace/grid-apps/commit/65c2978f43f092d5199a14bb82e4abac2080199c allows us to make a single pass with cutthrough, if there is no cutthrough or if cutthrough is equal to 0 it will return an empty gcode string. I've added a small cutthrough of 0.01 which will be added to single pass operations which don't declare a cutthrough value or if the cutthrough value is 0.

` // single pass needs a cutthrough to generate correctly
      const camZThru = passes <= 1 && !cutThrough ? 0.01 : CUT_THROUGH;`

The cam zbottom is set to -1, to account for the camZtop value which needs to be negative to avoid unecesary roughing passes to top of stock
` // -1 to account for topZ -1 hack
      const camZBottom = -zBottom - CUT_THROUGH - 1;`