### PR TITLE
Small changes 

### DIFF
--- a/src/components/main-routes/CreateMode.jsx
+++ b/src/components/main-routes/CreateMode.jsx
@@ -315,7 +315,7 @@ function CreateMode() {
         },
       },
     ];
-
+    //Only works with CTRL
     if ((e.ctrlKey || e.metaKey) && e.shiftKey) {
       for (const combo of shortcutCombos) {
         if (e.key === combo.key) {

--- a/src/components/main-routes/flowCanvas.jsx
+++ b/src/components/main-routes/flowCanvas.jsx
@@ -359,6 +359,7 @@ export default memo(function FlowCanvas({
       GlobalVariables.currentMolecule.nodesOnTheScreen.forEach((molecule) => {
         molecule.keyPress(e.key);
       });
+      setActiveAtom(GlobalVariables.currentMolecule);
     }
 
     if (GlobalVariables.ctrlDown && shortCuts.hasOwnProperty([e.key])) {
@@ -691,7 +692,9 @@ export default memo(function FlowCanvas({
 
   let parentLinkPath = [];
   if (GlobalVariables.currentMolecule) {
-    parentLinkPath.unshift(getMoleculeDisplayName(GlobalVariables.currentMolecule));
+    parentLinkPath.unshift(
+      getMoleculeDisplayName(GlobalVariables.currentMolecule),
+    );
     let currentParent = GlobalVariables.currentMolecule.parent;
     while (currentParent) {
       parentLinkPath.unshift(getMoleculeDisplayName(currentParent));
@@ -760,7 +763,6 @@ export default memo(function FlowCanvas({
       {undoNotification && (
         <div className="undo-notification">{undoNotification}</div>
       )}
-
 
       {/* User notification */}
       {userNotification && (

--- a/src/molecules/input.js
+++ b/src/molecules/input.js
@@ -126,7 +126,7 @@ export default class Input extends Atom {
         this.type === "import" ? "geometry" : this.type,
         this.value,
         "input",
-        inputOptions
+        inputOptions,
       );
       // We also subscribe directly to the parent ap.
       this.parentAP.subscribe(() => {
@@ -134,7 +134,7 @@ export default class Input extends Atom {
       }, this.uniqueID);
     } else {
       throw new Error(
-        "constructed an input with undefined parent. IDK what to do here"
+        "constructed an input with undefined parent. IDK what to do here",
       );
     }
 
@@ -162,7 +162,7 @@ export default class Input extends Atom {
 
     // Find all existing Input atoms in the parent molecule (excluding this one)
     const existingInputs = this.parent.nodesOnTheScreen.filter(
-      (atom) => atom.atomType === "Input" && atom !== this
+      (atom) => atom.atomType === "Input" && atom !== this,
     );
 
     // Calculate total number of inputs including this one
@@ -197,7 +197,7 @@ export default class Input extends Atom {
         const adjustedRequiredHeight = (totalInputs - 1) * atomSpacing;
         startY = Math.max(
           GlobalVariables.atomSize * 2,
-          maxY - adjustedRequiredHeight
+          maxY - adjustedRequiredHeight,
         );
       }
     }
@@ -438,7 +438,7 @@ export default class Input extends Atom {
     GlobalVariables.c.fillText(
       this.fittingString(GlobalVariables.c, this.name, maxTextWidth),
       5,
-      yInPixels + 3
+      yInPixels + 3,
     );
 
     // Draw the inputs
@@ -524,7 +524,7 @@ export default class Input extends Atom {
     const canvas = GlobalVariables.canvas.current;
     // Trigger layout reflow to ensure getBoundingClientRect returns current values
     void canvas.offsetHeight;
-    
+
     const canvasRect = canvas.getBoundingClientRect();
 
     this.tooltipElement = document.createElement("div");
@@ -565,16 +565,17 @@ export default class Input extends Atom {
       return;
     }
 
-    // Check if mouse is over this input atom using the input's actual dimensions
+    // Adjust hit area to match left-aligned drawing (drawn from x=0 to x=width)
     let xInPixels = GlobalVariables.widthToPixels(this.x);
     let yInPixels = GlobalVariables.heightToPixels(this.y);
-
-    // Use the input's width and height instead of just radius
+    // The shape is drawn from x=0 to x=width, so hit area is from xInPixels to xInPixels+width
+    const width = this.width || 100;
+    const height = this.height || 30;
     const isOverAtom =
-      x >= xInPixels - (this.width || 100) / 2 &&
-      x <= xInPixels + (this.width || 100) / 2 &&
-      y >= yInPixels - (this.height || 30) / 2 &&
-      y <= yInPixels + (this.height || 30) / 2;
+      x >= xInPixels &&
+      x <= xInPixels + width &&
+      y >= yInPixels - height / 2 &&
+      y <= yInPixels + height / 2;
 
     if (isOverAtom) {
       // Mouse is over the atom
@@ -645,10 +646,10 @@ export default class Input extends Atom {
           fileType === "STL"
             ? GlobalVariables.cad.importingSTL
             : fileType === "SVG"
-            ? GlobalVariables.cad.importingSVG
-            : fileType === "STEP"
-            ? GlobalVariables.cad.importingSTEP
-            : null;
+              ? GlobalVariables.cad.importingSVG
+              : fileType === "STEP"
+                ? GlobalVariables.cad.importingSTEP
+                : null;
 
         if (funcToCall === null) {
           throw new Error("Invalid file type");
@@ -778,10 +779,10 @@ export default class Input extends Atom {
         this.fileType === "STL"
           ? GlobalVariables.cad.importingSTL
           : this.fileType === "SVG"
-          ? GlobalVariables.cad.importingSVG
-          : this.fileType === "STEP"
-          ? GlobalVariables.cad.importingSTEP
-          : null;
+            ? GlobalVariables.cad.importingSVG
+            : this.fileType === "STEP"
+              ? GlobalVariables.cad.importingSTEP
+              : null;
 
       if (funcToCall === null) {
         throw new Error("Invalid file type");
@@ -790,7 +791,7 @@ export default class Input extends Atom {
       const result = await funcToCall(
         fileData,
         this.getContext(),
-        this.SVGwidth
+        this.SVGwidth,
       );
 
       this.value = result;
@@ -945,7 +946,7 @@ export default class Input extends Atom {
         sanitizedName = GlobalVariables.incrementVariableName(
           sanitizedName,
           this.parent,
-          [this]
+          [this],
         );
         if (this.name !== sanitizedName) {
           this.name = sanitizedName;
@@ -961,7 +962,15 @@ export default class Input extends Atom {
       value: this.type,
       label: "Input Type",
       disabled: false,
-      options: ["number", "string", "geometry", "array", "boolean", "range", "import"],
+      options: [
+        "number",
+        "string",
+        "geometry",
+        "array",
+        "boolean",
+        "range",
+        "import",
+      ],
       onChange: (newType) => {
         if (this.type !== newType) {
           this.type = newType;
@@ -1061,7 +1070,7 @@ export default class Input extends Atom {
           onClick: () => {
             this.loadFile(
               this.importOptions[this.importIndex],
-              this.setInputChanged
+              this.setInputChanged,
             );
           },
         };

--- a/src/prototypes/atom.js
+++ b/src/prototypes/atom.js
@@ -609,8 +609,13 @@ export default class Atom extends ObservableEntity {
     let yInPixels = GlobalVariables.heightToPixels(this.y);
     let radiusInPixels = GlobalVariables.widthToPixels(this.radius);
     if (this.isMoving == true) {
-      this.x = GlobalVariables.pixelsToWidth(x);
-      this.y = GlobalVariables.pixelsToHeight(y);
+      if (this.atomType == "Input") {
+        // Input atoms are locked to the left side, only update y position
+        this.y = GlobalVariables.pixelsToHeight(y);
+      } else {
+        this.x = GlobalVariables.pixelsToWidth(x);
+        this.y = GlobalVariables.pixelsToHeight(y);
+      }
     }
 
     this.inputs.forEach((child) => {
@@ -791,7 +796,7 @@ export default class Atom extends ObservableEntity {
         const isMoleculeInput = ap.type === "input";
 
         // Debug logging for Input-type attachments
-        if (isMoleculeInput || ap.name === "Wood Thickness") {
+        /*if (isMoleculeInput || ap.name === "Wood Thickness") {
           console.log(
             `[Serialize Debug] AP="${ap.name}", type="${ap.type}", valueType="${
               ap.valueType
@@ -801,7 +806,7 @@ export default class Atom extends ObservableEntity {
               isDifferentFromDefault || hasCustomEquation || isMoleculeInput
             }`,
           );
-        }
+        }*/
 
         // Save if value changed from default OR has custom equation OR is a molecule input
         if (isDifferentFromDefault || hasCustomEquation || isMoleculeInput) {


### PR DESCRIPTION
- Prevent input atom AP from moving in X when atom selected.
- Return focus to molecule when an atom is deleted
- Redraw input accounting for different length
Fixes #1540
