### PR TITLE
Recompute fix: move to serialize

### DIFF
--- a/src/components/main-routes/CreateMode.jsx
+++ b/src/components/main-routes/CreateMode.jsx
@@ -130,6 +130,17 @@ function CreateMode() {
     false,
   );
 
+  const [recomputeProgress, setRecomputeProgress] = useState(0);
+  const [recomputeVisible, setRecomputeVisible] = useState(false);
+
+  useProgressBar(
+    "recompute",
+    recomputeVisible,
+    recomputeProgress,
+    "Recomputing",
+    false,
+  );
+
   /** State for save progress bar */
   const [saveState, setSaveState] = useState(0);
   const [savePopUp, setSavePopUp] = useState(false);
@@ -656,6 +667,10 @@ function CreateMode() {
               setSettingsPopUp,
               duplicateDialog,
               setDuplicateDialog,
+              recomputeVisible,
+              setRecomputeVisible,
+              recomputeProgress,
+              setRecomputeProgress,
             }}
           />
 

--- a/src/components/secondary/TopMenu.jsx
+++ b/src/components/secondary/TopMenu.jsx
@@ -25,6 +25,10 @@ function TopMenu({
   setSettingsPopUp,
   duplicateDialog,
   setDuplicateDialog,
+  recomputeVisible,
+  setRecomputeVisible,
+  recomputeProgress,
+  setRecomputeProgress,
 }) {
   const { authorizedUserOcto, authRedirectHandler } = useAuth();
   const {
@@ -65,9 +69,15 @@ function TopMenu({
   const navigate = useNavigate();
 
   // Register progress bars with the manager
-  useProgressBar('save', savePopUp, saveState, 'Saving', false);
-  useProgressBar('duplicate', duplicatingProject, duplicateProgress, 'Duplicating', false);
-  useProgressBar('rename', renamingProject, renameProgress, 'Renaming', false);
+  useProgressBar("save", savePopUp, saveState, "Saving", false);
+  useProgressBar(
+    "duplicate",
+    duplicatingProject,
+    duplicateProgress,
+    "Duplicating",
+    false,
+  );
+  useProgressBar("rename", renamingProject, renameProgress, "Renaming", false);
 
   // Auto-hide save bar when complete
   useEffect(() => {
@@ -110,7 +120,7 @@ function TopMenu({
     const newProject = await duplicateProject(
       authorizedUserOcto,
       setDuplicateProgress,
-      customName
+      customName,
     );
 
     if (newProject) {
@@ -161,7 +171,7 @@ function TopMenu({
     const updatedProject = await renameProject(
       authorizedUserOcto,
       newName,
-      setRenameProgress
+      setRenameProgress,
     );
 
     setRenamingProject(false);
@@ -177,6 +187,13 @@ function TopMenu({
     }
   };
 
+  const closeNavbar = () => {
+    if (navbarOpenRef.current) {
+      navbarOpenRef.current = false;
+      setNavbarRenderTrigger((prev) => prev + 1);
+    }
+  };
+
   // objects for navigation items in the top menu
   const navItems = useMemo(
     () => [
@@ -185,7 +202,11 @@ function TopMenu({
         buttonFunc: () => {
           // Save current project state to localStorage before navigating
           // Note: owner and repoName come from GitHub's API and are validated by GitHub
-          if (GlobalVariables.topLevelMolecule && GlobalVariables.currentAWSnode?.owner && GlobalVariables.currentAWSnode?.repoName) {
+          if (
+            GlobalVariables.topLevelMolecule &&
+            GlobalVariables.currentAWSnode?.owner &&
+            GlobalVariables.currentAWSnode?.repoName
+          ) {
             const projectState = GlobalVariables.topLevelMolecule.serialize();
             projectState.filetypeVersion = 1;
             const projectKey = `unsavedProject_${GlobalVariables.currentAWSnode.owner}_${GlobalVariables.currentAWSnode.repoName}`;
@@ -302,7 +323,12 @@ function TopMenu({
         id: "Recompute Project",
         buttonFunc: () => {
           GlobalVariables.currentMolecule = GlobalVariables.topLevelMolecule;
-          GlobalVariables.topLevelMolecule.recomputeAll();
+          GlobalVariables.topLevelMolecule.recomputeAll(
+            setRecomputeVisible,
+            setRecomputeProgress,
+          );
+          setRecomputeVisible(true);
+          setRecomputeProgress(0);
         },
       },
       {
@@ -337,7 +363,7 @@ function TopMenu({
       authRedirectHandler,
       setSettingsPopUp,
       setExportPopUp,
-    ]
+    ],
   );
 
   //{checks for top level variable and show go-up button if this is not top molecule
@@ -428,7 +454,10 @@ function TopMenu({
               <button
                 key={item.id}
                 className="menu-nav-button"
-                onClick={item.buttonFunc}
+                onClick={() => {
+                  item.buttonFunc();
+                  closeNavbar();
+                }}
               >
                 <img
                   className=" thumnail-logo"

--- a/src/molecules/molecule.js
+++ b/src/molecules/molecule.js
@@ -1316,14 +1316,19 @@ export default class Molecule extends Atom {
     }
     return geomList;
   }
+  //Only enabling the molecules was causing propagation issues, so now we are deserializing the molecule to recompute it.
+  async recomputeAll(setRecomputeVisible, setRecomputeProgress) {
+    // Serialize the current molecule state
+    const snapshot = this.serialize({ x: 0, y: 0 }, setRecomputeProgress);
+    // Remove all atoms from the molecule
+    this.deleteAllAtoms();
 
-  async recomputeAll() {
-    this.disable();
+    // Clear CAD cache
     await GlobalVariables.cad.clearCache(this.getContext());
-    this.enable();
-    for (const atom of this.nodesOnTheScreen) {
-      atom.enable();
-    }
+    // Re-deserialize the molecule from the snapshot
+    await this.deserialize(snapshot);
+    setRecomputeProgress(100); // Update progress to indicate completion
+    setRecomputeVisible(false); // Hide the progress bar after recompute is done
   }
 
   /**


### PR DESCRIPTION
- The recompute molecule function which was working by disabling and then reenabling all the nodes on the screen was causing issues for anything connected to input atoms as well as for all github molecules and not propagating values appropriately. I switched the recompute function to serialize a snapshot of the project and redeserialize the entire molecule which although is a bit slower seems a more reliable solution. 
- Makes sure top menu navbar closes when anything in it is clicked
- Implements a progress bar for recompute/ values are not accurate but at least indicates to the user that there's a process in motion 