### PR TITLE
support 2d + 3d points in inputs and atoms (code)

### DIFF
--- a/src/molecules/code.js
+++ b/src/molecules/code.js
@@ -87,12 +87,12 @@ return assembly;
     GlobalVariables.c.beginPath();
     GlobalVariables.c.fillStyle = "#949294";
     GlobalVariables.c.font = `${GlobalVariables.widthToPixels(
-      this.radius
+      this.radius,
     )}px Work Sans Bold`;
     GlobalVariables.c.fillText(
       "</>",
       GlobalVariables.widthToPixels(this.x - this.radius / 1.5),
-      GlobalVariables.heightToPixels(this.y + this.radius * 1.5)
+      GlobalVariables.heightToPixels(this.y + this.radius * 1.5),
     );
   }
 
@@ -118,9 +118,9 @@ return assembly;
           this.inputs
             .map(
               (input) =>
-                `${input.name}:${input.defaultValue}:${input.valueType}`
+                `${input.name}:${input.defaultValue}:${input.valueType}`,
             )
-            .join("|")
+            .join("|"),
         );
       },
     };
@@ -160,7 +160,7 @@ return assembly;
       if (lineMatch) {
         const lineNumber = lineMatch[1];
         super.setError(
-          `User code error at line ${lineNumber}: ${err.name} - ${err.message}`
+          `User code error at line ${lineNumber}: ${err.name} - ${err.message}`,
         );
         logged = true;
       }
@@ -177,7 +177,7 @@ return assembly;
     return GlobalVariables.cad.code(
       this.code,
       argumentsArray,
-      this.getContext()
+      this.getContext(),
     );
   }
 
