### PR TITLE
Readme panel for runMode

### DIFF
--- a/src/components/main-routes/RunMode.jsx
+++ b/src/components/main-routes/RunMode.jsx
@@ -14,6 +14,7 @@ import ExportMenu from "../secondary/ExportMenu.jsx";
 import RenderMenu from "../secondary/RenderMenu.jsx";
 import BomMenu from "../secondary/BomMenu.jsx";
 import RenderProgressBar from "../secondary/RenderProgressBar.jsx";
+import ReadmePanel from "../secondary/ReadmePanel.jsx";
 import {
   BrowserRouter as Router,
   useParams,
@@ -261,6 +262,18 @@ function runMode() {
           position: { top: 120, left: screenWidth - 365 },
         }}
         collapsedOffset={[45, -90]}
+      />
+
+      {/* ReadmePanel below BomMenu, collapsed by default */}
+      <ReadmePanel
+        readme={GlobalVariables.currentRepo?.readme || ""}
+        id="atom-run-readme-panel"
+        position={{ top: 165, left: screenWidth - 365 }}
+        initialCollapsed={true}
+        contentCollapsed={expandedMenu !== "readme"}
+        setContentCollapsed={() => setExpandedMenu("readme")}
+        closeMenu={() => setExpandedMenu("none")}
+        collapsedOffset={[45, -135]}
       />
       <div id="headerBarRun">
         <img

--- a/src/components/secondary/ReadmePanel.jsx
+++ b/src/components/secondary/ReadmePanel.jsx
@@ -1,0 +1,87 @@
+import { useMemo } from "react";
+import { SimpleControlPanel } from "./SimpleControlPanel.jsx";
+import GlobalVariables from "../../js/globalvariables.js";
+
+// Book icon for ReadmePanel (slightly bigger)
+const BookIcon = ({ size = 24 }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect
+      x="3"
+      y="5"
+      width="18"
+      height="14"
+      rx="2.5"
+      fill="#c4a3d5"
+      stroke="#a18fcf"
+      strokeWidth="1.7"
+    />
+    <path
+      d="M8 8h8M8 11h8M8 14h6"
+      stroke="#fff"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+export default function ReadmePanel({
+  readme = "",
+  id = "readme-panel",
+  position,
+  initialCollapsed = false,
+  contentCollapsed,
+  setContentCollapsed,
+  panelRef,
+  closeMenu,
+  minWidth = 300,
+  maxHeight,
+  collapsedOffset = [0, 0],
+  collapsedIcon,
+  title = "Project Readme",
+}) {
+  console.log(
+    "Current top level molecule in ReadmePanel:",
+    GlobalVariables.topLevelMolecule
+  );
+  // Only one control: the readme as markdown
+  const controls = useMemo(
+    () => ({
+      projectReadme: {
+        type: "markdown",
+        label: "Readme",
+        value: readme || "No README available.",
+        order: 0,
+        disabled: true,
+      },
+    }),
+    [readme]
+  );
+
+  const screenHeight = window.innerHeight;
+
+  return (
+    <div>
+      <SimpleControlPanel
+        controls={controls}
+        id={id}
+        position={position || { top: screenHeight / 2 - 10, left: 30 }}
+        title={title}
+        minWidth={minWidth}
+        initialCollapsed={initialCollapsed}
+        maxHeight={maxHeight || screenHeight / 1.5}
+        contentCollapsed={contentCollapsed}
+        setContentCollapsed={setContentCollapsed}
+        ref={panelRef}
+        closeMenu={closeMenu}
+        collapsedOffset={collapsedOffset}
+        collapsedIcon={collapsedIcon || BookIcon}
+      />
+    </div>
+  );
+}

--- a/src/components/secondary/RunParams.jsx
+++ b/src/components/secondary/RunParams.jsx
@@ -71,7 +71,7 @@ export default function RunParams({
   }
 
   const inputParamsConfig = useMemo(() => {
-    return { ...inputParams, ...exportParams };
+    return { ...exportParams, ...inputParams };
   }, [inputParams, exportParams]);
 
   const [


### PR DESCRIPTION
Add readme panel for run mode/
Since we have collapsed the param panel and the export panel for run mode into one initial panel, leaving the readme info seems like it would create clutter. I'm separating it into its own panel for clarity.