### PR TITLE
GCODE fix 

### DIFF
--- a/KirimotoUpdate.js
+++ b/KirimotoUpdate.js
@@ -18,7 +18,7 @@ const generateGcode = (
     const stock_offset = {
       x: 3,
       y: 3,
-      z: 1,
+      z: -0.01,
     };
     const plunge = speed;
 
@@ -82,8 +82,8 @@ const generateGcode = (
         if (progressCallback) progressCallback(0.1); // 10% - STL loaded
 
         eng.setMode("CAM");
-
-        eng.setOrigin(-centerPos[0], centerPos[1], 0);
+        const bounds = eng.widget.getBoundingBox();
+        eng.setOrigin(-centerPos[0], centerPos[1], bounds.max.z);
         // Determine if project uses metric units
         const projectUnits = GlobalVariables.topLevelMolecule?.unitsKey || "MM";
         const isMetric = projectUnits === "MM";
@@ -106,8 +106,7 @@ const generateGcode = (
 
         if (progressCallback) progressCallback(0.25); // 25% - Tools set
 
-        const bounds = eng.widget.getBoundingBox();
-        const down = (bounds.dim.z + CUT_THROUGH) / (passes - 1);
+        const down = (bounds.dim.z + CUT_THROUGH) / passes;
         const stepOver = 0.8;
         // camZAnchor is only for UI
         //eng.setOrigin(bounds.mid.x, bounds.mid.y, bounds.max.z);
@@ -127,13 +126,14 @@ const generateGcode = (
           camOriginCenter: true,
           camStockOffset: false,
           camToolInit: true,
+          camZClearance: 5,
           //zBottom: -bounds.max.z - CUT_THROUGH,
           ops: [
             {
               all: false,
               disabled: false,
               down: down,
-              flats: false,
+              flats: true,
               inside: true,
               leave: 0,
               leavez: 0,

--- a/src/js/GCodeAbundanceLoader.js
+++ b/src/js/GCodeAbundanceLoader.js
@@ -115,7 +115,7 @@ class GCodeLoader extends Loader {
     extrudingMaterial.name = "extruded";
 
     // Rapid (moving/plunging, not cutting or extruding)
-    const rapidMaterial = new LineBasicMaterial({ color: 0xff0000 });
+    const rapidMaterial = new LineBasicMaterial({ color: 0xff9933 });
     rapidMaterial.name = "rapid";
 
     function newLayer(line) {


### PR DESCRIPTION
- Re established rough operation flat clearance
 - Change the stock absolute val to -0.1 hoping to avoid the rough clearing pass
 - Change path color to orange
 - Set origin to bounds.z.max to avoid 0 dip