@@ -191,24 +191,48 @@ return assembly;
     // Remove all block comments and line comments before matching Inputs array
     let codeNoComments = this.code.replace(/\/\*[\s\S]*?\*\//g, ""); // Remove block comments
     codeNoComments = codeNoComments.replace(/\/\/.*$/gm, ""); // Remove line comments
-    const allInputsMatches = [
-      ...codeNoComments.matchAll(/(?:const\s+)?Inputs\s*=\s*\[(.*?)]\s*;?/gs),
-    ];
-    
+
+    // Find Inputs = [ and extract the entire array by counting brackets
+    // This handles nested arrays in defaultValue (e.g., defaultValue: [0,0])
+    const inputsStart = codeNoComments.search(/(?:const\s+)?Inputs\s*=\s*\[/);
+    if (inputsStart === -1) return;
+
+    // Find the matching closing bracket by counting bracket depth
+    let bracketCount = 0;
+    let arrayEndIndex = -1;
+    const startBracket = codeNoComments.indexOf("[", inputsStart);
+
+    for (let i = startBracket; i < codeNoComments.length; i++) {
+      if (codeNoComments[i] === "[") bracketCount++;
+      if (codeNoComments[i] === "]") {
+        bracketCount--;
+        if (bracketCount === 0) {
+          arrayEndIndex = i + 1;
+          break;
+        }
+      }
+    }
+
+    if (arrayEndIndex === -1) return;
+
+    const fullMatch = codeNoComments.substring(inputsStart, arrayEndIndex);
+    const arrContent = fullMatch.match(/\[([\s\S]*)\]/)[1];
+    const allInputsMatches = [{ 0: fullMatch, 1: arrContent }];
+
     if (allInputsMatches.length > 0) {
       const firstMatch = allInputsMatches[0];
-      
+
       // If it's a const declaration, use safe eval
       if (/const\s+Inputs\s*=/.test(firstMatch[0])) {
         try {
           const sandboxFn = new Function(firstMatch[0] + "; return Inputs;");
           const inputsArray = sandboxFn();
-          
+
           const variableNames = [];
           inputsArray.forEach(({ inputName, type, defaultValue }) => {
             variableNames.push(inputName);
             const existingInput = this.inputs.find(
-              (input) => input.name === inputName
+              (input) => input.name === inputName,
             );
 
             if (!existingInput) {
@@ -216,7 +240,7 @@ return assembly;
                 inputName,
                 type,
                 defaultValue,
-                "input"
+                "input",
               );
             } else {
               existingInput.valueType = type;
@@ -242,22 +266,22 @@ return assembly;
         arrStr = arrStr.replace(/,\s*$/, ""); // Remove trailing comma at end
         arrStr = arrStr.replace(/(\w+)\s*:/g, '"$1":');
         arrStr = arrStr.replace(/'/g, '"');
-        
+
         try {
           const inputsArray = JSON.parse(`[${arrStr}]`);
-          
+
           const variableNames = [];
           inputsArray.forEach(({ inputName, type, defaultValue }) => {
             variableNames.push(inputName);
             const existingInput = this.inputs.find(
-              (input) => input.name === inputName
+              (input) => input.name === inputName,
             );
             if (!existingInput) {
               this._addIOWithoutSubscribing(
                 inputName,
                 type,
                 defaultValue,
-                "input"
+                "input",
               );
             } else {
               existingInput.valueType = type;
@@ -315,7 +339,7 @@ return assembly;
       x,
       xInPixels,
       y,
-      yInPixels
+      yInPixels,
     );
 
     if (distFromClick < this.radius) {

--- a/src/molecules/input.js
+++ b/src/molecules/input.js
@@ -52,6 +52,11 @@ export default class Input extends Atom {
     this.radius = 1 / 75;
 
     /**
+     * Properties for point type inputs
+     */
+    this.pointValue = null;
+
+    /**
      * Properties for import type inputs
      */
     this.fileName = null;
@@ -969,6 +974,8 @@ export default class Input extends Atom {
         "array",
         "boolean",
         "range",
+        "point2d",
+        "point3d",
         "import",
       ],
       onChange: (newType) => {
@@ -1050,6 +1057,82 @@ export default class Input extends Atom {
       };
     }
 
+    // If type is point2d, add controls for x and y coordinates
+    if (this.type === "point2d") {
+      // Initialize pointValue if not set
+      if (this.pointValue === null) {
+        this.pointValue = [0, 0];
+      }
+
+      inputParams[this.uniqueID + "pointX"] = {
+        type: "number",
+        value: this.pointValue[0],
+        label: "X Coordinate",
+        step: 0.1,
+        disabled: false,
+        onChange: (val) => {
+          this.pointValue[0] = val;
+          this.setInputChanged(val);
+        },
+      };
+
+      inputParams[this.uniqueID + "pointY"] = {
+        type: "number",
+        value: this.pointValue[1],
+        label: "Y Coordinate",
+        step: 0.1,
+        disabled: false,
+        onChange: (val) => {
+          this.pointValue[1] = val;
+          this.setInputChanged(val);
+        },
+      };
+    }
+
+    // If type is point3d, add controls for x, y, and z coordinates
+    if (this.type === "point3d") {
+      // Initialize pointValue if not set
+      if (this.pointValue === null) {
+        this.pointValue = [0, 0, 0];
+      }
+
+      inputParams[this.uniqueID + "pointX"] = {
+        type: "number",
+        value: this.pointValue[0],
+        label: "X Coordinate",
+        step: 0.1,
+        disabled: false,
+        onChange: (val) => {
+          this.pointValue[0] = val;
+          this.setInputChanged(val);
+        },
+      };
+
+      inputParams[this.uniqueID + "pointY"] = {
+        type: "number",
+        value: this.pointValue[1],
+        label: "Y Coordinate",
+        step: 0.1,
+        disabled: false,
+        onChange: (val) => {
+          this.pointValue[1] = val;
+          this.setInputChanged(val);
+        },
+      };
+
+      inputParams[this.uniqueID + "pointZ"] = {
+        type: "number",
+        value: this.pointValue[2],
+        label: "Z Coordinate",
+        step: 0.1,
+        disabled: false,
+        onChange: (val) => {
+          this.pointValue[2] = val;
+          this.setInputChanged(val);
+        },
+      };
+    }
+
     // If type is import, add controls for file upload
     if (this.type === "import") {
       if (this.fileName === null) {
@@ -1122,6 +1205,11 @@ export default class Input extends Atom {
     if (this.type === "range") {
       superSerialObject.min = this.min;
       superSerialObject.max = this.max;
+    }
+
+    // Save point coordinates if type is point2d or point3d
+    if (this.type === "point2d" || this.type === "point3d") {
+      superSerialObject.pointValue = this.pointValue;
     }
 
     // Save import-related properties if type is import

--- a/src/prototypes/atom.js
+++ b/src/prototypes/atom.js
@@ -798,6 +798,25 @@ export default class Atom extends ObservableEntity {
         return;
       }
 
+      // Handle point2d and point3d values (which are arrays)
+      if (
+        (ap.valueType === "point2d" || ap.valueType === "point3d") &&
+        Array.isArray(ap.getValue())
+      ) {
+        const currentValue = ap.getValue();
+        const isDifferentFromDefault =
+          !Array.isArray(ap.defaultValue) ||
+          JSON.stringify(ap.defaultValue) !== JSON.stringify(currentValue);
+        const isMoleculeInput = ap.type === "input";
+        if (isDifferentFromDefault || isMoleculeInput) {
+          ioValues.push({
+            name: ap.name,
+            ioValue: currentValue,
+          });
+        }
+        return;
+      }
+
       if (
         typeof ap.getValue() == "number" ||
         typeof ap.getValue() == "string"
@@ -1186,6 +1205,36 @@ export default class Atom extends ObservableEntity {
               if (input.value !== value) {
                 input.setValue(value);
               }
+            },
+          };
+        } else if (input.valueType === "point2d") {
+          // Handle 2D point inputs
+          const displayValue = hasConnector ? input.getValue() : input.value;
+          inputParams[this.uniqueID + input.name] = {
+            type: "point",
+            value: [displayValue?.[0] ?? 0, displayValue?.[1] ?? 0],
+            label: input.name,
+            step: 0.1,
+            disabled: hasConnector,
+            onChange: (value) => {
+              input.setValue([value[0], value[1]]);
+            },
+          };
+        } else if (input.valueType === "point3d") {
+          // Handle 3D point inputs
+          const displayValue = hasConnector ? input.getValue() : input.value;
+          inputParams[this.uniqueID + input.name] = {
+            type: "point",
+            value: [
+              displayValue?.[0] ?? 0,
+              displayValue?.[1] ?? 0,
+              displayValue?.[2] ?? 0,
+            ],
+            label: input.name,
+            step: 0.1,
+            disabled: hasConnector,
+            onChange: (value) => {
+              input.setValue([value[0], value[1], value[2]]);
             },
           };
         } else if (input.valueType === "array") {


### PR DESCRIPTION
I wanted to make it possible for inputs to receive points and pass them to code atoms so i've implemented full support for points which differ from array inputs (which appear to at the top level as select inputs), instead points display 3 inputs for number values. There's a distinction between 2d and 3d points but the input in the parameter menu shows 3 spaces for values (i will fix this later)