### PR TITLE
Fixes race which sometimes caused errors downstream of code atoms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,8 @@
         "esbuild": "^0.25.9",
         "eslint": "^9.39.2",
         "gh-pages": "^6.2.0",
+        "typescript": "^6.0.3",
+        "typescript-eslint": "^8.59.0",
         "vite": "^5.1.6",
         "vite-plugin-node-polyfills": "^0.23.0",
         "vite-plugin-pages": "^0.32.3",
@@ -4589,6 +4591,301 @@
       "optional": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
+      "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/type-utils": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.59.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
+      "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
+      "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.0",
+        "@typescript-eslint/types": "^8.59.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
+      "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
+      "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
+      "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
+      "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
+      "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.59.0",
+        "@typescript-eslint/tsconfig-utils": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
+      "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
+      "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@uiw/codemirror-extensions-basic-setup": {
@@ -10235,13 +10532,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -12076,14 +12373,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -12241,6 +12538,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -12333,6 +12643,44 @@
       "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
       "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
       "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.0.tgz",
+      "integrity": "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.59.0",
+        "@typescript-eslint/parser": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
     },
     "node_modules/ufo": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test": "node Puppet/index.js",
     "test:metrics": "node Puppet/metrics.js",
     "coverage": "vitest run --coverage",
-    "unit": "vitest --config=vitest.browser.config.ts"
+    "unit": "vitest --config=vitest.browser.config.ts",
+    "lint": "eslint src/**/*.ts src/**/*.tsx"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -74,6 +75,8 @@
     "esbuild": "^0.25.9",
     "eslint": "^9.39.2",
     "gh-pages": "^6.2.0",
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.59.0",
     "vite": "^5.1.6",
     "vite-plugin-node-polyfills": "^0.23.0",
     "vite-plugin-pages": "^0.32.3",

