### PR TITLE
Double computation fix

### DIFF
--- a/src/molecules/molecule.js
+++ b/src/molecules/molecule.js
@@ -1017,7 +1017,7 @@ export default class Molecule extends Atom {
       // Force propagation upstream since intermediate changes have been
       // withheld. Only call setReady if we have a valid value.
       const value = this.value;
-      this.setWaiting();
+
       if (value !== null && value !== undefined) {
         this.setReady(value);
       }


### PR DESCRIPTION
This fixes the issue where going out and up of molecules was triggering a recompute even when the value of the molecule hadn't changed. The settowaiting called triggered onupstream changes for all the downstream molecules despite values not changing.