### PR TITLE
Update deprecated react-three dep + specify github version

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "react-query": "^3.39.3",
     "react-router-dom": "^6.22.3",
     "react-select": "^5.8.0",
-    "react-three-fiber": "^6.0.13",
     "rehype-raw": "^7.0.0",
     "replicad": "^0.22.0",
     "replicad-decorate": "^0.1.2",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -134,7 +134,6 @@ function AppContent() {
   const [processing, setProcessing] = useState(false);
 
   useEffect(() => {
-
     setRenderProgress(0);
     setRenderBarVisible(true);
     setRenderStage("Waiting for input"); // Start with Building stage by default
@@ -473,11 +472,13 @@ function AppContent() {
     if (authorizedUser) {
       var octokit = authorizedUser;
     } else {
-      var octokit = new Octokit();
+      var octokit = new Octokit({
+        headers: { "X-GitHub-Api-Version": "2022-11-28" },
+      });
     }
     // Sets the current repo information from node data
-    octokit
-      .request("GET /repos/{owner}/{repo}", {
+    octokit.rest.repos
+      .get({
         owner: project.owner,
         repo: project.repoName,
       })
@@ -487,10 +488,11 @@ function AppContent() {
         GlobalVariables.currentRepoName = project.repoName;
       });
 
-    return octokit
-      .request("GET /repos/{owner}/{repo}/contents/project.abundance", {
+    return octokit.rest.repos
+      .getContent({
         owner: project.owner,
         repo: project.repoName,
+        path: "project.abundance",
       })
       .then(async (response) => {
         let rawFileContent = await fetchGitHubFileContent(response.data);

--- a/src/components/main-routes/UserGuidePage.jsx
+++ b/src/components/main-routes/UserGuidePage.jsx
@@ -21,13 +21,15 @@ function UserGuidePage() {
     const fetchReadme = async () => {
       try {
         setLoading(true);
-        
+
         // Always fetch from the Abundance repository
         const repoOwner = "BarbourSmith";
         const repoNameToUse = "Abundance";
 
         // Create Octokit instance (authenticated if available, otherwise public)
-        const octokit = authorizedUserOcto || new Octokit();
+        const octokit =
+          authorizedUserOcto ||
+          new Octokit({ headers: { "X-GitHub-Api-Version": "2022-11-28" } });
 
         // Fetch README content from GitHub API
         const response = await octokit.request(
@@ -38,16 +40,14 @@ function UserGuidePage() {
             mediaType: {
               format: "raw",
             },
-          }
+          },
         );
 
         setReadmeContent(response.data);
         setError(null);
       } catch (err) {
         console.error("Error fetching User Guide:", err);
-        setError(
-          "Unable to load the User Guide. Please try again later."
-        );
+        setError("Unable to load the User Guide. Please try again later.");
       } finally {
         setLoading(false);
       }
@@ -63,25 +63,27 @@ function UserGuidePage() {
   // Convert heading text to GitHub-style ID
   const generateHeadingId = (children) => {
     if (!children) return "";
-    
+
     // Extract text from children (handle both string and array)
     let text = "";
     if (typeof children === "string") {
       text = children;
     } else if (Array.isArray(children)) {
-      text = children.map(child => 
-        typeof child === "string" ? child : child?.props?.children || ""
-      ).join("");
+      text = children
+        .map((child) =>
+          typeof child === "string" ? child : child?.props?.children || "",
+        )
+        .join("");
     } else if (children.props?.children) {
       text = children.props.children;
     }
-    
+
     // Convert to lowercase and replace spaces with hyphens
     return text
       .toLowerCase()
       .replace(/[^\w\s-]/g, "") // Remove special characters
-      .replace(/\s+/g, "-")      // Replace spaces with hyphens
-      .replace(/--+/g, "-")      // Replace multiple hyphens with single
+      .replace(/\s+/g, "-") // Replace spaces with hyphens
+      .replace(/--+/g, "-") // Replace multiple hyphens with single
       .trim();
   };
 
@@ -92,7 +94,7 @@ function UserGuidePage() {
       e.preventDefault();
       const targetId = href.substring(1);
       const targetElement = document.getElementById(targetId);
-      
+
       if (targetElement) {
         targetElement.scrollIntoView({ behavior: "smooth", block: "start" });
       }
@@ -106,38 +108,31 @@ function UserGuidePage() {
         <button className="readme-back-button" onClick={handleBack}>
           ← Back
         </button>
-        <h1 className="readme-title">
-          Abundance User Guide
-        </h1>
+        <h1 className="readme-title">Abundance User Guide</h1>
       </div>
 
       <div className="readme-content">
-        {loading && (
-          <div className="readme-loading">Loading User Guide...</div>
-        )}
-        
+        {loading && <div className="readme-loading">Loading User Guide...</div>}
+
         {error && (
           <div className="readme-error">
             <p>{error}</p>
             <button onClick={handleBack}>Go Back</button>
           </div>
         )}
-        
+
         {!loading && !error && (
           <ReactMarkdown
             rehypePlugins={[rehypeRaw]}
             components={{
               // Handle links with proper anchor navigation
               a: ({ node, ...props }) => (
-                <a 
-                  {...props} 
-                  onClick={(e) => handleLinkClick(e, props.href)}
-                />
+                <a {...props} onClick={(e) => handleLinkClick(e, props.href)} />
               ),
               // Add styling classes and IDs to headers for anchor navigation
               h1: ({ node, children, ...props }) => (
-                <h1 
-                  className="readme-h1" 
+                <h1
+                  className="readme-h1"
                   id={generateHeadingId(children)}
                   {...props}
                 >
@@ -145,8 +140,8 @@ function UserGuidePage() {
                 </h1>
               ),
               h2: ({ node, children, ...props }) => (
-                <h2 
-                  className="readme-h2" 
+                <h2
+                  className="readme-h2"
                   id={generateHeadingId(children)}
                   {...props}
                 >
@@ -154,8 +149,8 @@ function UserGuidePage() {
                 </h2>
               ),
               h3: ({ node, children, ...props }) => (
-                <h3 
-                  className="readme-h3" 
+                <h3
+                  className="readme-h3"
                   id={generateHeadingId(children)}
                   {...props}
                 >

--- a/src/components/main-routes/flowCanvas.jsx
+++ b/src/components/main-routes/flowCanvas.jsx
@@ -159,8 +159,8 @@ export default memo(function FlowCanvas({
             // Also load the project metadata from GitHub (without overwriting the molecules)
             if (authorizedUserOcto) {
               const octokit = authorizedUserOcto;
-              octokit
-                .request("GET /repos/{owner}/{repo}", {
+              octokit.rest.repos
+                .get({
                   owner: GlobalVariables.currentAWSnode.owner,
                   repo: GlobalVariables.currentAWSnode.repoName,
                 })

--- a/src/components/render/BackgroundModel.jsx
+++ b/src/components/render/BackgroundModel.jsx
@@ -23,7 +23,9 @@ export default function BackgroundModel({
 
     const loadModel = async () => {
       try {
-        const octokit = authorizedUserOcto || new Octokit();
+        const octokit =
+          authorizedUserOcto ||
+          new Octokit({ headers: { "X-GitHub-Api-Version": "2022-11-28" } });
 
         const result = await octokit.rest.repos.getContent({
           owner: GlobalVariables.currentAWSnode.owner,

--- a/src/components/render/NonReplicadMesh.jsx
+++ b/src/components/render/NonReplicadMesh.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, use } from "react";
 import { useRendering } from "../../contexts/RenderingContext.jsx";
 import * as THREE from "three";
 import { useLayoutEffect } from "react";
-import { invalidate } from "react-three-fiber";
+import { invalidate } from "@react-three/fiber";
 
 export default function NonReplicadMesh({}) {
   const { nonReplicadGeometry } = useRendering();

--- a/src/molecules/githubmolecule.js
+++ b/src/molecules/githubmolecule.js
@@ -215,7 +215,7 @@ export default class GitHubMolecule extends Molecule {
     // Verify the repository is accessible before deleting the existing node.
     // If the repository has been deleted or is unreachable, keep the existing
     // molecule and show an error rather than silently removing it.
-    const octokit = authorizedUserOcto || new Octokit();
+    const octokit = authorizedUserOcto || new Octokit({ headers: { "X-GitHub-Api-Version": "2022-11-28" } });
     try {
       await octokit.request(
         "GET /repos/{owner}/{repo}/contents/project.abundance",

--- a/src/molecules/import.js
+++ b/src/molecules/import.js
@@ -108,7 +108,9 @@ export default class Import extends Atom {
       return GlobalVariables.fetchFileContent(repoOwner, repoName, filePath);
     }
 
-    const octokit = new Octokit();
+    const octokit = new Octokit({
+      headers: { "X-GitHub-Api-Version": "2022-11-28" },
+    });
     return octokit.rest.repos.getContent({
       owner: repoOwner,
       repo: repoName,
@@ -182,7 +184,7 @@ export default class Import extends Atom {
     let base64String = result.data.content;
 
     // GitHub API returns base64 with \n every 60 chars; atob() rejects whitespace
-    let binary = atob(base64String.replace(/\s/g, ''));
+    let binary = atob(base64String.replace(/\s/g, ""));
 
     if (this.type == "SVG") {
       return binary;
@@ -329,9 +331,7 @@ export default class Import extends Atom {
           }
         })
         .catch((err) => {
-          this.setError(
-            `Failed to process imported file "${this.fileName}".`,
-          );
+          this.setError(`Failed to process imported file "${this.fileName}".`);
           throw err;
         });
     } else {

--- a/src/molecules/input.js
+++ b/src/molecules/input.js
@@ -628,7 +628,9 @@ export default class Input extends Atom {
       return GlobalVariables.fetchFileContent(repoOwner, repoName, filePath);
     }
 
-    const octokit = new Octokit();
+    const octokit = new Octokit({
+      headers: { "X-GitHub-Api-Version": "2022-11-28" },
+    });
     return octokit.rest.repos.getContent({
       owner: repoOwner,
       repo: repoName,

--- a/src/molecules/molecule.js
+++ b/src/molecules/molecule.js
@@ -321,7 +321,9 @@ export default class Molecule extends Atom {
   }
 
   async reloadFork() {
-    const octokit = new Octokit();
+    const octokit = new Octokit({
+      headers: { "X-GitHub-Api-Version": "2022-11-28" },
+    });
     let parent = GlobalVariables.currentAWSnode.parentRepo.split("/");
     let parentOwner = parent[0];
     let parentRepo = parent[1];
@@ -1436,7 +1438,9 @@ export default class Molecule extends Atom {
     if (authorizedUser) {
       octokit = authorizedUser;
     } else {
-      octokit = new Octokit();
+      octokit = new Octokit({
+        headers: { "X-GitHub-Api-Version": "2022-11-28" },
+      });
     }
     if (
       gitObj.privateRepo &&


### PR DESCRIPTION
Addressing some of the dependency warnings we have been getting I have gone ahead and updated the react-three fiber dependency as well as added headers to all our new octokit instance calls specifying a github version as is recommended by github.