--- a/src/worker/code.ts
+++ b/src/worker/code.ts
@@ -396,7 +396,7 @@ async function executeCode(
     if (isPrimitive(rawResult) || Array.isArray(rawResult)) {
       // Clean up the warm cache without caching the result
       // Primitive and array (point) results are not cached - only geometry results are cached
-      util.geometryProvider!.cleanupBatchWithoutCaching(context);
+      await util.geometryProvider!.cleanupBatchWithoutCaching(context);
       return rawResult;
     }
 
@@ -407,7 +407,7 @@ async function executeCode(
       context,
       cacheId,
     );
-    util.geometryProvider!.endBatchOperation(context, abundanceObj);
+    await util.geometryProvider!.endBatchOperation(context, abundanceObj);
     return abundanceObj;
   } catch (error) {
     console.error("Code execution error:", error);

--- a/src/worker/geometryProvider.ts
+++ b/src/worker/geometryProvider.ts
@@ -79,25 +79,32 @@ class GeometryProvider {
       if (this.projectLRU.length > this.MAX_PROJECTS) {
         this.projectLRU.shift();
       }
-      getAllProjectIds().then(async (allIds) => {
-        if (allIds.size <= this.MAX_PROJECTS) {
-          return;
-        }
-        const evictIds = Array.from(allIds).filter(
-          (id) => !this.projectLRU.includes(id)
-        );
-        for (const evictId of evictIds) {
-          await deleteProjectCache(evictId);
-        }
-      });
+      // We specifically don't await this async task since cleanup
+      // of old projects can happen slowly in the back ground and
+      // doesn't need to block other cache operations.
+      void this.evictProjectsBesides(new Set(this.projectLRU));
     }
+  }
+
+  private evictProjectsBesides(projectIds: Set<string>) {
+    return getAllProjectIds().then(async (allIds) => {
+      if (allIds.size <= this.MAX_PROJECTS) {
+        return;
+      }
+      const evictIds = Array.from(allIds).filter(
+        (id) => !this.projectLRU.includes(id),
+      );
+      for (const evictId of evictIds) {
+        await deleteProjectCache(evictId);
+      }
+    });
   }
 
   // Returns the id of the geometry once it's been added to the cache.
   private async createIfAbsent(
     id: string,
     context: RequestContext,
-    builder: () => Promise<ReplicadObject | undefined>
+    builder: () => Promise<ReplicadObject | undefined>,
   ): Promise<string | undefined> {
     this.updateLRU(context.project);
     if (
@@ -128,7 +135,7 @@ class GeometryProvider {
 
   private getFromWarmCache(
     id: string,
-    context: RequestContext
+    context: RequestContext,
   ): ReplicadObject | undefined {
     if (!context.operationId) {
       return undefined;
@@ -146,7 +153,7 @@ class GeometryProvider {
   private putInWarmCache(
     id: string,
     operationId: string,
-    geometry: ReplicadObject
+    geometry: ReplicadObject,
   ) {
     const operationCache = this.warmCache.get(operationId);
     if (!operationCache) {
@@ -178,8 +185,8 @@ class GeometryProvider {
       console.trace("Cache miss for id:", id);
       throw new Error(
         `Geometry with ID ${id} not found in cache, context: ${JSON.stringify(
-          context
-        )}`
+          context,
+        )}`,
       );
     }
     let result = undefined;
@@ -216,7 +223,7 @@ class GeometryProvider {
    */
   async sweepCache(
     idsToRetain: Set<string>,
-    context: RequestContext
+    context: RequestContext,
   ): Promise<number> {
     // Step 1: filter geometries based on key since that's a much faster approach
     // and we don't need access to the geom values.
@@ -226,7 +233,7 @@ class GeometryProvider {
       "ReplicadObject",
       (shapeKey: string) => {
         return idsToRetain.has(shapeKey);
-      }
+      },
     );
     const geomTime = performance.now() - s;
 
@@ -247,7 +254,7 @@ class GeometryProvider {
           } catch (e) {
             console.error(
               "Failed to parse AbundanceObject. Deleting from cache: ",
-              e
+              e,
             );
             return false; // delete malformed assemblies
           }
@@ -256,7 +263,7 @@ class GeometryProvider {
         console.warn("Received no value for AbundanceObject:", shapeKey);
         return false;
       },
-      true
+      true,
     );
 
     const assemblyTime = performance.now() - s - geomTime;
@@ -272,7 +279,7 @@ class GeometryProvider {
   async drawRectangle(
     x: number,
     y: number,
-    context: RequestContext
+    context: RequestContext,
   ): Promise<string> {
     const id = this._makeId("rectangle", x, y);
     await this.createIfAbsent(id, context, () => {
@@ -292,7 +299,7 @@ class GeometryProvider {
   async drawPolysides(
     radius: number,
     numberOfSides: number,
-    context: RequestContext
+    context: RequestContext,
   ): Promise<string> {
     const id = this._makeId("polysides", radius, numberOfSides);
     await this.createIfAbsent(id, context, () => {
@@ -304,7 +311,7 @@ class GeometryProvider {
   async drawText(
     text: string,
     options: any,
-    context: RequestContext
+    context: RequestContext,
   ): Promise<string> {
     const id = this._makeId("text", text, options);
     await this.createIfAbsent(id, context, async () => {
@@ -315,7 +322,7 @@ class GeometryProvider {
 
   async expandCompoundShape(
     id: string,
-    context: RequestContext
+    context: RequestContext,
   ): Promise<string[]> {
     const compound = await this.get(id, context);
     if (!(compound instanceof replicad.Compound)) {
@@ -343,7 +350,7 @@ class GeometryProvider {
     inputId: string,
     plane: SimplePlane,
     height: number,
-    context: RequestContext
+    context: RequestContext,
   ): Promise<string> {
     const extrudedId = this._makeId("extrude", inputId, plane, height);
     await this.createIfAbsent(extrudedId, context, async () => {
@@ -364,7 +371,7 @@ class GeometryProvider {
     dx: number,
     dy: number,
     dz: number,
-    context: RequestContext
+    context: RequestContext,
   ): Promise<string> {
     const movedId = this._makeId("move", id, dx, dy, dz);
     await this.createIfAbsent(movedId, context, async () => {
@@ -379,7 +386,7 @@ class GeometryProvider {
     x: number,
     y: number,
     z: number,
-    context: RequestContext
+    context: RequestContext,
   ): Promise<string> {
     const rotateId = this._makeId("rotate", id, x, y, z);
     await this.createIfAbsent(rotateId, context, async () => {
@@ -400,7 +407,7 @@ class GeometryProvider {
   async scale(
     id: string,
     scaleFactor: number,
-    context: RequestContext
+    context: RequestContext,
   ): Promise<string> {
     const scaleId = this._makeId("scale", id, scaleFactor);
     await this.createIfAbsent(scaleId, context, async () => {
@@ -413,7 +420,7 @@ class GeometryProvider {
   async fillet(
     id: string,
     radius: number,
-    context: RequestContext
+    context: RequestContext,
   ): Promise<string> {
     const filletId = this._makeId("fillet", id, radius);
     await this.createIfAbsent(filletId, context, async () => {
@@ -429,7 +436,7 @@ class GeometryProvider {
   async chamfer(
     id: string,
     size: number,
-    context: RequestContext
+    context: RequestContext,
   ): Promise<string> {
     const chamferId = this._makeId("chamfer", id, size);
     await this.createIfAbsent(chamferId, context, async () => {
@@ -472,7 +479,7 @@ class GeometryProvider {
   async intersect(
     input1ID: string,
     inputID2: string,
-    context: RequestContext
+    context: RequestContext,
   ): Promise<string | undefined> {
     const id = this._makeId("intersect", input1ID, inputID2);
     return await this.createIfAbsent(id, context, async () => {
@@ -496,7 +503,7 @@ class GeometryProvider {
           "Invalid types for intersection: " +
             typeof args[0] +
             " and " +
-            typeof args[1]
+            typeof args[1],
         );
       }
     });
@@ -506,7 +513,7 @@ class GeometryProvider {
   async fuse(
     input1ID: string,
     inputID2: string,
-    context: RequestContext
+    context: RequestContext,
   ): Promise<string> {
     const sortedArgs = [input1ID, inputID2].sort();
     const resultId = this._makeId("fuse", sortedArgs[0], sortedArgs[1]);
@@ -526,7 +533,7 @@ class GeometryProvider {
           "Invalid types for fusion: " +
             typeof args[0] +
             " and " +
-            typeof args[1]
+            typeof args[1],
         );
       }
     });
@@ -535,7 +542,7 @@ class GeometryProvider {
 
   async assemblyFuse(
     assembly: AbundanceObject,
-    context: RequestContext
+    context: RequestContext,
   ): Promise<string> {
     const partIds = flattenAssembly(assembly).map((part) => part.geometry);
     if (partIds.length === 1) {
@@ -544,7 +551,7 @@ class GeometryProvider {
     const id = this._makeId("assemblyFuse", ...partIds.sort());
     await this.createIfAbsent(id, context, async () => {
       const shapes = await Promise.all(
-        partIds.map((partId) => this.get(partId, context))
+        partIds.map((partId) => this.get(partId, context)),
       );
 
       let result = undefined;
@@ -576,7 +583,7 @@ class GeometryProvider {
   async cut(
     toCut: string,
     cutter: string,
-    context: RequestContext
+    context: RequestContext,
   ): Promise<string> {
     const toCutGeom = await this.get(toCut, context);
     if (toCutGeom instanceof replicad.Wire) {
@@ -618,7 +625,7 @@ class GeometryProvider {
   async startBatchOperation(
     context: RequestContext,
     id: string,
-    persistIntermediates: boolean = false
+    persistIntermediates: boolean = false,
   ): Promise<AbundanceObject | RequestContext> {
     const batchId = "batch-" + id;
 
@@ -637,7 +644,7 @@ class GeometryProvider {
 
   async endBatchOperation(
     context: RequestContext,
-    result: AbundanceObject
+    result: AbundanceObject,
   ): Promise<void> {
     if (!context.operationId) {
       throw new Error("provided context is not a batch operation " + context);
@@ -652,14 +659,14 @@ class GeometryProvider {
           await putShape(
             context.project,
             leaf.geometry,
-            this.getFromWarmCache(leaf.geometry, context)!.serialize()
+            this.getFromWarmCache(leaf.geometry, context)!.serialize(),
           );
         } else {
           // check that it's already in the serialized cache
           const exists = await shapeExists(context.project, leaf.geometry);
           if (!exists) {
             throw new Error(
-              "Batch operation references unknown geometry: " + leaf.geometry
+              "Batch operation references unknown geometry: " + leaf.geometry,
             );
           }
         }
@@ -685,7 +692,7 @@ class GeometryProvider {
   async shrinkWrapSketches(
     compositeSketchId: string,
     points: number,
-    context: RequestContext
+    context: RequestContext,
   ) {
     const shrinkWrapId = this._makeId("shrinkWrap", compositeSketchId, points);
     await this.createIfAbsent(shrinkWrapId, context, async () => {
@@ -699,7 +706,7 @@ class GeometryProvider {
   async loftSketches(
     sketchIds: string[],
     planes: SimplePlane[],
-    context: RequestContext
+    context: RequestContext,
   ): Promise<string> {
     if (sketchIds.length != planes.length) {
       throw new Error("Number of sketches and planes must match");
@@ -710,14 +717,14 @@ class GeometryProvider {
       for (let i = 0; i < sketchIds.length; i++) {
         let partObj = (await this.get(
           sketchIds[i],
-          context
+          context,
         )) as replicad.Drawing;
         let sketchedpart = partObj.sketchOnPlane(asReplicadPlane(planes[i]));
         if (!("sketches" in sketchedpart)) {
           sketches.push(sketchedpart);
         } else {
           throw new Error(
-            "Sketches to be lofted can't have interior geometries"
+            "Sketches to be lofted can't have interior geometries",
           );
         }
       }
@@ -738,7 +745,7 @@ class GeometryProvider {
     geometry: ReplicadObject,
     context: RequestContext,
     operationName: string,
-    operationArgs: any[]
+    operationArgs: any[],
   ) {
     const id: string = this._makeId(operationName, ...operationArgs);
     await this.createIfAbsent(id, context, () => Promise.resolve(geometry));
@@ -752,14 +759,14 @@ class GeometryProvider {
   async cacheAssemblyStructure(
     id: string,
     assembly: AbundanceObject,
-    context: RequestContext
+    context: RequestContext,
   ): Promise<void> {
     return await putShape(context.project, id, JSON.stringify(assembly), true);
   }
 
   async getAssembly(
     id: string,
-    context: RequestContext
+    context: RequestContext,
   ): Promise<AbundanceObject | undefined> {
     return await getShape(context.project, id).then((shape) => {
       if (shape && shape.type == "AbundanceObject") {


### PR DESCRIPTION
Context:
code atoms are implemented as a batch operation. At the end of this operation the user might return an assembly. In this case we need to promote all geometries in that assembly from the transient batch operation cache (a warm cache) into the permanent geometry cache so that they'll be accessible to downstream operations.

This PR adds two missing "await"s in `code.ts` were allowing code atoms to sometimes return while the geometry promotion was still in progress. This in turn caused race-condition failures downstream of the following atoms tried to retrieve those shapes before the async promotion was finished.

Additionally, I've added a linter which flags dropped promises. Runnable with `npm run lint` but note that it's not yet integrated into our build checks (eg: it'd be nice to have lint failures be caught in a github PR vs relying on devs to remember to run the linter for every change). And the changes in geometryProvider address the one other issue this linter caught, though in that case the dropped promise is working as intended so I've just restructured and added a comment to clarify.