### PR TITLE
bugs + PREVIEW navigation 

### DIFF
--- a/KirimotoUpdate.js
+++ b/KirimotoUpdate.js
@@ -257,7 +257,6 @@ const generateGcode = (
         return eng.export();
       })
       .then((gcode) => {
-        console.log("G-code generated successfully.");
         resolve(gcode);
       })
       .catch((error) => {

--- a/src/components/main-routes/CreateMode.jsx
+++ b/src/components/main-routes/CreateMode.jsx
@@ -75,7 +75,8 @@ function CreateMode() {
     searchGithubMolecules,
     saveProject: saveProjectFromContext,
   } = useProject();
-  const { uploadFile, deleteFile, fetchFileContent, fetchRawFileContent } = useFileImport();
+  const { uploadFile, deleteFile, fetchFileContent, fetchRawFileContent } =
+    useFileImport();
   const meshRef = useRef();
 
   // Make meshRef, file import functions, and save function available globally
@@ -96,6 +97,17 @@ function CreateMode() {
   }, [uploadFile, deleteFile, fetchFileContent, fetchRawFileContent]);
 
   const navigate = useNavigate();
+  const { owner, repoName } = useParams();
+
+  // Update GlobalVariables when route params change (triggers FlowCanvas to reload project)
+  useEffect(() => {
+    if (owner && repoName) {
+      GlobalVariables.currentAWSnode = {
+        owner,
+        repoName,
+      };
+    }
+  }, [owner, repoName]);
 
   /** State for user notification */
   const [userNotification, setUserNotificationRaw] = useState(null);
@@ -743,6 +755,7 @@ function CreateMode() {
             }}
           />
           <FlowCanvas
