### PR TITLE
Fix no project flag

### DIFF
--- a/src/components/main-routes/LoginMode.jsx
+++ b/src/components/main-routes/LoginMode.jsx
@@ -1131,8 +1131,12 @@ const ShowProjects = ({
   };
 
   // Determine if user is new (no projects), triggers animation to draw attention to getting started tab
+  // Only trigger when search is empty - a search with no results should not be treated as "no projects"
   const isNewUser =
-    !isLoadingUser && myRepos && (!myRepos.repos || myRepos.repos.length === 0);
+    !isLoadingUser &&
+    !search &&
+    myRepos &&
+    (!myRepos.repos || myRepos.repos.length === 0);
 
   const navigate = useNavigate();
   const { start, isActive } = useTutorial();


### PR DESCRIPTION
Only trigger animation if the user truly has no projects. Before if the user used the search bar and no projects were found, the getting started animation got triggered. Now we check whether the search is empty to make sure that it's not simply a failed search.