### PR TITLE
Exporting projects github molecule bug fix

### DIFF
--- a/src/components/main-routes/CreateMode.jsx
+++ b/src/components/main-routes/CreateMode.jsx
@@ -66,7 +66,7 @@ function CreateMode() {
     setShowTopLevelWireframe,
   } = useRendering();
 
-  const { cad, loadProject } = useProject();
+  const { cad, loadProject, searchGithubMolecules } = useProject();
   const meshRef = useRef();
 
   // Make meshRef available globally for thumbnail generation
@@ -453,46 +453,6 @@ function CreateMode() {
     setUserUploadedFile(false);
   }, [GlobalVariables.currentAWSnode]);
 
-  function searchGithubMolecules(molecule) {
-    return new Promise((resolve, reject) => {
-      try {
-        const githubMoleculeUsedList = [];
-
-        function recursiveSearch(molecule) {
-          // Check if the molecule has nodes
-          if (
-            !molecule.nodesOnTheScreen ||
-            !Array.isArray(molecule.nodesOnTheScreen)
-          ) {
-            return;
-          }
-          // Iterate through each node in the molecule
-          molecule.nodesOnTheScreen.forEach((node) => {
-            if (node.atomType === "GitHubMolecule") {
-              // Add to the githubMoleculeUsedList if atomType is "Github molecule"
-              if (node.parentRepo == null) return; // Safety check if parentRepo is null
-              githubMoleculeUsedList.push({
-                owner: node.parentRepo.owner,
-                repoName: node.parentRepo.repoName,
-              });
-            } else if (node.atomType === "Molecule") {
-              // Recursively search inside the nodes of this molecule
-              recursiveSearch(node);
-            }
-          });
-        }
-
-        // Start the recursive search
-        recursiveSearch(molecule);
-
-        // Resolve the promise with the list of Github molecules
-        resolve(githubMoleculeUsedList);
-      } catch (error) {
-        // Reject the promise if an error occurs
-        reject(error);
-      }
-    });
-  }
   /**
    * Create a commit as part of the saving process.
    */

--- a/src/contexts/ProjectContext.jsx
+++ b/src/contexts/ProjectContext.jsx
@@ -42,46 +42,6 @@ export function ProjectProvider({ children, cad, loadProject }) {
     exporting,
     setNewProjectBar
   ) => {
-    function searchGithubMolecules(molecule) {
-      return new Promise((resolve, reject) => {
-        try {
-          const githubMoleculeUsedList = [];
-
-          function recursiveSearch(molecule) {
-            // Check if the molecule has nodes
-            if (
-              !molecule.nodesOnTheScreen ||
-              !Array.isArray(molecule.nodesOnTheScreen)
-            ) {
-              return;
-            }
-            // Iterate through each node in the molecule
-            molecule.nodesOnTheScreen.forEach((node) => {
-              if (node.atomType === "GitHubMolecule") {
-                // Add to the githubMoleculeUsedList if atomType is "Github molecule"
-                if (node.parentRepo == null) return; // Safety check if parentRepo is null
-                githubMoleculeUsedList.push({
-                  owner: node.parentRepo.owner,
-                  repoName: node.parentRepo.repoName,
-                });
-              } else if (node.atomType === "Molecule") {
-                // Recursively search inside the nodes of this molecule
-                recursiveSearch(node);
-              }
-            });
-          }
-
-          // Start the recursive search
-          recursiveSearch(molecule);
-
-          // Resolve the promise with the list of Github molecules
-          resolve(githubMoleculeUsedList);
-        } catch (error) {
-          // Reject the promise if an error occurs
-          reject(error);
-        }
-      });
-    }
     let githubMoleculeUsedList = [];
     if (molecule !== undefined && exporting) {
       githubMoleculeUsedList = await searchGithubMolecules(
@@ -298,6 +258,47 @@ export function ProjectProvider({ children, cad, loadProject }) {
     console.log("Project created");
     console.log(GlobalVariables.currentAWSnode);
     return GlobalVariables.currentAWSnode;
+  };
+
+  const searchGithubMolecules = (molecule) => {
+    return new Promise((resolve, reject) => {
+      try {
+        const githubMoleculeUsedList = [];
+
+        function recursiveSearch(molecule) {
+          // Check if the molecule has nodes
+          if (
+            !molecule.nodesOnTheScreen ||
+            !Array.isArray(molecule.nodesOnTheScreen)
+          ) {
+            return;
+          }
+          // Iterate through each node in the molecule
+          molecule.nodesOnTheScreen.forEach((node) => {
+            if (node.atomType === "GitHubMolecule") {
+              // Add to the githubMoleculeUsedList if atomType is "Github molecule"
+              if (node.parentRepo == null) return; // Safety check if parentRepo is null
+              githubMoleculeUsedList.push({
+                owner: node.parentRepo.owner,
+                repoName: node.parentRepo.repoName,
+              });
+            } else if (node.atomType === "Molecule") {
+              // Recursively search inside the nodes of this molecule
+              recursiveSearch(node);
+            }
+          });
+        }
+
+        // Start the recursive search
+        recursiveSearch(molecule);
+
+        // Resolve the promise with the list of Github molecules
+        resolve(githubMoleculeUsedList);
+      } catch (error) {
+        // Reject the promise if an error occurs
+        reject(error);
+      }
+    });
   };
 
   /**
@@ -767,6 +768,7 @@ export function ProjectProvider({ children, cad, loadProject }) {
     createProject,
     duplicateProject,
     renameProject,
+    searchGithubMolecules,
   };
   return (
     <ProjectContext.Provider value={value}>{children}</ProjectContext.Provider>


### PR DESCRIPTION
When exporting a molecule to github, the github molecules used field remained empty since create project passed an empty object. When exporting molecules, run the search for github molecules in the same way that save project does so rankings in aws get updated correctly.