### PR TITLE
fix date modified bug

### DIFF
--- a/Lambda AWS Functions/post-new-project-abundance/lambda_function.py
+++ b/Lambda AWS Functions/post-new-project-abundance/lambda_function.py
@@ -15,6 +15,7 @@ def lambda_handler(event: any, context: any):
     table = dynamodb.Table(table_name)
 
     print(event)
+    newDate = str(datetime.now().toordinal())
 
     try:
         owner = event["owner"]
@@ -32,7 +33,7 @@ def lambda_handler(event: any, context: any):
         parentRepo = event["parentRepo"]
         githubMoleculesUsed = event["githubMoleculesUsed"]
         html_url = event["html_url"]
-        dateModified = datetime.now().strftime('%m/%d/%Y')
+        dateModified = newDate
 
         newYear = datetime.now().year
 


### PR DESCRIPTION
Updating aws post-new-project function to use correct dateModified format to fix recently created projects now showing up in the grid until saved manually. This was due to a formatting mismatch. 

- The local change merely archives the function, actual change happened on the aws console -