### PR TITLE
Fix geometry connector replacements

### DIFF
--- a/src/molecules/molecule.js
+++ b/src/molecules/molecule.js
@@ -1584,7 +1584,12 @@ export default class Molecule extends Atom {
     if (!geometryInput) {
       return; // New atom doesn't have an available geometry input
     }
-
+    // If no free geometry input is found, fall back to any geometry input to allow replacement
+    // placeConnector will handle replacing the existing connection if types are compatible
+    if (!geometryInput && newAtom.inputs) {
+      geometryInput =
+        newAtom.inputs.find((input) => input.valueType === "geometry") || null;
+    }
     // Use the first selected atom with geometry output (could be enhanced to be smarter)
     const sourceAtom = selectedGeometryAtoms[0];
 


### PR DESCRIPTION
If the connector with a geometry value tries to connect to the molecules but no geometry input is available, it should replace the first input with a geometry value. 