### PR TITLE
Change names of arguments to Difference atom

### DIFF
--- a/src/molecules/difference.js
+++ b/src/molecules/difference.js
@@ -29,12 +29,19 @@ export default class Difference extends Atom {
     this.description = "Subtracts shape two from shape one.";
 
     this.addAllIOs([
-      { name: "geometry1", valueType: "geometry" },
-      { name: "geometry2", valueType: "geometry" },
+      { name: "retain", valueType: "geometry" },
+      { name: "remove", valueType: "geometry" },
       { name: "geometry", valueType: "geometry", type: "output" },
     ]);
 
-    this.setValues(values);
+    this.setValues(
+      values,
+      // old names
+      {
+        retain: "geometry1",
+        remove: "geometry2",
+      },
+    );
   }
 
   /**
@@ -56,7 +63,7 @@ export default class Difference extends Atom {
       circleRadius,
       0,
       Math.PI * 2,
-      false
+      false,
     );
     GlobalVariables.c.fill();
     GlobalVariables.c.stroke();
@@ -79,8 +86,8 @@ export default class Difference extends Atom {
    * Compute the difference of two geometries.
    */
   compute(inputs) {
-    const input1 = inputs.geometry1;
-    const input2 = inputs.geometry2;
+    const input1 = inputs.retain;
+    const input2 = inputs.remove;
     return GlobalVariables.cad.difference(input1, input2, this.getContext());
   }
 }

--- a/src/molecules/difference.js
+++ b/src/molecules/difference.js
@@ -38,8 +38,8 @@ export default class Difference extends Atom {
       values,
       // old names
       {
-        retain: "geometry1",
-        remove: "geometry2",
+        retain: ["geometry1"],
+        remove: ["geometry2"],
       },
     );
   }

