### PR TITLE
Reset forced waiting on go up to parent 

### DIFF
--- a/src/molecules/molecule.js
+++ b/src/molecules/molecule.js
@@ -1018,6 +1018,7 @@ export default class Molecule extends Atom {
       // withheld. Only call setReady if we have a valid value.
       const value = this.value;
 
+      this.setWaiting();
       if (value !== null && value !== undefined) {
         this.setReady(value);
       }


### PR DESCRIPTION
When we go up to parent molecule, changes that we have made inside the molecule have been withheld and we have to force a downstream update. We do this by setting the molecule to waiting and then setting to ready immediately if a geometry is available