### PR TITLE
Fix for broken imports in nested molecules

### DIFF
--- a/src/molecules/molecule.js
+++ b/src/molecules/molecule.js
@@ -571,7 +571,12 @@ export default class Molecule extends Atom {
     if (remappedData?.allAtoms) {
       const atomPromises = [];
       remappedData.allAtoms.forEach((atomData) => {
-        const promise = targetMolecule.placeAtom(atomData, true, undefined, true); // skipAutoConnect = true
+        const promise = targetMolecule.placeAtom(
+          atomData,
+          true,
+          undefined,
+          true
+        ); // skipAutoConnect = true
         atomPromises.push(promise);
       });
 
@@ -1168,7 +1173,7 @@ export default class Molecule extends Atom {
   deepGeomList() {
     let geomList = [];
     this.nodesOnTheScreen.forEach((atom) => {
-      if (atom.status === Status.READY) {
+      if (atom.status !== Status.DISABLED) {
         if (
           atom.atomType === "Molecule" ||
           atom.atomType === "GitHubMolecule"


### PR DESCRIPTION
Fix cache sweep issue that was evicting contents of nested molecules whenever there wasn't something connected to the nested molecule output.

As far as I can tell this was affecting all atom types in nested molecules but is most visible with imports because if they're evicted from the cache they don't recover, ie, it requires user to re-upload the source file.