--- a/src/molecules/molecule.js
+++ b/src/molecules/molecule.js
@@ -1891,7 +1891,10 @@ export default class Molecule extends Atom {
         //When we have found the input atom
         atom.inputs.forEach((input) => {
           //Check each of its inputs
-          if (input.name == connectorObj.ap2Name) {
+          if (
+            input.name == connectorObj.ap2Name ||
+            input.oldNames?.includes(connectorObj.ap2Name)
+          ) {
             inputAttachmentPoint = input; //Until we find the one with the right name
           }
         });

--- a/src/prototypes/atom.js
+++ b/src/prototypes/atom.js
@@ -173,8 +173,9 @@ export default class Atom extends ObservableEntity {
   /**
    * Applies each of the passed values to this as this.x
    * @param {object} values - A list of values to set
+   * @param {object} backCompatInputNames - A mapping of current input names to old input names for backwards compatibility when loading old saves. Format is {currentName: [oldName1, oldName2, ...]}
    */
-  setValues(values) {
+  setValues(values, backCompatInputNames = {}) {
     //Assign the object to have the passed in values
 
     for (var key in values) {
@@ -182,21 +183,29 @@ export default class Atom extends ObservableEntity {
     }
 
     if (typeof this.ioValues !== "undefined") {
-      this.ioValues.forEach((ioValue) => {
-        //for each saved value
-        this.inputs.forEach((ap) => {
-          //Find the matching IO and set it to be the saved value
-          if (ioValue.name == ap.name && ap.type == "input") {
-            ap.value = ioValue.ioValue;
-            if (
-              "currentEquation" in ioValue &&
-              !Number.isFinite(Number(ioValue.currentEquation))
-            ) {
-              // only load currentEquation if it exists and isn't a numeric literal
-              ap.currentEquation = ioValue.currentEquation;
-            }
+      // this.inputs is set by current version of this atom's code.
+
+      this.inputs.forEach((ap) => {
+        if (ap.name in backCompatInputNames) {
+          ap.oldNames = backCompatInputNames[ap.name];
+        }
+
+        //Find the matching IO and set it to be the saved value
+        const matchingSavedVal = this.ioValues?.find(
+          (savedVal) =>
+            savedVal.name === ap.name || ap.oldNames?.includes(savedVal.name)
+        );
+
+        if (matchingSavedVal && ap.type == "input") {
+          ap.value = matchingSavedVal.ioValue;
+          if (
+            "currentEquation" in matchingSavedVal &&
+            !Number.isFinite(Number(matchingSavedVal.currentEquation))
+          ) {
+            // only load currentEquation if it exists and isn't a numeric literal
+            ap.currentEquation = matchingSavedVal.currentEquation;
           }
-        });
+        }
       });
     }
   }

--- a/src/prototypes/attachmentpoint.js
+++ b/src/prototypes/attachmentpoint.js
@@ -145,6 +145,9 @@ export default class AttachmentPoint extends ObservableEntity {
      */
     this.parentMolecule = null;
 
+    this.name = "";
+    this.oldNames = [];
+
     for (var key in values) {
       /**
        * Assign values in values as this.x
@@ -242,20 +245,20 @@ export default class AttachmentPoint extends ObservableEntity {
       yInPixels,
       radiusInPixels,
       Math.PI / 2,
-      (-1 * Math.PI) / 2
+      (-1 * Math.PI) / 2,
     );
     GlobalVariables.c.rect(
       leftEdge,
       topEdge,
       textWidth + radiusInPixels + halfRadius,
-      radiusInPixels * 2
+      radiusInPixels * 2,
     );
     GlobalVariables.c.arc(
       leftEdge + textWidth + radiusInPixels + halfRadius,
       yInPixels,
       radiusInPixels,
       (-1 * Math.PI) / 2,
-      Math.PI / 2
+      Math.PI / 2,
     );
     GlobalVariables.c.fill();
 
@@ -273,7 +276,7 @@ export default class AttachmentPoint extends ObservableEntity {
     } else {
       GlobalVariables.c.fillStyle = Atom.statusAsColor(
         this.status,
-        this.parentMolecule.selected
+        this.parentMolecule.selected,
       );
     }
 
@@ -288,7 +291,7 @@ export default class AttachmentPoint extends ObservableEntity {
       radiusInPixels,
       0,
       Math.PI * 2,
-      false
+      false,
     );
     GlobalVariables.c.fill();
     GlobalVariables.c.stroke();
@@ -363,14 +366,14 @@ export default class AttachmentPoint extends ObservableEntity {
         parentXInPixels,
         x,
         parentYInPixels,
-        y
+        y,
       ) <= GlobalVariables.widthToPixels(activationBoundary)
     ) {
       this.isVisible = true;
       [this.x, this.y] = this.computePosition(activationBoundary);
       [this.x, this.y] = GlobalVariables.constrainToCanvasBorders(
         this.x,
-        this.y
+        this.y,
       );
       this.isTargeted = this.isCloseEnoughToTarget(x, y);
     } else {
@@ -412,7 +415,7 @@ export default class AttachmentPoint extends ObservableEntity {
    */
   computePosition(boundary) {
     const inputList = this.parentMolecule.inputs.filter(
-      (ap) => ap.type == "input"
+      (ap) => ap.type == "input",
     );
 
     if (this.type == "output") {
@@ -422,7 +425,7 @@ export default class AttachmentPoint extends ObservableEntity {
           this.parentMolecule.width ||
           GlobalVariables.widthToPixels(GlobalVariables.atomSize * 3.25);
         const inputWidthFractional = GlobalVariables.pixelsToWidth(
-          inputWidthInPixels * 0.75
+          inputWidthInPixels * 0.75,
         );
         return [
           this.parentMolecule.x + inputWidthFractional,
@@ -469,7 +472,7 @@ export default class AttachmentPoint extends ObservableEntity {
         -1 *
         GlobalVariables.pixelsToHeight(
           GlobalVariables.widthToPixels(hoverRadius) *
-            Math.sin(attachmentPointNumber * anglePerIO + angleCorrection)
+            Math.sin(attachmentPointNumber * anglePerIO + angleCorrection),
         );
 
       return [
@@ -495,7 +498,7 @@ export default class AttachmentPoint extends ObservableEntity {
       x,
       GlobalVariables.widthToPixels(this.x),
       y,
-      GlobalVariables.heightToPixels(this.y)
+      GlobalVariables.heightToPixels(this.y),
     );
 
     const apRadiusInPixels = GlobalVariables.widthToPixels(this.scaledRadius);
@@ -512,7 +515,7 @@ export default class AttachmentPoint extends ObservableEntity {
       const distFromParent = AttachmentPoint.getDistFromParent(inputCount);
       let hoverRadius = GlobalVariables.widthToPixels(
         distFromParent * this.parentMolecule.radius -
-          this.scaledRadius * AttachmentPoint.TARGET_SCALEUP
+          this.scaledRadius * AttachmentPoint.TARGET_SCALEUP,
       );
 
       const anglePerIO = Math.PI / (inputCount + 1);
@@ -520,7 +523,7 @@ export default class AttachmentPoint extends ObservableEntity {
 
       targetRadius = Math.max(
         apRadiusInPixels,
-        Math.min(targetRadius, maxNonOverlappingRadius)
+        Math.min(targetRadius, maxNonOverlappingRadius),
       );
       return dist < targetRadius;
     }
@@ -561,7 +564,7 @@ export default class AttachmentPoint extends ObservableEntity {
       if (this.connectors.length == 1) {
         if (this.connectors[0] !== connector) {
           throw new Error(
-            "Input connector exists but doesn't match delete target"
+            "Input connector exists but doesn't match delete target",
           );
         }
         const otherAP = connector.getOtherAP(this);
@@ -675,7 +678,7 @@ export default class AttachmentPoint extends ObservableEntity {
       if (currentMolecule.nodesOnTheScreen) {
         const inputAtom = currentMolecule.nodesOnTheScreen.find(
           (atom) =>
-            GlobalVariables.isReferencableByName(atom) && atom.name === name
+            GlobalVariables.isReferencableByName(atom) && atom.name === name,
         );
         if (inputAtom) {
           return inputAtom;
@@ -778,7 +781,7 @@ export default class AttachmentPoint extends ObservableEntity {
             this.onSubscribedInputChanged(inputAtom);
           },
           this.uniqueID,
-          false
+          false,
         ); // Don't use immediateCallback - we'll trigger evaluation once after all subscriptions
 
         subscribedCount++;
@@ -849,7 +852,7 @@ export default class AttachmentPoint extends ObservableEntity {
           const safeVar = varName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
           substitutedEquation = substitutedEquation.replace(
             new RegExp(`\\b${safeVar}\\b`, "g"),
-            String(state.value)
+            String(state.value),
           );
         } else {
           allReady = false;
@@ -870,7 +873,7 @@ export default class AttachmentPoint extends ObservableEntity {
       } else {
         // Fallback: try to evaluate as a simple JavaScript expression
         result = Function(
-          '"use strict"; return (' + substitutedEquation + ")"
+          '"use strict"; return (' + substitutedEquation + ")",
         )();
       }
 
@@ -1007,7 +1010,7 @@ export default class AttachmentPoint extends ObservableEntity {
           newValue === undefined || newValue === null
             ? Status.WAITING
             : Status.READY,
-          newValue
+          newValue,
         );
       }
     } else {


### PR DESCRIPTION
Change difference args to be "retain" and "remove" instead of "geometry1" and "geometry2".

I always get confused about which is which and think this adds clarity.

Technical note: this also adds back compatibility infrastructure for argument name changes. In projects created before this change the inputs to difference are saved as "geometry1" and "geometry2". The back compatibility logic ensures that when loading difference atoms we import their old-named args and when loading save connectors we also make the connection if the saved file refers to the args old name.