### PR TITLE
Gcode displaying main mesh fix

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -377,6 +377,7 @@ function AppContent() {
         targetMesh.current = moleculeValue;
 
         if (
+          !nonReplicadGeometryFromAtom?.hideMainMesh &&
           JSON.stringify(targetMesh.current) ===
             JSON.stringify(backgroundMesh.current?.id) &&
           backgroundMesh.current?.mesh
@@ -393,7 +394,7 @@ function AppContent() {
         } else {
           // General case - generate the mesh for selected atom
           //Check if mesh should be hidden (a.e gcode)
-          if (!nonReplicadGeometryFromAtom.hideMainMesh) {
+          if (!nonReplicadGeometryFromAtom?.hideMainMesh) {
             makeMesh();
           } else {
             setMesh([]);


### PR DESCRIPTION
Because of a special case in which the mesh doesn't change if it has already been made, the hidemainmesh flag got skipped and kept displaying the mesh regardless of what the hidemesh flag passed.

Fixes #1570