### PR TITLE
add some info to github molecule

### DIFF
--- a/src/js/projectNameUtils.js
+++ b/src/js/projectNameUtils.js
@@ -1,6 +1,6 @@
 /**
  * Utility functions for converting project names between display format and GitHub format.
- * 
+ *
  * GitHub repositories cannot contain spaces, so we replace them with underscores.
  * For display purposes, we convert underscores back to spaces.
  */
@@ -8,7 +8,7 @@
 /**
  * Convert a project name from display format to GitHub format.
  * Replaces all spaces with underscores.
- * 
+ *
  * @param {string} displayName - The project name as entered by the user (may contain spaces)
  * @returns {string} The project name formatted for GitHub (spaces replaced with underscores)
  * @example
@@ -16,16 +16,16 @@
  * convertToGithubName("My_Project") // returns "My_Project"
  */
 export function convertToGithubName(displayName) {
-  if (!displayName || typeof displayName !== 'string') {
+  if (!displayName || typeof displayName !== "string") {
     return displayName;
   }
-  return displayName.replace(/\s+/g, '_');
+  return displayName.replace(/\s+/g, "_");
 }
 
 /**
  * Convert a project name from GitHub format to display format.
  * Replaces all underscores with spaces.
- * 
+ *
  * @param {string} githubName - The project name from GitHub (may contain underscores)
  * @returns {string} The project name formatted for display (underscores replaced with spaces)
  * @example
@@ -33,8 +33,43 @@ export function convertToGithubName(displayName) {
  * convertToDisplayName("My Project") // returns "My Project"
  */
 export function convertToDisplayName(githubName) {
-  if (!githubName || typeof githubName !== 'string') {
+  if (!githubName || typeof githubName !== "string") {
     return githubName;
   }
-  return githubName.replace(/_/g, ' ');
+  return githubName.replace(/_/g, " ");
+}
+
+/**
+ * Convert Gregorian ordinal date to JavaScript Date object.
+ * Python's datetime.toordinal() counts days since January 1, year 1.
+ * @param {number|string} ordinalDate - Ordinal date (e.g., 739692 for April 27, 2026)
+ * @returns {Date} JavaScript Date object
+ */
+export function convertOrdinalDateToDate(ordinalDate) {
+  if (!ordinalDate) return null;
+
+  // Convert to number if it's a string
+  const ordinal =
+    typeof ordinalDate === "string" ? parseInt(ordinalDate, 10) : ordinalDate;
+
+  if (isNaN(ordinal)) return null;
+
+  // Create a date from the ordinal by counting days from year 1
+  // JavaScript's Date epoch is January 1, 1970 (ordinal day 719163)
+  const JAVASCRIPT_EPOCH_ORDINAL = 719163;
+  const daysSinceEpoch = ordinal - JAVASCRIPT_EPOCH_ORDINAL;
+
+  // Create date from milliseconds
+  return new Date(daysSinceEpoch * 24 * 60 * 60 * 1000);
+}
+
+/**
+ * Convert ordinal date to locale string.
+ * @param {number|string} ordinalDate - Ordinal date number
+ * @returns {string} Formatted date string
+ */
+export function formatOrdinalDate(ordinalDate) {
+  if (!ordinalDate) return "N/A";
+  const date = convertOrdinalDateToDate(ordinalDate);
+  return date ? date.toLocaleString() : "N/A";
 }

--- a/src/molecules/cutlayout.js
+++ b/src/molecules/cutlayout.js
@@ -365,7 +365,7 @@ export default class CutLayout extends Atom {
     } else {
       // No saved placements, set to waiting and wait for user to compute layout with the new geometry.
       this.setStatus(Status.WAITING);
-      console.trace("No saved placements, waiting for user to compute layout.");
+      console.log("No saved placements, waiting for user to compute layout.");
     }
   }
 

--- a/src/molecules/gcode.js
+++ b/src/molecules/gcode.js
@@ -210,7 +210,10 @@ export default class Gcode extends Atom {
         const resultWire = await this._generateSequentialGcode([inputGeometry]);
       }
     } catch (err) {
-      console.error("Error generating G-code:", err);
+      console.error(
+        "Error generating G-code in " + this.getAtomPath() + ":",
+        err,
+      );
       this.setError(err);
       this.progress = 1.0;
       this.processing = false;
@@ -244,7 +247,10 @@ export default class Gcode extends Atom {
         await this._processSinglePart(inputID);
       }
     } catch (err) {
-      console.error("Error handling geometry input:", err);
+      console.error(
+        "Error handling geometry input in " + this.getAtomPath() + ":",
+        err,
+      );
       this.setError(err);
     }
   }