+            key={`${owner}-${repoName}`}
             {...{
               activeAtom,
               authorizedUserOcto,
@@ -771,13 +784,11 @@ function CreateMode() {
       );
     } else {
       // Fallback: navigate to run mode if repo is still missing
-      const { owner, repoName } = useParams();
       navigate(`/run/${owner}/${repoName}`);
     }
   } else {
     /** get repository from github by the id in the url */
     console.warn("You are not logged in");
-    const { owner, repoName } = useParams();
     //try reauthenticating
     authRedirectHandler({
       redirectType: "reauth",

--- a/src/components/main-routes/PreviewCreateMode.jsx
+++ b/src/components/main-routes/PreviewCreateMode.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef } from "react";
 import GlobalVariables from "../../js/globalvariables.js";
+import Molecule from "../../molecules/molecule.js";
 import ToggleRunCreate from "../secondary/ToggleRunCreate.jsx";
 import FlowCanvas from "./flowCanvas.jsx";
 import LowerHalf from "./lowerHalf.jsx";
@@ -91,6 +92,51 @@ function PreviewCreateMode() {
 
   /** State for top level molecule */
   const [currentMoleculeTop, setTop] = useState(false);
+
+  /** Load project when URL params change */
+  useEffect(() => {
+    // Check if project is already loaded
+    if (
+      GlobalVariables.currentAWSnode &&
+      GlobalVariables.currentAWSnode.repoName === repoName &&
+      GlobalVariables.loadedRepo?.name === repoName
+    ) {
+      // Project already loaded, just set up the view
+      GlobalVariables.currentMolecule = GlobalVariables.topLevelMolecule;
+      GlobalVariables.currentMolecule.selected = true;
+      setActiveAtom(GlobalVariables.currentMolecule);
+    } else {
+      // Project not loaded - fetch from AWS and load it
+      GlobalVariables.resetView();
+      fetch(
+        `https://hg5gsgv9te.execute-api.us-east-2.amazonaws.com/abundance-stage/fetchSingleRepo?owner=${owner}&repoName=${repoName}`,
+      )
+        .then((res) => res.json())
+        .then((data) => {
+          if (data && data.item) {
+            GlobalVariables.currentAWSnode = data.item;
+
+            // Load a blank project
+            GlobalVariables.topLevelMolecule = new Molecule({
+              x: 0,
+              y: 0,
+              topLevel: true,
+              atomType: "Molecule",
+            });
+            GlobalVariables.currentMolecule = GlobalVariables.topLevelMolecule;
+            GlobalVariables.currentMolecule.selected = true;
+            loadProject(GlobalVariables.currentAWSnode);
+            setActiveAtom(GlobalVariables.currentMolecule);
+          }
+        })
+        .catch((e) => {
+          console.error("Error loading preview project:", e);
+          setNotification("Can't load project: " + (e.message || e), "error");
+          setTimeout(() => setNotification(null), 5000);
+          navigate("/");
+        });
+    }
+  }, [owner, repoName]);
 
   const solidParamRef = useRef(solidParam);
   useEffect(() => {
@@ -289,11 +335,12 @@ function PreviewCreateMode() {
         <img
           className={
             "thumnail-logo" +
-            (userScopes && userScopes.includes("repo") ? " logo-private-scope" : "")
+            (userScopes && userScopes.includes("repo")
+              ? " logo-private-scope"
+              : "")
           }
           src={
-            import.meta.env.VITE_APP_PATH_FOR_PICS +
-            "/imgs/abundance_logo.png"
+            import.meta.env.VITE_APP_PATH_FOR_PICS + "/imgs/abundance_logo.png"
           }
           alt="logo"
           onClick={() => navigate("/")}

--- a/src/components/main-routes/PreviewCreateMode.jsx
+++ b/src/components/main-routes/PreviewCreateMode.jsx
@@ -6,6 +6,7 @@ import FlowCanvas from "./flowCanvas.jsx";
 import LowerHalf from "./lowerHalf.jsx";
 import CodeWindow from "../secondary/codeWindow.jsx";
 import { useParams, useNavigate } from "react-router-dom";
+import GoUpLevelButton from "../secondary/GoUpLevelButton.jsx";
 
 import ParamsMenu from "../secondary/ParamsMenu.jsx";
 import RenderMenu from "../secondary/RenderMenu.jsx";
@@ -319,6 +320,7 @@ function PreviewCreateMode() {
         setActiveAtom={setActiveAtom}
       />
       <CodeWindow {...{ activeAtom }} />
+      {!GlobalVariables.currentMolecule.topLevel ? <GoUpLevelButton /> : null}
       <FlowCanvas
         {...{
           activeAtom,

--- a/src/components/main-routes/PreviewCreateMode.jsx
+++ b/src/components/main-routes/PreviewCreateMode.jsx
@@ -297,40 +297,6 @@ function PreviewCreateMode() {
         initialCollapsed={true}
         collapsedOffset={[45, 0]}
       />
-      <RenderMenu
-        {...{
-          contentCollapsed: expandedMenu !== "render",
-          setContentCollapsed: () => setExpandedMenu("render"),
-          position: { top: screenHeight / 2 + 35, left: 10 },
-          collapsedOffset: [45, -45],
-          closeMenu: () => setExpandedMenu("none"),
-        }}
-        id={"atom-create-render-panel"}
-      />
-      <BomMenu
-        {...{
-          id: "atom-bom-panel",
-          contentCollapsed: expandedMenu !== "bom",
-          setContentCollapsed: () => setExpandedMenu("bom"),
-          closeMenu: () => setExpandedMenu("none"),
-          position: { top: screenHeight / 2 + 80, left: 10 },
-          collapsedOffset: [45, -90],
-        }}
-      />
-      <GitSearchMenu
-        {...{
-          activeAtom,
-          id: "atom-git-search-panel",
-          contentCollapsed: expandedMenu !== "git-search",
-          setContentCollapsed: () => setExpandedMenu("git-search"),
-          closeMenu: () => setExpandedMenu("none"),
-          setParamsMenuExpanded: () => setExpandedMenu("params"),
-          position: { top: screenHeight / 2 + 125, left: 10 },
-          collapsedOffset: [45, -135],
-          gitRef: gitRef,
-          setUserNotification: (msg, type) => setNotification(msg, type),
-        }}
-      />
       <div id="headerBar">
         <img
           className={
@@ -373,6 +339,7 @@ function PreviewCreateMode() {
           windowSize,
           redirectType,
           saveProject: null,
+          isPreview: true,
         }}
       />
       <div className="parent flex-parent" id="lowerHalf">

--- a/src/components/main-routes/flowCanvas.jsx
+++ b/src/components/main-routes/flowCanvas.jsx
@@ -394,17 +394,16 @@ export default memo(function FlowCanvas({
         );
       }
 
-      GlobalVariables.atomsSelected = [];
-      //Adds items to the  array that we will use to delete
-      GlobalVariables.currentMolecule.copy();
-      GlobalVariables.atomsSelected.forEach((item) => {
-        GlobalVariables.currentMolecule.nodesOnTheScreen.forEach(
-          (nodeOnTheScreen) => {
-            if (nodeOnTheScreen.uniqueID == item.uniqueID) {
-              nodeOnTheScreen.deleteNode();
-            }
-          },
-        );
+      // Delete selected atoms without clearing the clipboard (atomsSelected)
+      // Use a local variable instead of reusing atomsSelected which stores copied atoms
+      const atomsToDelete = [];
+      GlobalVariables.currentMolecule.nodesOnTheScreen.forEach((atom) => {
+        if (atom.selected) {
+          atomsToDelete.push(atom);
+        }
+      });
+      atomsToDelete.forEach((item) => {
+        item.deleteNode();
       });
       //every time a key is pressed
       GlobalVariables.currentMolecule.nodesOnTheScreen.forEach((molecule) => {
@@ -618,8 +617,7 @@ export default memo(function FlowCanvas({
             },
             false, // Don't pass to undo
           )
-          .then((newAtom) => {
-          });
+          .then((newAtom) => {});
       }
 
       if (!clickHandledByMolecule) {

--- a/src/components/main-routes/flowCanvas.jsx
+++ b/src/components/main-routes/flowCanvas.jsx
@@ -21,6 +21,7 @@ export default memo(function FlowCanvas({
   saveProject,
   setSaveState,
   setSavePopUp,
+  isPreview = false,
 }) {
   /** State for github molecule search input */
   const [isHovering, setIsHovering] = useState(false);
@@ -589,7 +590,7 @@ export default memo(function FlowCanvas({
       longPressTimer.current = null;
     }
 
-    // if it's a right click show the circular menu
+    // if it's a right click show the circular menu (disabled in preview mode)
     var isRightMB;
     if ("which" in event) {
       // Gecko (Firefox), WebKit (Safari/Chrome) & Opera
@@ -600,6 +601,10 @@ export default memo(function FlowCanvas({
     }
     // if it's a right click show the circular menu
     if (isRightMB) {
+      // In preview mode, disable the circular menu
+      if (isPreview) {
+        return;
+      }
       var doubleClick = false;
       // Convert viewport coordinates to canvas-relative coordinates for correct positioning
       const canvasCoords = getCanvasCoordinates(event.clientX, event.clientY);
@@ -843,6 +848,26 @@ export default memo(function FlowCanvas({
           );
         })}
       </div>
+
+      {isPreview && (
+        <div
+          style={{
+            position: "absolute",
+            top: "20px",
+            left: "50%",
+            transform: "translateX(-50%)",
+            fontSize: "24px",
+            fontWeight: "bold",
+            opacity: 0.3,
+            pointerEvents: "none",
+            zIndex: "4",
+            color: "var(---flowCanvas-background)",
+            letterSpacing: "2px",
+          }}
+        >
+          PREVIEW
+        </div>
+      )}
       <div>
         <div id="circle-menu1" className="cn-menu1" ref={circleMenu}></div>
       </div>

--- a/src/components/main-routes/flowCanvas.jsx
+++ b/src/components/main-routes/flowCanvas.jsx
@@ -4,6 +4,8 @@ import Molecule from "../../molecules/molecule.js";
 import { createCMenu, cmenu } from "../../js/NewMenu.js";
 import { DeleteAtomsCommand } from "../../js/undoCommands.js";
 import { useNavigate } from "react-router-dom";
+import NavigateToMoleculeDialog from "../secondary/NavigateToMoleculeDialog.jsx";
+import PreviewMoleculeDialog from "../secondary/PreviewMoleculeDialog.jsx";
 
 export default memo(function FlowCanvas({
   loadProject,
@@ -27,6 +29,15 @@ export default memo(function FlowCanvas({
   /** State for undo notification */
   const [undoNotification, setUndoNotification] = useState(null);
   const [isShortcut, setIsShortcutTriggered] = useState(false);
+
+  /** State for GitHub molecule dialogs */
+  const [navigateDialogOpen, setNavigateDialogOpen] = useState(false);
+  const [previewDialogOpen, setPreviewDialogOpen] = useState(false);
+  const [moleculeDialogData, setMoleculeDialogData] = useState({
+    owner: "",
+    repoName: "",
+    moleculeName: "",
+  });
 
   const canvasRef = useRef(null);
   const circleMenu = useRef(null);
@@ -203,6 +214,47 @@ export default memo(function FlowCanvas({
       canvasRef.current.height = windowSize.height * canvasHeightScale;
     }
   }, [windowSize]);
+
+  /** Handle GitHub molecule navigation and preview dialogs */
+  useEffect(() => {
+    const handleNavigateRequest = (event) => {
+      setMoleculeDialogData({
+        owner: event.detail.owner,
+        repoName: event.detail.repoName,
+        moleculeName: event.detail.moleculeName,
+      });
+      setNavigateDialogOpen(true);
+    };
+
+    const handlePreviewRequest = (event) => {
+      setMoleculeDialogData({
+        owner: event.detail.owner,
+        repoName: event.detail.repoName,
+        moleculeName: event.detail.moleculeName,
+      });
+      setPreviewDialogOpen(true);
+    };
+
+    window.addEventListener(
+      "github-molecule-navigate-request",
+      handleNavigateRequest,
+    );
+    window.addEventListener(
+      "github-molecule-preview-request",
+      handlePreviewRequest,
+    );
+
+    return () => {
+      window.removeEventListener(
+        "github-molecule-navigate-request",
+        handleNavigateRequest,
+      );
+      window.removeEventListener(
+        "github-molecule-preview-request",
+        handlePreviewRequest,
+      );
+    };
+  }, []);
 
   const draw = () => {
     GlobalVariables.c.clearRect(
@@ -806,6 +858,22 @@ export default memo(function FlowCanvas({
           {userNotification}
         </div>
       )}
+
+      {/* GitHub molecule dialogs */}
+      <NavigateToMoleculeDialog
+        isOpen={navigateDialogOpen}
+        onClose={() => setNavigateDialogOpen(false)}
+        owner={moleculeDialogData.owner}
+        repoName={moleculeDialogData.repoName}
+        moleculeName={moleculeDialogData.moleculeName}
+      />
+      <PreviewMoleculeDialog
+        isOpen={previewDialogOpen}
+        onClose={() => setPreviewDialogOpen(false)}
+        owner={moleculeDialogData.owner}
+        repoName={moleculeDialogData.repoName}
+        moleculeName={moleculeDialogData.moleculeName}
+      />
     </>
   );
 });

--- a/src/components/secondary/GoUpLevelButton.jsx
+++ b/src/components/secondary/GoUpLevelButton.jsx
@@ -1,0 +1,27 @@
+import GlobalVariables from "../../js/globalvariables.js";
+import { useAppState } from "../../contexts/index.js";
+
+const GoUpLevelButton = () => {
+  const { setActiveAtom } = useAppState();
+  return (
+    <>
+      <button
+        id="go-up-button"
+        className="nav-bar go-up-button menu-nav-button"
+        onClick={() => {
+          GlobalVariables.currentMolecule.goToParentMolecule();
+          setActiveAtom(GlobalVariables.currentMolecule);
+        }}
+      >
+        <img
+          className="nav-img thumnail-logo"
+          src={import.meta.env.VITE_APP_PATH_FOR_PICS + "/imgs/Go Up.svg"}
+          key=""
+          title=""
+        />
+      </button>
+    </>
+  );
+};
+
+export default GoUpLevelButton;

--- a/src/components/secondary/NavigateToMoleculeDialog.jsx
+++ b/src/components/secondary/NavigateToMoleculeDialog.jsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom";
+import GlobalVariables from "../../js/globalvariables.js";
 
 /**
  * Dialog to confirm navigation to an owned GitHub molecule project
@@ -19,9 +20,12 @@ function NavigateToMoleculeDialog({
 
   const handleNavigate = () => {
     onClose();
+    // Set GlobalVariables before navigating so FlowCanvas has the right project when it mounts
+    GlobalVariables.currentAWSnode = {
+      owner,
+      repoName,
+    };
     navigate(`/${owner}/${repoName}`);
-    // Reload the page to load the target project
-    window.location.reload();
   };
 
   const handleStay = () => {

--- a/src/components/secondary/NewProjectPopUp.jsx
+++ b/src/components/secondary/NewProjectPopUp.jsx
@@ -77,7 +77,7 @@ const validateTopics = (topics) => {
     }
 
     if (cleaned !== topicValue) {
-      errors.push(`Tag "${topicValue}" will be changed to "${cleaned}"`);
+      errors.push(`Tag "${topicValue}" should be changed to "${cleaned}"`);
     }
 
     sanitized.push(cleaned);
@@ -171,11 +171,6 @@ const NewProjectPopUp = ({ setExportPopUp, authorizedUserOcto, exporting }) => {
 
     if (allErrors.length > 0) {
       setValidationErrors(allErrors);
-      // Block submission and show error dialog
-      window.alert(
-        "Please fix the following issues before submitting:\n\n" +
-          allErrors.join("\n"),
-      );
       return; // Do not proceed with submission
     }
 
@@ -225,7 +220,10 @@ const NewProjectPopUp = ({ setExportPopUp, authorizedUserOcto, exporting }) => {
   return (
     <>
       <div className="login-page export-div">
-        <div className="form animate fadeInUp one">
+        <div
+          className="form animate fadeInUp one"
+          style={{ scrollbarGutter: "stable", overflow: "visible" }}
+        >
           <button
             onClick={() => {
               setExportPopUp(false);
@@ -236,6 +234,7 @@ const NewProjectPopUp = ({ setExportPopUp, authorizedUserOcto, exporting }) => {
           </button>
           <form
             className="new-project-form"
+            style={{ scrollbarGutter: "stable", overflow: "visible" }}
             onSubmit={(e) => {
               handleSubmit(e);
             }}
@@ -302,6 +301,9 @@ const NewProjectPopUp = ({ setExportPopUp, authorizedUserOcto, exporting }) => {
               ref={projectTopicRef}
               onKeyDown={(e) => handleKeyDown(e, "topic")}
             />
+
+            <div style={{ borderTop: "1px solid #ccc", padding: "10px 0" }} />
+
             <button className="submit-button" disabled={pending} type="submit">
               {pending ? newProjectBar + "%" : "Submit/Export to Github"}
             </button>

--- a/src/components/secondary/PreviewMoleculeDialog.jsx
+++ b/src/components/secondary/PreviewMoleculeDialog.jsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom";
+import GlobalVariables from "../../js/globalvariables.js";
 
 /**
  * Dialog to preview a GitHub molecule project (for non-owners)
@@ -18,6 +19,19 @@ function PreviewMoleculeDialog({
   const navigate = useNavigate();
 
   const handlePreview = () => {
+    // Store the current project info so we can return to it from preview
+    if (
+      GlobalVariables.currentAWSnode?.owner &&
+      GlobalVariables.currentAWSnode?.repoName
+    ) {
+      sessionStorage.setItem(
+        "previewOriginProject",
+        JSON.stringify({
+          owner: GlobalVariables.currentAWSnode.owner,
+          repoName: GlobalVariables.currentAWSnode.repoName,
+        }),
+      );
+    }
     onClose();
     navigate(`/preview/${owner}/${repoName}`);
   };

--- a/src/components/secondary/PreviewMoleculeDialog.jsx
+++ b/src/components/secondary/PreviewMoleculeDialog.jsx
@@ -1,0 +1,103 @@
+import { useNavigate } from "react-router-dom";
+
+/**
+ * Dialog to preview a GitHub molecule project (for non-owners)
+ * @param {boolean} isOpen - Whether the dialog is open
+ * @param {function} onClose - Function to close the dialog
+ * @param {string} owner - The owner of the GitHub molecule
+ * @param {string} repoName - The repository name of the GitHub molecule
+ * @param {string} moleculeName - The name of the molecule being previewed
+ */
+function PreviewMoleculeDialog({
+  isOpen,
+  onClose,
+  owner,
+  repoName,
+  moleculeName,
+}) {
+  const navigate = useNavigate();
+
+  const handlePreview = () => {
+    onClose();
+    navigate(`/preview/${owner}/${repoName}`);
+  };
+
+  const handleClose = () => {
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <dialog
+      open={isOpen}
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "stretch",
+        padding: "20px",
+        minWidth: "400px",
+      }}
+      className="share-dialog"
+    >
+      <h3 style={{ margin: "0 0 15px 0" }}>Preview Project?</h3>
+
+      <p style={{ margin: "0 0 20px 0" }}>
+        View the project <strong>{moleculeName || repoName}</strong> in preview
+        mode.
+      </p>
+
+      <p style={{ margin: "0 0 20px 0", fontSize: "14px" }}>
+        This will take you to a read-only preview of{" "}
+        <strong>
+          {owner}/{repoName}
+        </strong>
+        . You won't be able to edit it, but you can explore its structure. Would
+        you like to continue?
+      </p>
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "flex-end",
+          gap: "10px",
+          marginTop: "10px",
+        }}
+      >
+        <button
+          onClick={handleClose}
+          autoFocus
+          style={{
+            padding: "8px 16px",
+            cursor: "pointer",
+          }}
+        >
+          Cancel
+        </button>
+        <button
+          onClick={handlePreview}
+          style={{
+            padding: "8px 16px",
+            cursor: "pointer",
+            backgroundColor: "#2196F3",
+            color: "white",
+            border: "none",
+            borderRadius: "4px",
+          }}
+        >
+          Preview Project
+        </button>
+      </div>
+
+      <a
+        className="closeButton"
+        onClick={handleClose}
+        style={{ cursor: "pointer" }}
+      >
+        {"\u00D7"}
+      </a>
+    </dialog>
+  );
+}
+
+export default PreviewMoleculeDialog;

--- a/src/components/secondary/ToggleRunCreate.jsx
+++ b/src/components/secondary/ToggleRunCreate.jsx
@@ -69,7 +69,7 @@ function ToggleRunCreate({ run, isItOwned, isPreview, setActiveAtom }) {
       try {
         const { owner, repoName } = JSON.parse(originProject);
         sessionStorage.removeItem("previewOriginProject");
-        window.location.assign(`/${owner}/${repoName}`);
+        navigate(`/${owner}/${repoName}`);
         return;
       } catch (e) {
         console.error("Error parsing origin project:", e);

--- a/src/components/secondary/ToggleRunCreate.jsx
+++ b/src/components/secondary/ToggleRunCreate.jsx
@@ -62,6 +62,21 @@ function ToggleRunCreate({ run, isItOwned, isPreview, setActiveAtom }) {
     if (setActiveAtom && GlobalVariables.topLevelMolecule) {
       setActiveAtom(GlobalVariables.topLevelMolecule);
     }
+
+    // If coming from preview of a project, return to the original project in create mode
+    const originProject = sessionStorage.getItem("previewOriginProject");
+    if (isPreview && originProject) {
+      try {
+        const { owner, repoName } = JSON.parse(originProject);
+        sessionStorage.removeItem("previewOriginProject");
+        window.location.assign(`/${owner}/${repoName}`);
+        return;
+      } catch (e) {
+        console.error("Error parsing origin project:", e);
+      }
+    }
+
+    // Default: navigate to preview project's run mode or current repo's run mode
     if (GlobalVariables.currentRepo) {
       navigate(
         `/run/${GlobalVariables.currentRepo.owner.login}/${GlobalVariables.currentRepo.name}`,
@@ -71,8 +86,12 @@ function ToggleRunCreate({ run, isItOwned, isPreview, setActiveAtom }) {
   if (GlobalVariables.currentRepo) {
     if (!runModeon) {
       if (isPreview) {
+        const originProject = sessionStorage.getItem("previewOriginProject");
+        const backButtonTitle = originProject
+          ? "Back to Original Project"
+          : "Back to Run Mode";
         return (
-          <label title="Back to Run Mode" className="back_to_runmode">
+          <label title={backButtonTitle} className="back_to_runmode">
             <button id="back-to-run-mode-btn" onClick={handleBackToRunMode}>
               <svg
                 width="18"
@@ -103,7 +122,7 @@ function ToggleRunCreate({ run, isItOwned, isPreview, setActiveAtom }) {
                     "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
                 }}
               >
-                Back to Run Mode
+                {originProject ? "Back to Project" : "Back to Run Mode"}
               </p>
             </button>
           </label>

--- a/src/components/secondary/TopMenu.jsx
+++ b/src/components/secondary/TopMenu.jsx
@@ -6,6 +6,7 @@ import DuplicateCompleteDialog from "./DuplicateCompleteDialog.jsx";
 import RenameProjectDialog from "./RenameProjectDialog.jsx";
 import { useNavigate } from "react-router-dom";
 import SettingsPopUp from "./SettingsPopUp.jsx";
+import GoUpLevelButton from "./GoUpLevelButton.jsx";
 import {
   useAuth,
   useAppState,
@@ -366,30 +367,6 @@ function TopMenu({
     ],
   );
 
-  //{checks for top level variable and show go-up button if this is not top molecule
-  //i'm not so sure this useeffect is right. put on list to review
-  const TopLevel = () => {
-    return (
-      <>
-        <button
-          id="go-up-button"
-          className="nav-bar go-up-button menu-nav-button"
-          onClick={() => {
-            GlobalVariables.currentMolecule.goToParentMolecule();
-            setActiveAtom(GlobalVariables.currentMolecule);
-          }}
-        >
-          <img
-            className="nav-img thumnail-logo"
-            src={import.meta.env.VITE_APP_PATH_FOR_PICS + "/imgs/Go Up.svg"}
-            key=""
-            title=""
-          />
-        </button>
-      </>
-    );
-  };
-
   /*{nav bar toggle component}*/
   // Use a ref to persist navbar state across re-renders without triggering them
   const navbarOpenRef = useRef(false);
@@ -544,7 +521,7 @@ function TopMenu({
           newProjectRepoName={duplicatedProjectInfo.repoName}
         />
       ) : null}
-      {currentMoleculeTop ? <TopLevel /> : null}
+      {currentMoleculeTop ? <GoUpLevelButton /> : null}
       <Navbar {...{ currentMoleculeTop, renderTrigger: navbarRenderTrigger }} />
     </>
   );

--- a/src/js/undoCommands.js
+++ b/src/js/undoCommands.js
@@ -99,6 +99,27 @@ export class ReplaceConnectionCommand {
 }
 
 /**
+ * Command that reverses the deletion of a single connector.
+ * Stores the connector data so it can be restored via placeConnector().
+ */
+export class DeleteConnectorCommand {
+  constructor(connectorData, parentMolecule) {
+    this.connectorData = connectorData; // {ap1ID, ap2ID, ap2Name}
+    this.parentMolecule = parentMolecule;
+    this.description = "Delete connector";
+  }
+
+  async undo() {
+    GlobalVariables.isUndoing = true;
+    try {
+      this.parentMolecule.placeConnector(this.connectorData);
+    } finally {
+      GlobalVariables.isUndoing = false;
+    }
+  }
+}
+
+/**
  * Command that reverses a parameter value change on an atom.
  * Consecutive changes to the same atom+field are merged so rapid typing
  * produces only a single undo step.

--- a/src/molecules/gcode.js
+++ b/src/molecules/gcode.js
@@ -221,6 +221,7 @@ export default class Gcode extends Atom {
     } finally {
       // Always reset the flag when generation completes
       this.isGenerating = false;
+      console.log("G-code generated successfully in " + this.getAtomPath());
       // If a pending run was queued, run again
       if (this.pendingGeneration) {
         this.pendingGeneration = false;

--- a/src/molecules/githubmolecule.js
+++ b/src/molecules/githubmolecule.js
@@ -147,7 +147,6 @@ export default class GitHubMolecule extends Molecule {
         : "Unknown",
       disabled: true,
     };
-    console.log(this.lastReloadedFromGithubAt);
     inputParams["Reload From Github"] = {
       type: "button",
       label: "Reload From Github",

--- a/src/molecules/githubmolecule.js
+++ b/src/molecules/githubmolecule.js
@@ -74,16 +74,30 @@ export default class GitHubMolecule extends Molecule {
         this.parentRepo &&
         this.parentRepo.owner === GlobalVariables.currentUser
       ) {
-        // User owns this GitHub molecule - allow navigation with confirmation
+        // User owns this GitHub molecule - dispatch navigate request event
         const moleculeName = this.name || this.parentRepo.repoName;
-        const confirmMessage = `Navigate to ${moleculeName}?\n\nThis will take you to the project "${this.parentRepo.owner}/${this.parentRepo.repoName}" and leave your current project.\n\nDo you want to continue?`;
-
-        if (window.confirm(confirmMessage)) {
-          // User confirmed - navigate to the owned molecule's project
-          window.location.href = `/${this.parentRepo.owner}/${this.parentRepo.repoName}`;
-        }
+        window.dispatchEvent(
+          new CustomEvent("github-molecule-navigate-request", {
+            detail: {
+              owner: this.parentRepo.owner,
+              repoName: this.parentRepo.repoName,
+              moleculeName: moleculeName,
+            },
+          }),
+        );
+      } else if (this.parentRepo) {
+        // User doesn't own this molecule - dispatch preview request event
+        const moleculeName = this.name || this.parentRepo.repoName;
+        window.dispatchEvent(
+          new CustomEvent("github-molecule-preview-request", {
+            detail: {
+              owner: this.parentRepo.owner,
+              repoName: this.parentRepo.repoName,
+              moleculeName: moleculeName,
+            },
+          }),
+        );
       }
-      // else: User doesn't own this molecule - do nothing (can't navigate into it)
 
       clickProcessed = true;
     }

--- a/src/molecules/githubmolecule.js
+++ b/src/molecules/githubmolecule.js
@@ -42,6 +42,12 @@ export default class GitHubMolecule extends Molecule {
      */
     this.description = "Project imported from GitHub";
 
+    /**
+     * Timestamp (milliseconds since epoch) of when this molecule was last reloaded from GitHub
+     * @type {number}
+     */
+    this.lastReloadedFromGithubAt = null;
+
     this.gitHubUniqueID;
 
     this.setValues(values);
@@ -118,6 +124,8 @@ export default class GitHubMolecule extends Molecule {
 
   createInputParams(setInputChanged, authorizedUserOcto, userScopes) {
     let inputParams = {};
+    this.setInputMoleculeChanged = setInputChanged; // Store for later use in reload button
+
     inputParams = super.createInputParams();
     inputParams["ParentInfo"] = {
       type: "string",
@@ -125,12 +133,21 @@ export default class GitHubMolecule extends Molecule {
       value: `${this.parentRepo.owner}/${this.parentRepo.repoName}`,
       disabled: true,
     };
-    inputParams["Last Modified"] = {
+    inputParams["Parent Last Modified"] = {
       type: "string",
       label: "Last Modified",
       value: formatOrdinalDate(this.parentRepo.dateModified),
       disabled: true,
     };
+    inputParams["Last Reloaded"] = {
+      type: "string",
+      label: "Last Reloaded From GitHub",
+      value: this.lastReloadedFromGithubAt
+        ? new Date(this.lastReloadedFromGithubAt).toLocaleString()
+        : "Unknown",
+      disabled: true,
+    };
+    console.log(this.lastReloadedFromGithubAt);
     inputParams["Reload From Github"] = {
       type: "button",
       label: "Reload From Github",
@@ -143,15 +160,29 @@ export default class GitHubMolecule extends Molecule {
   }
 
   /**
+   * Override serialize to include lastReloadedFromGithubAt timestamp
+   */
+  serialize(offset = { x: 0, y: 0 }) {
+    const serialized = super.serialize(offset);
+
+    // Include last reload timestamp if it exists
+    if (this.lastReloadedFromGithubAt !== null) {
+      serialized.lastReloadedFromGithubAt = this.lastReloadedFromGithubAt;
+    }
+
+    return serialized;
+  }
+
+  /**
    * Reload this github molecule from github
    */
   async reloadMoleculeFromGithub(authorizedUserOcto, userScopes) {
     var githubMoleculeObjectPreReload = this.serialize();
+
     var githubMoleculeParentObjectConnectorsPreReload =
       this.parent.serialize().allConnectors;
 
     let gitObj = this.parentRepo;
-    let parentMolecule = this.parent;
 
     //Only delete and continue if you have permission to load
     if (

--- a/src/molecules/githubmolecule.js
+++ b/src/molecules/githubmolecule.js
@@ -131,7 +131,6 @@ export default class GitHubMolecule extends Molecule {
       value: formatOrdinalDate(this.parentRepo.dateModified),
       disabled: true,
     };
-    console.log(this.parentRepo.dateModified);
     inputParams["Reload From Github"] = {
       type: "button",
       label: "Reload From Github",

--- a/src/molecules/molecule.js
+++ b/src/molecules/molecule.js
@@ -182,7 +182,7 @@ export default class Molecule extends Atom {
     GlobalVariables.c.fill();
   }
 
-  createInputParams() {
+  createInputParams(setInputChanged) {
     let inputParams = { ...super.createInputParams() };
 
     inputParams["molecule name" + this.uniqueID] = {
@@ -1501,6 +1501,7 @@ export default class Molecule extends Atom {
               parentRepo: gitObj,
               topLevel: false,
               ioValues: oldObject.ioValues,
+              lastReloadedFromGithubAt: Date.now(),
             };
           } else {
             let xPos = position
@@ -1520,6 +1521,7 @@ export default class Molecule extends Atom {
               x: xPos,
               y: yPos,
               topLevel: false,
+              lastReloadedFromGithubAt: Date.now(),
             };
           }
 

--- a/src/prototypes/attachmentpoint.js
+++ b/src/prototypes/attachmentpoint.js
@@ -3,6 +3,7 @@ import GlobalVariables from "../js/globalvariables.js";
 import Atom from "../prototypes/atom.js";
 import { Global } from "@emotion/react";
 import { ObservableEntity, Status } from "./observableEntity.js";
+import { DeleteConnectorCommand } from "../js/undoCommands.js";
 
 /**
  * Sentinel value to represent an optional geometry input that has no connection.
@@ -242,20 +243,20 @@ export default class AttachmentPoint extends ObservableEntity {
       yInPixels,
       radiusInPixels,
       Math.PI / 2,
-      (-1 * Math.PI) / 2
+      (-1 * Math.PI) / 2,
     );
     GlobalVariables.c.rect(
       leftEdge,
       topEdge,
       textWidth + radiusInPixels + halfRadius,
-      radiusInPixels * 2
+      radiusInPixels * 2,
     );
     GlobalVariables.c.arc(
       leftEdge + textWidth + radiusInPixels + halfRadius,
       yInPixels,
       radiusInPixels,
       (-1 * Math.PI) / 2,
-      Math.PI / 2
+      Math.PI / 2,
     );
     GlobalVariables.c.fill();
 
@@ -273,7 +274,7 @@ export default class AttachmentPoint extends ObservableEntity {
     } else {
       GlobalVariables.c.fillStyle = Atom.statusAsColor(
         this.status,
-        this.parentMolecule.selected
+        this.parentMolecule.selected,
       );
     }
 
@@ -288,7 +289,7 @@ export default class AttachmentPoint extends ObservableEntity {
       radiusInPixels,
       0,
       Math.PI * 2,
-      false
+      false,
     );
     GlobalVariables.c.fill();
     GlobalVariables.c.stroke();
@@ -363,14 +364,14 @@ export default class AttachmentPoint extends ObservableEntity {
         parentXInPixels,
         x,
         parentYInPixels,
-        y
+        y,
       ) <= GlobalVariables.widthToPixels(activationBoundary)
     ) {
       this.isVisible = true;
       [this.x, this.y] = this.computePosition(activationBoundary);
       [this.x, this.y] = GlobalVariables.constrainToCanvasBorders(
         this.x,
-        this.y
+        this.y,
       );
       this.isTargeted = this.isCloseEnoughToTarget(x, y);
     } else {
@@ -412,7 +413,7 @@ export default class AttachmentPoint extends ObservableEntity {
    */
   computePosition(boundary) {
     const inputList = this.parentMolecule.inputs.filter(
-      (ap) => ap.type == "input"
+      (ap) => ap.type == "input",
     );
 
     if (this.type == "output") {
@@ -422,7 +423,7 @@ export default class AttachmentPoint extends ObservableEntity {
           this.parentMolecule.width ||
           GlobalVariables.widthToPixels(GlobalVariables.atomSize * 3.25);
         const inputWidthFractional = GlobalVariables.pixelsToWidth(
-          inputWidthInPixels * 0.75
+          inputWidthInPixels * 0.75,
         );
         return [
           this.parentMolecule.x + inputWidthFractional,
@@ -469,7 +470,7 @@ export default class AttachmentPoint extends ObservableEntity {
         -1 *
         GlobalVariables.pixelsToHeight(
           GlobalVariables.widthToPixels(hoverRadius) *
-            Math.sin(attachmentPointNumber * anglePerIO + angleCorrection)
+            Math.sin(attachmentPointNumber * anglePerIO + angleCorrection),
         );
 
       return [
@@ -495,7 +496,7 @@ export default class AttachmentPoint extends ObservableEntity {
       x,
       GlobalVariables.widthToPixels(this.x),
       y,
-      GlobalVariables.heightToPixels(this.y)
+      GlobalVariables.heightToPixels(this.y),
     );
 
     const apRadiusInPixels = GlobalVariables.widthToPixels(this.scaledRadius);
@@ -512,7 +513,7 @@ export default class AttachmentPoint extends ObservableEntity {
       const distFromParent = AttachmentPoint.getDistFromParent(inputCount);
       let hoverRadius = GlobalVariables.widthToPixels(
         distFromParent * this.parentMolecule.radius -
-          this.scaledRadius * AttachmentPoint.TARGET_SCALEUP
+          this.scaledRadius * AttachmentPoint.TARGET_SCALEUP,
       );
 
       const anglePerIO = Math.PI / (inputCount + 1);
@@ -520,7 +521,7 @@ export default class AttachmentPoint extends ObservableEntity {
 
       targetRadius = Math.max(
         apRadiusInPixels,
-        Math.min(targetRadius, maxNonOverlappingRadius)
+        Math.min(targetRadius, maxNonOverlappingRadius),
       );
       return dist < targetRadius;
     }
@@ -536,7 +537,19 @@ export default class AttachmentPoint extends ObservableEntity {
         this.connectors[0].selected &&
         ["Delete", "Backspace"].includes(key)
       ) {
-        this.deleteConnector(this.connectors[0]);
+        const connector = this.connectors[0];
+        // Serialize connector data for undo before deletion
+        const connectorData = {
+          ap1ID: connector.attachmentPoint1.parentMolecule.uniqueID,
+          ap2ID: connector.attachmentPoint2.parentMolecule.uniqueID,
+          ap2Name: connector.attachmentPoint2.name,
+        };
+        // Create undo command - use the molecule that contains the connected atoms
+        GlobalVariables.pushUndoCommand(
+          new DeleteConnectorCommand(connectorData, this.parentMolecule.parent),
+        );
+        // Delete the connector
+        this.deleteConnector(connector);
       }
     }
   }
@@ -561,7 +574,7 @@ export default class AttachmentPoint extends ObservableEntity {
       if (this.connectors.length == 1) {
         if (this.connectors[0] !== connector) {
           throw new Error(
-            "Input connector exists but doesn't match delete target"
+            "Input connector exists but doesn't match delete target",
           );
         }
         const otherAP = connector.getOtherAP(this);
@@ -675,7 +688,7 @@ export default class AttachmentPoint extends ObservableEntity {
       if (currentMolecule.nodesOnTheScreen) {
         const inputAtom = currentMolecule.nodesOnTheScreen.find(
           (atom) =>
-            GlobalVariables.isReferencableByName(atom) && atom.name === name
+            GlobalVariables.isReferencableByName(atom) && atom.name === name,
         );
         if (inputAtom) {
           return inputAtom;
@@ -778,7 +791,7 @@ export default class AttachmentPoint extends ObservableEntity {
             this.onSubscribedInputChanged(inputAtom);
           },
           this.uniqueID,
-          false
+          false,
         ); // Don't use immediateCallback - we'll trigger evaluation once after all subscriptions
 
         subscribedCount++;
@@ -849,7 +862,7 @@ export default class AttachmentPoint extends ObservableEntity {
           const safeVar = varName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
           substitutedEquation = substitutedEquation.replace(
             new RegExp(`\\b${safeVar}\\b`, "g"),
-            String(state.value)
+            String(state.value),
           );
         } else {
           allReady = false;
@@ -870,7 +883,7 @@ export default class AttachmentPoint extends ObservableEntity {
       } else {
         // Fallback: try to evaluate as a simple JavaScript expression
         result = Function(
-          '"use strict"; return (' + substitutedEquation + ")"
+          '"use strict"; return (' + substitutedEquation + ")",
         )();
       }
 
@@ -1007,7 +1020,7 @@ export default class AttachmentPoint extends ObservableEntity {
           newValue === undefined || newValue === null
             ? Status.WAITING
             : Status.READY,
-          newValue
+          newValue,
         );
       }
     } else {

--- a/src/styles/maslowCreate.css
+++ b/src/styles/maslowCreate.css
@@ -827,7 +827,7 @@ Sidebar navigation
 
 .back_to_runmode {
   position: fixed;
-  top: 3vh;
+  top: 49%;
   right: 5vh;
   z-index: 2;
 }


### PR DESCRIPTION
-Change where gcode success gets logged and log it with atom path 
- Fix validation wording and remove unnecessary alert from new project pop up form
- BUG FIX: Separate delete array from copy array to prevent cross action behavior.
- Add deleteConnector to undo command patterns.
- Add date of most recent github reload to github molecule and serialize it to allow the user to keep track of reload.

- Modifies navigation to prevent full page reloads on project changes
- Adds navigation for not owned projects from create mode + adds return to project. 
- Restores goup button to preview mode.
- Simplifies component for previewmode making less features accesible in preview