### PR TITLE
Visualize gcode from saved position

### DIFF
--- a/src/components/render/GCodeLoaderMesh.jsx
+++ b/src/components/render/GCodeLoaderMesh.jsx
@@ -21,9 +21,12 @@ export default function GCodeLoaderMesh({ authorizedUserOcto }) {
       try {
         const loader = new GCodeLoader();
         const parsedObjects = [];
+        let lastPosition = { x: 0, y: 0, z: 0 };
         for (const part of gcodeParts) {
-          const parseGcodeString = loader.parse(part);
-          parsedObjects.push(parseGcodeString);
+          const { object: parsedObject, lastPosition: partLastPosition } =
+            loader.parse(part, lastPosition.x, lastPosition.y);
+          lastPosition = partLastPosition;
+          parsedObjects.push(parsedObject);
         }
 
         const allGcodeObjects = new Group();

--- a/src/js/GCodeAbundanceLoader.js
+++ b/src/js/GCodeAbundanceLoader.js
@@ -82,10 +82,17 @@ class GCodeLoader extends Loader {
    * @param {string} data - The raw Gcode data as a string.
    * @return {Group} The parsed GCode asset.
    */
-  parse(data) {
+  /**
+   * Parses the given GCode data and returns a group with lines and last position.
+   * @param {string} data - The raw Gcode data as a string.
+   * @param {number} [x] - Optional starting x position.
+   * @param {number} [y] - Optional starting y position.
+   * @returns {{ object: Group, lastPosition: { x: number, y: number, z: number } }}
+   */
+  parse(data, x, y) {
     let state = {
-      x: 0,
-      y: 0,
+      x: x || 0,
+      y: y || 0,
       z: 0,
       e: 0,
       f: 0,
@@ -94,6 +101,7 @@ class GCodeLoader extends Loader {
       extrusionOverride: false,
       extrusionRelative: false,
     };
+    let lastPosition = { x: x || 0, y: y || 0, z: 0 };
     const layers = [];
 
     let currentLayer = undefined;
@@ -254,6 +262,14 @@ class GCodeLoader extends Loader {
       } else {
         //console.warn( 'THREE.GCodeLoader: Command not supported:' + cmd );
       }
+      // Track last position for x, y, z if present
+      if (
+        state.x !== undefined &&
+        state.y !== undefined &&
+        state.z !== undefined
+      ) {
+        lastPosition = { x: state.x, y: state.y, z: state.z };
+      }
     }
 
     function addObject(vertexSegments, i) {
@@ -302,7 +318,7 @@ class GCodeLoader extends Loader {
 
     object.rotation.set(-Math.PI / 2, 0, 0);
 
-    return object;
+    return { object, lastPosition };
   }
 }
 


### PR DESCRIPTION
Although the gcode was generating correctly the gcode parser for visualization returned to origin between parts. To avoid this we passed a saved x,y value to the parser which represents the last x,y value from the previous part if available. This allows the gcode visualization to match with the actual gcode generated in concatenation.

Parser can't handle concatenated the strings which is why we pass individual parts.