@@ -273,8 +279,7 @@ export default class Gcode extends Atom {
     /* Find flat faces for area operation */
     GlobalVariables.cad
       .findFlatFaces(scaledMesh, this.getContext())
-      .then((flatFaces) => {
-      });
+      .then((flatFaces) => {});
     // Export the geometry to STL and generate G-code
     GlobalVariables.cad
       .visExport(scaledMesh, "STL", this.getContext())
@@ -742,14 +747,16 @@ export default class Gcode extends Atom {
       return;
     }
 
-    // Check if geometry input is ready
-    const geometryValue = this.findIOValue("geometry");
-    if (geometryValue !== null) {
-      this.setWaiting();
-      // Always call _generateGcode so concurrency guard and pending logic are respected
-      this._generateGcode();
+    // Only generate gcode if all inputs are ready
+    if (this.inputsAreReady()) {
+      const geometryValue = this.findIOValue("geometry");
+      if (geometryValue !== null) {
+        this.setWaiting();
+        // Always call _generateGcode so concurrency guard and pending logic are respected
+        this._generateGcode();
+      }
     } else {
-      // If geometry is not available yet, set to waiting
+      // If not all inputs are ready, set to waiting
       this.setWaiting();
     }
   }

--- a/src/molecules/githubmolecule.js
+++ b/src/molecules/githubmolecule.js
@@ -3,6 +3,7 @@ import GlobalVariables from "../js/globalvariables.js";
 import { Octokit } from "octokit";
 
 import { Status } from "../prototypes/observableEntity.js";
+import { formatOrdinalDate } from "../js/projectNameUtils.js";
 
 /**
  * This class creates the GitHubMolecule atom.
@@ -118,6 +119,19 @@ export default class GitHubMolecule extends Molecule {
   createInputParams(setInputChanged, authorizedUserOcto, userScopes) {
     let inputParams = {};
     inputParams = super.createInputParams();
+    inputParams["ParentInfo"] = {
+      type: "string",
+      label: "Parent Repository",
+      value: `${this.parentRepo.owner}/${this.parentRepo.repoName}`,
+      disabled: true,
+    };
+    inputParams["Last Modified"] = {
+      type: "string",
+      label: "Last Modified",
+      value: formatOrdinalDate(this.parentRepo.dateModified),
+      disabled: true,
+    };
+    console.log(this.parentRepo.dateModified);
     inputParams["Reload From Github"] = {
       type: "button",
       label: "Reload From Github",
@@ -164,7 +178,14 @@ export default class GitHubMolecule extends Molecule {
         },
       );
     } catch (error) {
-      window.dispatchEvent(new CustomEvent('user-notification', { detail: { message: `Cannot reload: the repository "${gitObj.owner}/${gitObj.repoName}" could not be found or accessed.`, type: 'error' } }));
+      window.dispatchEvent(
+        new CustomEvent("user-notification", {
+          detail: {
+            message: `Cannot reload: the repository "${gitObj.owner}/${gitObj.repoName}" could not be found or accessed.`,
+            type: "error",
+          },
+        }),
+      );
       return;
     }
 

--- a/src/prototypes/atom.js
+++ b/src/prototypes/atom.js
@@ -427,7 +427,7 @@ export default class Atom extends ObservableEntity {
    */
   alertingErrorHandler() {
     return (err) => {
-      console.error("Error in atom: " + this.name);
+      console.error("Error in atom: " + this.getAtomPath());
       console.error(err);
       this.setError(err || "Unknown error occurred");
     };
@@ -933,8 +933,28 @@ export default class Atom extends ObservableEntity {
     if (err instanceof Error) {
       err = err.message;
     }
-    this.alert = { type: AlertType.ERROR, message: String(err) };
+    const path = this.getAtomPath();
+    const message = path ? `[${path}] ${err}` : String(err);
+    this.alert = { type: AlertType.ERROR, message };
     this.setStatus(Status.ERROR);
+  }
+
+  /**
+   * Get the full path of this atom in the molecule hierarchy.
+   * Example: "top level/molecule1/moleculemimi/code"
+   * @returns {string} The full path of this atom
+   */
+  getAtomPath() {
+    const path = [];
+    let current = this;
+
+    // Walk up the parent chain
+    while (current) {
+      path.unshift(current.name || current.atomType || "unknown");
+      current = current.parent || current.parentMolecule;
+    }
+
+    return path.join("/");
   }
 
   /**
@@ -1771,7 +1791,7 @@ export default class Atom extends ObservableEntity {
     if (unresolved.length) {
       const msg = `Variable(s) not found: ${unresolved.join(
         ", ",
-      )}. Make sure the variables you are using exist as inputs`;
+      )}. Make sure the variables you are using exist as inputs in ${this.getAtomPath()}`;
       console.warn(msg);
       throw new Error(msg);
     } else {


### PR DESCRIPTION
- Adds extra inputs to the param menu of github molecule to make it clear what repo and parent its loading from
- Adds getAtomPath method to be able to add path to error messages and more easily track error provenance
- Makes sure the gcode atom waits for its inputs to be ready before computing