### PR TITLE
Rotational Precision in CutLayout is now user-config-able

### DIFF
--- a/src/molecules/cutlayout.js
+++ b/src/molecules/cutlayout.js
@@ -77,7 +77,7 @@ export default class CutLayout extends Atom {
           GlobalVariables.topLevelMolecule.unitsKey == "MM" ? 10 : 0.4,
       },
       {
-        name: "Orientations per Part",
+        name: "Orientations",
         valueType: "number",
         defaultValue: 12,
       },
@@ -201,7 +201,7 @@ export default class CutLayout extends Atom {
       var sheetWidth = this.findIOValue("Sheet Width");
       var sheetHeight = this.findIOValue("Sheet Height");
       var partPadding = this.findIOValue("Part Padding");
-      var rotations = this.findIOValue("Orientations per Part");
+      var rotations = this.findIOValue("Orientations");
       const priorStatus = this.status;
       this.setProcessing();
       console.trace("Displaying layout with " + placements.length + " sheets.");
@@ -291,8 +291,8 @@ export default class CutLayout extends Atom {
       var sheetWidth = this.findIOValue("Sheet Width");
       var sheetHeight = this.findIOValue("Sheet Height");
       var partPadding = this.findIOValue("Part Padding");
-      var rotations = this.findIOValue("Orientations per Part");
-
+      var rotations = this.findIOValue("Orientations");
+      
       if (!inputGeom) {
         this.setError('"geometry" input is missing');
         return;

--- a/src/worker/cutlayout.ts
+++ b/src/worker/cutlayout.ts
@@ -50,6 +50,8 @@ async function layout(
   context: RequestContext,
   previousPlacements: Placement[][] | undefined = undefined
 ): Promise<[AbundanceObject, Placement[][]]> {
+  checkConfig(layoutConfig);
+
   var [rotatedAssembly, shapesForLayout] = await rotateForLayout(
     assembly,
     layoutConfig,
@@ -476,6 +478,15 @@ async function applyLayout(
   );
 
   return result;
+}
+
+function checkConfig(layoutConfig: LayoutConfig) {
+  if (layoutConfig.width <= 0 || layoutConfig.height <= 0) {
+    throw new Error("Sheet width and height must be greater than zero.");
+  }
+  if (layoutConfig.rotations < 1 || !Number.isInteger(layoutConfig.rotations)) {
+    throw new Error("Orientations must be an integer of 1 or more.");
+  }
 }
 
 /**


### PR DESCRIPTION
allow user to set the rotational precision of the layout system. Examples:

* set "orientations" to 4 to constrain to orthogonal layouts - good if your parts are all rectangular-ish
* set "orientations" to 2 to ensure parts align with plywood grain direction in a specific way

Defaults to 12, must be set to a value > 0.

