### PR TITLE
Param should be focused upon panel opening

### DIFF
--- a/src/components/secondary/SimpleControlPanel.jsx
+++ b/src/components/secondary/SimpleControlPanel.jsx
@@ -291,7 +291,6 @@ export const SimpleControlPanel = forwardRef(function SimpleControlPanel(
 
   useImperativeHandle(ref, () => ({
     triggerPanelKeyDown: (event) => {
-      console.log("triggerPanelKeyDown", event);
       handlePanelKeyDown(event);
     },
   }));


### PR DESCRIPTION
When a panel is first opened, for example when placing github molecules, the input should be automatically focused. This used effect focuses the first input when the collapsed state changes