### PR TITLE
New primitives

### DIFF
--- a/scripts/build-ts-framework.mjs
+++ b/scripts/build-ts-framework.mjs
@@ -156,7 +156,9 @@ dts = dts
   // callback param/return) with `Assembly<LeafGeom>` so `leaf.geometry`
   // narrows to the proper replicad union without any user-side checks.
   .replace(/\bAssembly<any>/g, "Assembly<LeafGeom>")
-  // is2D / is3D: turn boolean returns into proper type-narrowing guards.
+  // is2D / is3D / isWire / isPoint: turn boolean returns into proper
+  // type-narrowing guards so user code can read `.geometry` as the
+  // appropriate replicad type without a manual cast.
   .replace(
     /is2D\(\): boolean;/g,
     "is2D(): this is Assembly<_replicad.Drawing>;",
@@ -164,6 +166,14 @@ dts = dts
   .replace(
     /is3D\(\): boolean;/g,
     "is3D(): this is Assembly<_replicad.AnyShape>;",
+  )
+  .replace(
+    /isWire\(\): boolean;/g,
+    "isWire(): this is Assembly<_replicad.Wire>;",
+  )
+  .replace(
+    /isPoint\(\): boolean;/g,
+    "isPoint(): this is Assembly<_replicad.Vertex>;",
   );
 
 // Build the final .d.ts: import + declare global wrapper, then a real
@@ -185,6 +195,7 @@ const finalDts =
   `    type Sketch = _replicad.Sketch;\n` +
   `    type Sketches = _replicad.Sketches;\n` +
   `    type Wire = _replicad.Wire;\n` +
+  `    type Vertex = _replicad.Vertex;\n` +
   `    type Face = _replicad.Face;\n` +
   `    type Solid = _replicad.Solid;\n` +
   `    type Shape<T> = _replicad.Shape<T>;\n` +

--- a/src/components/render/ReplicadMesh.jsx
+++ b/src/components/render/ReplicadMesh.jsx
@@ -15,6 +15,7 @@ import {
   PerspectiveCamera,
   Vector3,
   Box3,
+  DoubleSide,
 } from "three";
 import {
   syncFaces,
@@ -41,9 +42,20 @@ export default React.memo(
 
     function makeMeshes(meshes) {
       let meshArray = [];
-      let keepOutMesh = [];
       if (!Array.isArray(meshes)) return meshArray;
       meshes.map((m) => {
+        // Point3D — no buffer geometry to build, just store the coordinate
+        if (m.point) {
+          meshArray.push({
+            pointPosition: m.point,
+            color: m.color,
+            solid: false,
+            surface: false,
+            isWire: false,
+          });
+          return;
+        }
+
         const body = new BufferGeometry();
         const lines = new BufferGeometry();
         // We use the three helpers to synchronise the buffer geometry with the
@@ -57,6 +69,8 @@ export default React.memo(
         const thisBody = body;
         const thisLines = lines;
         const thisColor = m.color;
+        // Wire has edges but no faces — render as lines only
+        const isWireType = !m.faces && !!m.edges;
         // If the color is keep out or glass make it transparent
         if (thisColor == "#D9544D" || thisColor == "#E6F3FF") {
           meshArray.push({
@@ -64,6 +78,8 @@ export default React.memo(
             lines: thisLines,
             color: thisColor,
             solid: false,
+            surface: false,
+            isWire: isWireType,
           });
         } else {
           meshArray.push({
@@ -71,6 +87,8 @@ export default React.memo(
             lines: thisLines,
             color: thisColor,
             solid: isSolid,
+            surface: !!m.surface,
+            isWire: isWireType,
           });
         }
       });
@@ -322,61 +340,93 @@ export default React.memo(
         {fullMesh.map((m, index) => {
           return (
             <group key={"group" + m.color + index}>
-              {!isSolid ? (
-                <mesh geometry={m.body} key={"mesh" + m.color}>
-                  {/*the offsets are here to avoid z fighting between the mesh and the lines*/}
-                  {m.color != "#D9544D" && m.color != "#E6F3FF" ? (
-                    <meshMatcapMaterial
-                      color={m.color}
-                      key={"material" + m.color}
-                      polygonOffset
-                      polygonOffsetFactor={2.0}
-                      polygonOffsetUnits={1.0}
+              {m.pointPosition ? (
+                // Point3D — render as a fixed screen-space sprite point
+                <points key={"point" + index}>
+                  <bufferGeometry>
+                    <bufferAttribute
+                      attach="attributes-position"
+                      count={1}
+                      array={new Float32Array(m.pointPosition)}
+                      itemSize={3}
                     />
-                  ) : m.color == "#E6F3FF" ? (
-                    <meshPhysicalMaterial
-                      color={m.color}
-                      transparent={true}
-                      opacity={0.5}
-                      transmission={0.6}
-                      roughness={0}
-                      metalness={0}
-                      clearcoat={1}
-                      clearcoatRoughness={0}
-                      ior={1.5}
-                    />
+                  </bufferGeometry>
+                  <pointsMaterial
+                    color={m.color}
+                    size={8}
+                    sizeAttenuation={false}
+                  />
+                </points>
+              ) : m.isWire ? (
+                // Wire — render as lines only, no body mesh
+                <lineSegments key={"wirelines" + index} geometry={m.lines}>
+                  <lineBasicMaterial
+                    color={m.color}
+                    opacity={1}
+                    linewidth={8}
+                  />
+                </lineSegments>
+              ) : (
+                // Normal solid / surface / 2D geometry
+                <>
+                  {!isSolid ? (
+                    <mesh geometry={m.body} key={"mesh" + m.color}>
+                      {/*the offsets are here to avoid z fighting between the mesh and the lines*/}
+                      {m.color != "#D9544D" && m.color != "#E6F3FF" ? (
+                        <meshMatcapMaterial
+                          color={m.color}
+                          key={"material" + m.color}
+                          polygonOffset
+                          polygonOffsetFactor={2.0}
+                          polygonOffsetUnits={1.0}
+                          side={m.surface ? DoubleSide : undefined}
+                        />
+                      ) : m.color == "#E6F3FF" ? (
+                        <meshPhysicalMaterial
+                          color={m.color}
+                          transparent={true}
+                          opacity={0.5}
+                          transmission={0.6}
+                          roughness={0}
+                          metalness={0}
+                          clearcoat={1}
+                          clearcoatRoughness={0}
+                          ior={1.5}
+                        />
+                      ) : (
+                        <meshBasicMaterial
+                          geometry={m.body}
+                          transparent={true}
+                          opacity={0.3}
+                          color={m.color}
+                        >
+                          <Wireframe geometry={m.body} {...wireframeProps} />
+                        </meshBasicMaterial>
+                      )}
+                    </mesh>
                   ) : (
                     <meshBasicMaterial
                       geometry={m.body}
                       transparent={true}
-                      opacity={0.3}
+                      opacity={0.7}
                       color={m.color}
                     >
                       <Wireframe geometry={m.body} {...wireframeProps} />
                     </meshBasicMaterial>
                   )}
-                </mesh>
-              ) : (
-                <meshBasicMaterial
-                  geometry={m.body}
-                  transparent={true}
-                  opacity={0.7}
-                  color={m.color}
-                >
-                  <Wireframe geometry={m.body} {...wireframeProps} />
-                </meshBasicMaterial>
+                  <lineSegments
+                    key={"lines" + m.color}
+                    geometry={m.lines}
+                  ></lineSegments>
+                  <lineSegments key={"linesmesh" + m.color} geometry={m.lines}>
+                    <lineBasicMaterial
+                      color={"#3c5a6e"}
+                      opacity={"1"}
+                      linewidth={8}
+                    />
+                  </lineSegments>
+                </>
               )}
-              <lineSegments
-                key={"lines" + m.color}
-                geometry={m.lines}
-              ></lineSegments>
-              <lineSegments key={"linesmesh" + m.color} geometry={m.lines}>
-                <lineBasicMaterial
-                  color={"#3c5a6e"}
-                  opacity={"1"}
-                  linewidth={8}
-                />
-              </lineSegments>
             </group>
           );
         })}

--- a/src/components/render/ReplicadMesh.jsx
+++ b/src/components/render/ReplicadMesh.jsx
@@ -15,7 +15,6 @@ import {
   PerspectiveCamera,
   Vector3,
   Box3,
-  DoubleSide,
 } from "three";
 import {
   syncFaces,
@@ -50,7 +49,6 @@ export default React.memo(
             pointPosition: m.point,
             color: m.color,
             solid: false,
-            surface: false,
             isWire: false,
           });
           return;
@@ -78,7 +76,6 @@ export default React.memo(
             lines: thisLines,
             color: thisColor,
             solid: false,
-            surface: false,
             isWire: isWireType,
           });
         } else {
@@ -87,7 +84,6 @@ export default React.memo(
             lines: thisLines,
             color: thisColor,
             solid: isSolid,
-            surface: !!m.surface,
             isWire: isWireType,
           });
         }
@@ -371,7 +367,7 @@ export default React.memo(
                 </>
               
               ) : (
-                // Normal solid / surface / 2D geometry
+                // Normal solid / 2D geometry
                 <>
                   {!isSolid ? (
                     <mesh geometry={m.body} key={"mesh" + m.color}>
@@ -383,7 +379,6 @@ export default React.memo(
                           polygonOffset
                           polygonOffsetFactor={2.0}
                           polygonOffsetUnits={1.0}
-                          side={m.surface ? DoubleSide : undefined}
                         />
                       ) : m.color == "#E6F3FF" ? (
                         <meshPhysicalMaterial

--- a/src/components/render/ReplicadMesh.jsx
+++ b/src/components/render/ReplicadMesh.jsx
@@ -353,19 +353,23 @@ export default React.memo(
                   </bufferGeometry>
                   <pointsMaterial
                     color={m.color}
-                    size={8}
+                    size={5}
                     sizeAttenuation={false}
                   />
                 </points>
               ) : m.isWire ? (
                 // Wire — render as lines only, no body mesh
-                <lineSegments key={"wirelines" + index} geometry={m.lines}>
-                  <lineBasicMaterial
-                    color={m.color}
-                    opacity={1}
-                    linewidth={8}
-                  />
-                </lineSegments>
+                <>
+                  <lineSegments key={"wirelines" + index} geometry={m.lines} />
+                  <lineSegments key={"wirelinesdark" + index} geometry={m.lines}>
+                    <lineBasicMaterial
+                      color={"#3c5a6e"}
+                      opacity={"1"}
+                      linewidth={8}
+                    />
+                  </lineSegments>
+                </>
+              
               ) : (
                 // Normal solid / surface / 2D geometry
                 <>

--- a/src/components/render/ReplicadMesh.jsx
+++ b/src/components/render/ReplicadMesh.jsx
@@ -338,7 +338,7 @@ export default React.memo(
             <group key={"group" + m.color + index}>
               {m.pointPosition ? (
                 // Point3D — render as a fixed screen-space sprite point
-                <points key={"point" + index}>
+                <points key={"point" + JSON.stringify(m.pointPosition) + index}>
                   <bufferGeometry>
                     <bufferAttribute
                       attach="attributes-position"

--- a/src/components/render/TopLevelWireframeMesh.jsx
+++ b/src/components/render/TopLevelWireframeMesh.jsx
@@ -24,6 +24,14 @@ export default React.memo(function TopLevelWireframeMesh() {
 
     let meshArray = [];
     mesh.forEach((m) => {
+      // Point3D — translucent point, no buffer geometry to build
+      if (m.point) {
+        meshArray.push({
+          pointPosition: m.point,
+          color: m.color,
+        });
+        return;
+      }
       const body = new BufferGeometry();
       const lines = new BufferGeometry();
       // We use the three helpers to synchronise the buffer geometry with the
@@ -36,7 +44,14 @@ export default React.memo(function TopLevelWireframeMesh() {
       const thisBody = body;
       const thisLines = lines;
       const thisColor = m.color;
-      meshArray.push({ body: thisBody, lines: thisLines, color: thisColor });
+      // Wire — edges only, no faces
+      const isWireType = !m.faces && !!m.edges;
+      meshArray.push({
+        body: m.faces ? thisBody : null,
+        lines: thisLines,
+        color: thisColor,
+        isWire: isWireType,
+      });
     });
     setFullMesh(meshArray);
     // We have configured the canvas to only refresh when there is a change,
@@ -60,16 +75,46 @@ export default React.memo(function TopLevelWireframeMesh() {
       {fullMesh.map((m, index) => {
         return (
           <group key={"grouptoplevelwire" + m.color + index}>
-            <Wireframe
-              geometry={m.body}
-              stroke={"#888888"}
-              squeeze={true}
-              dash={false}
-              simplify={true}
-              fill={"#888888"}
-              fillOpacity={0.05}
-              strokeOpacity={0.3}
-            />
+            {m.pointPosition ? (
+              // Translucent background point
+              <points>
+                <bufferGeometry>
+                  <bufferAttribute
+                    attach="attributes-position"
+                    count={1}
+                    array={new Float32Array(m.pointPosition)}
+                    itemSize={3}
+                  />
+                </bufferGeometry>
+                <pointsMaterial
+                  color={"#888888"}
+                  size={5}
+                  sizeAttenuation={false}
+                  transparent={true}
+                  opacity={0.6}
+                />
+              </points>
+            ) : m.isWire ? (
+              // Translucent background wire — lines only
+              <lineSegments geometry={m.lines}>
+                <lineBasicMaterial
+                  color={"#888888"}
+                  transparent={true}
+                  opacity={0.6}
+                />
+              </lineSegments>
+            ) : (
+              <Wireframe
+                geometry={m.body}
+                stroke={"#888888"}
+                squeeze={true}
+                dash={false}
+                simplify={true}
+                fill={"#888888"}
+                fillOpacity={0.05}
+                strokeOpacity={0.3}
+              />
+            )}
           </group>
         );
       })}

--- a/src/components/render/WireframeMesh.jsx
+++ b/src/components/render/WireframeMesh.jsx
@@ -18,6 +18,14 @@ export default React.memo(function ShapeMeshes() {
   useLayoutEffect(() => {
     let meshArray = [];
     mesh.map((m) => {
+      // Point3D — translucent point, no buffer geometry to build
+      if (m.point) {
+        meshArray.push({
+          pointPosition: m.point,
+          color: m.color,
+        });
+        return;
+      }
       const body = new BufferGeometry();
       const lines = new BufferGeometry();
       // We use the three helpers to synchronise the buffer geometry with the
@@ -31,7 +39,14 @@ export default React.memo(function ShapeMeshes() {
       const thisBody = body;
       const thisLines = lines;
       const thisColor = m.color;
-      meshArray.push({ body: thisBody, lines: thisLines, color: thisColor });
+      // Wire — edges only, no faces
+      const isWireType = !m.faces && !!m.edges;
+      meshArray.push({
+        body: m.faces ? thisBody : null,
+        lines: thisLines,
+        color: thisColor,
+        isWire: isWireType,
+      });
     });
     setFullMesh(meshArray);
     // We have configured the canvas to only refresh when there is a change,
@@ -52,16 +67,46 @@ export default React.memo(function ShapeMeshes() {
       {fullMesh.map((m, index) => {
         return (
           <group key={"groupwire" + m.color + index}>
-            <Wireframe
-              geometry={m.body}
-              stroke={"#bebbbf"}
-              squeeze={true}
-              dash={false}
-              simplify={true}
-              fill={"#bebbbf"}
-              fillOpacity={0.1}
-              strokeOpacity={0.2}
-            />
+            {m.pointPosition ? (
+              // Translucent background point
+              <points>
+                <bufferGeometry>
+                  <bufferAttribute
+                    attach="attributes-position"
+                    count={1}
+                    array={new Float32Array(m.pointPosition)}
+                    itemSize={3}
+                  />
+                </bufferGeometry>
+                <pointsMaterial
+                  color={"#bebbbf"}
+                  size={5}
+                  sizeAttenuation={false}
+                  transparent={true}
+                  opacity={0.6}
+                />
+              </points>
+            ) : m.isWire ? (
+              // Translucent background wire — lines only
+              <lineSegments geometry={m.lines}>
+                <lineBasicMaterial
+                  color={"#bebbbf"}
+                  transparent={true}
+                  opacity={0.6}
+                />
+              </lineSegments>
+            ) : (
+              <Wireframe
+                geometry={m.body}
+                stroke={"#bebbbf"}
+                squeeze={true}
+                dash={false}
+                simplify={true}
+                fill={"#bebbbf"}
+                fillOpacity={0.1}
+                strokeOpacity={0.2}
+              />
+            )}
           </group>
         );
       })}

--- a/src/components/secondary/SimpleControlPanel.jsx
+++ b/src/components/secondary/SimpleControlPanel.jsx
@@ -272,7 +272,6 @@ function ArrayInputControl({
   label,
   isDisabled,
   elementType,
-  onLocalChange,
   onCommit,
   inputStyle,
   inputDisabledStyle,
@@ -287,11 +286,6 @@ function ArrayInputControl({
   const [isFocused, setIsFocused] = useState(false);
   const textareaRef = useRef(null);
   const gutterRef = useRef(null);
-
-  // Reset draft if external value changes while not focused.
-  useEffect(() => {
-    if (!isFocused) setDraft(null);
-  }, [committedText, isFocused]);
 
   const text = draft !== null ? draft : committedText;
   const lines = text.length === 0 ? [""] : text.split("\n");
@@ -310,11 +304,7 @@ function ArrayInputControl({
   };
 
   const handleChange = (e) => {
-    const newText = e.target.value;
-    setDraft(newText);
-    // Keep local panel state in sync so other code reading currentValue sees
-    // it. Don't coerce here so the user sees exactly what they typed.
-    onLocalChange(newText.split("\n"));
+    setDraft(e.target.value);
   };
 
   const handleBlur = () => {
@@ -1880,41 +1870,21 @@ export const SimpleControlPanel = forwardRef(function SimpleControlPanel(
                         </select>
                       </div>
                     );
-                  case "array": {
-                    const arr = Array.isArray(currentValue)
-                      ? currentValue
-                      : Array.isArray(config.value)
-                        ? config.value
-                        : [];
-                    const commitArr = (newArr) => {
-                      setControlValue(key, newArr);
-                      setLocalValues((prev) => {
-                        const next = { ...prev };
-                        delete next[key];
-                        return next;
-                      });
-                      if (typeof config.onChange === "function") {
-                        config.onChange(newArr, key);
-                      }
-                    };
+                  case "array":
                     return (
                       <ArrayInputControl
                         key={key}
-                        value={arr}
+                        value={Array.isArray(currentValue) ? currentValue : []}
                         label={label}
                         isDisabled={isDisabled}
                         elementType={config.elementType}
-                        onLocalChange={(newArr) =>
-                          handleLocalChange(key, newArr)
-                        }
-                        onCommit={commitArr}
+                        onCommit={(newArr) => commitChange(key, newArr, config)}
                         inputStyle={inputStyle}
                         inputDisabledStyle={inputDisabledStyle}
                         inputFocusedStyle={inputFocusedStyle}
                         labelStyle={labelStyle}
                       />
                     );
-                  }
                   case "button":
                     return (
                       <div key={key} style={labelStyle}>

--- a/src/components/secondary/SimpleControlPanel.jsx
+++ b/src/components/secondary/SimpleControlPanel.jsx
@@ -22,6 +22,7 @@ const EyeIcon = ({ size = 16 }) => (
 import React, {
   useState,
   useEffect,
+  useRef,
   forwardRef,
   useImperativeHandle,
   use,
@@ -255,6 +256,174 @@ const closeButtonStyle = {
   padding: 0,
   transition: "background 0.2s",
 };
+
+/**
+ * Single-textarea editor for array-type inputs. Each line is one entry.
+ *
+ * - Newline separates entries; index numbers shown in a non-editable gutter
+ *   on the left, kept in sync with the textarea's scroll position.
+ * - Enter just inserts a newline naturally → new entry.
+ * - Tab moves focus to the next form control (default browser behavior).
+ * - Local edits are buffered; the array is committed to the molecule on blur,
+ *   with empty trailing entries trimmed.
+ */
+function ArrayInputControl({
+  value,
+  label,
+  isDisabled,
+  elementType,
+  onLocalChange,
+  onCommit,
+  inputStyle,
+  inputDisabledStyle,
+  inputFocusedStyle,
+  labelStyle,
+}) {
+  const incoming = Array.isArray(value) ? value : [];
+  const committedText = incoming.join("\n");
+
+  // Local text buffer while the user is typing. `null` means "show committed".
+  const [draft, setDraft] = useState(null);
+  const [isFocused, setIsFocused] = useState(false);
+  const textareaRef = useRef(null);
+  const gutterRef = useRef(null);
+
+  // Reset draft if external value changes while not focused.
+  useEffect(() => {
+    if (!isFocused) setDraft(null);
+  }, [committedText, isFocused]);
+
+  const text = draft !== null ? draft : committedText;
+  const lines = text.length === 0 ? [""] : text.split("\n");
+  const lineCount = lines.length;
+  // Show at least 3 rows, grow up to 10 rows of content.
+  const rows = Math.min(10, Math.max(3, lineCount));
+
+  // Coerce a string line to the configured element type.
+  // - "number"  → Number(line); empty lines dropped before reaching here.
+  // - "boolean" → "true" (case-insensitive) is true; everything else false.
+  // - "string" / undefined → keep raw string.
+  const coerceLine = (line) => {
+    if (elementType === "number") return Number(line);
+    if (elementType === "boolean") return line.trim().toLowerCase() === "true";
+    return line;
+  };
+
+  const handleChange = (e) => {
+    const newText = e.target.value;
+    setDraft(newText);
+    // Keep local panel state in sync so other code reading currentValue sees
+    // it. Don't coerce here so the user sees exactly what they typed.
+    onLocalChange(newText.split("\n"));
+  };
+
+  const handleBlur = () => {
+    setIsFocused(false);
+    // Commit: split on newlines, trim trailing empties only.
+    const arr = text.split("\n");
+    while (arr.length > 0 && arr[arr.length - 1] === "") arr.pop();
+    // For non-string element types, also strip empty lines anywhere — they
+    // would coerce to NaN / false, which is rarely what the user wants.
+    const filtered =
+      elementType === "number" || elementType === "boolean"
+        ? arr.filter((s) => s !== "")
+        : arr;
+    onCommit(filtered.map(coerceLine));
+    setDraft(null);
+  };
+
+  const handleScroll = () => {
+    if (gutterRef.current && textareaRef.current) {
+      gutterRef.current.scrollTop = textareaRef.current.scrollTop;
+    }
+  };
+
+  const baseInputStyle = isDisabled
+    ? { ...inputStyle, ...inputDisabledStyle }
+    : isFocused
+      ? { ...inputStyle, ...inputFocusedStyle }
+      : inputStyle;
+
+  const textareaStyle = {
+    ...baseInputStyle,
+    width: "100%",
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, monospace",
+    lineHeight: "20px",
+    resize: "vertical",
+    whiteSpace: "pre",
+    overflow: "auto",
+    borderTopLeftRadius: 0,
+    borderBottomLeftRadius: 0,
+    borderLeft: "none",
+  };
+
+  const gutterStyle = {
+    boxSizing: "border-box",
+    padding: "4px 6px 4px 8px",
+    fontSize: inputStyle.fontSize ?? 14,
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, monospace",
+    lineHeight: "20px",
+    color: "var(--control-text-muted)",
+    background: "#1e222c",
+    border: "1px solid #333741",
+    borderRight: "none",
+    borderTopLeftRadius: 4,
+    borderBottomLeftRadius: 4,
+    textAlign: "right",
+    userSelect: "none",
+    overflow: "hidden",
+    minWidth: 26,
+    flexShrink: 0,
+  };
+
+  return (
+    <div
+      style={{
+        ...labelStyle,
+        alignItems: "flex-start",
+        flexDirection: "column",
+        gap: 4,
+      }}
+    >
+      <span
+        style={{
+          color: isDisabled
+            ? inputDisabledStyle.color
+            : "var(--control-text-muted)",
+        }}
+      >
+        {label}:
+      </span>
+      <div
+        style={{
+          display: "flex",
+          width: "100%",
+          alignItems: "stretch",
+        }}
+      >
+        <div ref={gutterRef} style={gutterStyle} aria-hidden="true">
+          {lines.map((_, i) => (
+            <div key={i}>{i}</div>
+          ))}
+        </div>
+        <textarea
+          ref={textareaRef}
+          value={text}
+          rows={rows}
+          disabled={isDisabled}
+          onChange={handleChange}
+          onFocus={() => setIsFocused(true)}
+          onBlur={handleBlur}
+          onScroll={handleScroll}
+          spellCheck={false}
+          style={textareaStyle}
+          placeholder="One value per line"
+        />
+      </div>
+    </div>
+  );
+}
+
 
 /**
  * @param {{
@@ -543,6 +712,22 @@ export const SimpleControlPanel = forwardRef(function SimpleControlPanel(
 
   // Listen for keyboard events on the panel to trigger focus
   const handlePanelKeyDown = (e) => {
+    // If the user is already typing inside a form control (input, textarea,
+    // select, or any contenteditable element), don't steal focus to the
+    // first registered input. This prevents the array textarea (and any
+    // other unregistered inputs) from losing focus mid-keystroke.
+    const target = e.target;
+    if (target) {
+      const tag = target.tagName;
+      if (
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        tag === "SELECT" ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+    }
     // Just pass through to handleKeyDown - it will set shouldFocus as needed
     handleKeyDown(e);
   };
@@ -1695,6 +1880,41 @@ export const SimpleControlPanel = forwardRef(function SimpleControlPanel(
                         </select>
                       </div>
                     );
+                  case "array": {
+                    const arr = Array.isArray(currentValue)
+                      ? currentValue
+                      : Array.isArray(config.value)
+                        ? config.value
+                        : [];
+                    const commitArr = (newArr) => {
+                      setControlValue(key, newArr);
+                      setLocalValues((prev) => {
+                        const next = { ...prev };
+                        delete next[key];
+                        return next;
+                      });
+                      if (typeof config.onChange === "function") {
+                        config.onChange(newArr, key);
+                      }
+                    };
+                    return (
+                      <ArrayInputControl
+                        key={key}
+                        value={arr}
+                        label={label}
+                        isDisabled={isDisabled}
+                        elementType={config.elementType}
+                        onLocalChange={(newArr) =>
+                          handleLocalChange(key, newArr)
+                        }
+                        onCommit={commitArr}
+                        inputStyle={inputStyle}
+                        inputDisabledStyle={inputDisabledStyle}
+                        inputFocusedStyle={inputFocusedStyle}
+                        labelStyle={labelStyle}
+                      />
+                    );
+                  }
                   case "button":
                     return (
                       <div key={key} style={labelStyle}>

--- a/src/components/secondary/codeWindow.jsx
+++ b/src/components/secondary/codeWindow.jsx
@@ -317,8 +317,13 @@ Allowed input types are:
 • number
 • string
 • boolean
-• Assembly - a structured Abundance assembly (may contain a single or multiple geometries).
-  See Abundance Methods panel.
+• Assembly - a structured Abundance assembly. Geometry may be one of:
+    - 3D solid  (.is3D() → true)
+    - 2D sketch (.is2D() → true)
+    - Wire curve (.isWire() → true)
+    - Surface shell (.isSurface() → true)
+    - Point3D vertex (.isPoint3D() → true)
+  See Abundance Methods panel for full API.
 
 Allowed return types are same as input types.
 

--- a/src/components/secondary/codeWindow.jsx
+++ b/src/components/secondary/codeWindow.jsx
@@ -321,7 +321,6 @@ Allowed input types are:
     - 3D solid  (.is3D() → true)
     - 2D sketch (.is2D() → true)
     - Wire curve (.isWire() → true)
-    - Surface shell (.isSurface() → true)
     - Point3D vertex (.isPoint3D() → true)
   See Abundance Methods panel for full API.
 

--- a/src/molecules/code.js
+++ b/src/molecules/code.js
@@ -745,6 +745,14 @@ return assembly;
       existing.valueType = arg.type;
       existing.defaultValue = arg.defaultValue;
       existing.isOptional = arg.isOptional;
+      // For array inputs, remember the element type so the control panel
+      // can coerce edits and so we know it's not Assembly[] (rejected by
+      // the parser). Cleared for non-array inputs.
+      if (arg.type === "array") {
+        existing.elementType = arg.elementType;
+      } else if ("elementType" in existing) {
+        delete existing.elementType;
+      }
     }
 
     // Remove inputs no longer declared in the run() signature.

--- a/src/molecules/input.js
+++ b/src/molecules/input.js
@@ -1122,14 +1122,16 @@ export default class Input extends Atom {
       },
     };
 
-    // If type is array, add a control to input options
+    // If type is array, add a control to edit the default array values
     if (this.type === "array") {
+      const defaultArr = Array.isArray(this.options) ? [...this.options] : [];
       inputParams[this.uniqueID + "arrayOptions"] = {
-        type: "string",
-        value: Array.isArray(this.options) ? this.options.join(", ") : "",
-        label: "Array Options (comma separated)",
+        type: "array",
+        value: defaultArr,
+        label: "Default Values",
         disabled: false,
         onChange: (val) => {
+          const newArr = Array.isArray(val) ? [...val] : [];
           if (!GlobalVariables.isUndoing && this.parent) {
             const oldOptions = Array.isArray(this.options)
               ? [...this.options]
@@ -1144,22 +1146,17 @@ export default class Input extends Atom {
                   atom.options = oldVal;
                   if (atom.parentAP) atom.parentAP.options = oldVal;
                   if (typeof atom.setInputChanged === "function")
-                    atom.setInputChanged(oldVal.join(", "));
+                    atom.setInputChanged(oldVal);
                 },
-                `Change array options`,
+                `Change array default values`,
               ),
             );
           }
-          // Split by comma and trim whitespace
-          this.options = val
-            .split(",")
-            .map((v) => v.trim())
-            .filter((v) => v.length > 0);
-          //Add a new input to the current molecule
+          this.options = newArr;
           if (this.parentAP) {
             this.parentAP.options = this.options;
           }
-          this.setInputChanged(val);
+          this.setInputChanged(newArr);
         },
       };
     }

--- a/src/molecules/molecule.js
+++ b/src/molecules/molecule.js
@@ -152,6 +152,11 @@ export default class Molecule extends Atom {
       return [1, 1]; // be nice about division by 0
     }
 
+    if (this.status == Status.READY) {
+      // If this atom is ready, skip to progress 100%
+      return [totalCount, totalCount];
+    }
+
     return [readyCount, totalCount];
   }
 

--- a/src/molecules/utils/code-header-parser.js
+++ b/src/molecules/utils/code-header-parser.js
@@ -8,18 +8,22 @@
  * `parseCodeHeader(srcCode)`.
  */
 
-/** @typedef {"number" | "string" | "boolean" | "geometry"} AbundanceValueType */
+/** @typedef {"number" | "string" | "boolean" | "geometry" | "array"} AbundanceValueType */
+/** @typedef {"number" | "string" | "boolean"} AbundanceArrayElementType */
 
 /**
  * @typedef {Object} ParsedArg
  * @property {string} name - Parameter name (a valid JS identifier).
  * @property {AbundanceValueType} type - Abundance value type derived from
  *   the TS type annotation. Anything not a primitive becomes `"geometry"`.
+ * @property {AbundanceArrayElementType} [elementType] - Element type, set
+ *   only when `type === "array"`. One of `"number" | "string" | "boolean"`.
  * @property {boolean} isOptional - True if the parameter has a `?` marker
  *   or an explicit default value.
- * @property {number|string|boolean|null|undefined} defaultValue - Parsed
- *   JS literal of the default expression. `undefined` when no default was
- *   declared and the type is not geometry; `null` for geometry inputs
+ * @property {number|string|boolean|Array|null|undefined} defaultValue -
+ *   Parsed JS literal of the default expression. `undefined` when no
+ *   default was declared and the type is not geometry/array; `null` for
+ *   geometry inputs without an explicit default; `[]` for array inputs
  *   without an explicit default.
  */
 
@@ -118,19 +122,43 @@ function splitParam(p) {
 }
 
 /**
- * Map a TypeScript type expression to one of Abundance's input value types.
- * Anything not number/string/boolean (replicad shapes, AbundanceObj, any,
- * ...) becomes a `geometry` input. Unions like `number | undefined` are
- * mapped by their leading token.
+ * Map a TypeScript type expression to an Abundance value descriptor.
  *
- * @returns {AbundanceValueType}
+ * Primitives (`number`, `string`, `boolean`) map to their respective value
+ * types. `Assembly` (and any non-primitive single token) maps to `geometry`.
+ * Array forms `T[]` and `Array<T>` for primitive `T` map to `array` with
+ * the corresponding `elementType`. `Assembly[]` / `Array<Assembly>` are
+ * explicitly rejected. Unions like `number | undefined` are mapped by
+ * their leading token.
+ *
+ * @returns {{ valueType: AbundanceValueType, elementType?: AbundanceArrayElementType }}
  */
-function tsTypeToValueType(tsType) {
-  const first = (tsType || "").trim().split(/[\s|&]/)[0];
-  if (first === "number") return "number";
-  if (first === "string") return "string";
-  if (first === "boolean") return "boolean";
-  if (first === "Assembly") return "geometry";
+function tsTypeToValueInfo(tsType) {
+  const head = (tsType || "").trim().split(/[\s|&]/)[0].trim();
+  if (!head) {
+    throw new Error(`Unsupported or missing type annotation: "${tsType}"`);
+  }
+
+  // `Array<T>` form.
+  const arrayGenericMatch = head.match(/^Array<\s*([^<>]+?)\s*>$/);
+  // `T[]` form (primitive identifier followed by `[]`). Only accept simple
+  // identifiers here; e.g. `number[][]` is not supported.
+  const bracketMatch = head.match(/^([A-Za-z_$][\w$]*)\[\]$/);
+
+  if (arrayGenericMatch || bracketMatch) {
+    const inner = (arrayGenericMatch?.[1] ?? bracketMatch[1]).trim();
+    if (inner === "number" || inner === "string" || inner === "boolean") {
+      return { valueType: "array", elementType: inner };
+    }
+    throw new Error(
+      `Unsupported array element type: "${inner}". Supported element types are number, string, boolean.`,
+    );
+  }
+
+  if (head === "number") return { valueType: "number" };
+  if (head === "string") return { valueType: "string" };
+  if (head === "boolean") return { valueType: "boolean" };
+  if (head === "Assembly") return { valueType: "geometry" };
   throw new Error(`Unsupported or missing type annotation: "${tsType}"`);
 }
 
@@ -140,12 +168,17 @@ function tsTypeToValueType(tsType) {
  * malformed primitive literals.
  *
  * Returns `undefined` when no default was declared and the type is not
- * `geometry` (the caller can then fall back to its own default). Geometry
- * inputs without an explicit default get `null`, indicating no upstream
- * connection is required.
+ * `geometry` or `array` (the caller can then fall back to its own default).
+ * Geometry inputs without an explicit default get `null`, indicating no
+ * upstream connection is required. Array inputs without an explicit
+ * default get `[]`.
  */
-function parseDefaultLiteral(raw, valueType, paramName) {
-  if (raw === undefined) return valueType === "geometry" ? null : undefined;
+function parseDefaultLiteral(raw, valueType, paramName, elementType) {
+  if (raw === undefined) {
+    if (valueType === "geometry") return null;
+    if (valueType === "array") return [];
+    return undefined;
+  }
   if (raw === "") {
     throw new Error(
       `Parameter "${paramName}" in run() has an empty default value`,
@@ -176,6 +209,32 @@ function parseDefaultLiteral(raw, valueType, paramName) {
       return raw.slice(1, -1);
     }
     return raw;
+  }
+  if (valueType === "array") {
+    let parsed;
+    try {
+      // User code is already executed in a worker sandbox; treat the raw
+      // expression as a JS literal. Parens force expression context so a
+      // bare `[...]` is parsed as an array, not a block.
+      parsed = new Function(`return (${raw});`)();
+    } catch (e) {
+      throw new Error(
+        `Parameter "${paramName}" has an invalid array default value: "${raw}" (${e.message})`,
+      );
+    }
+    if (!Array.isArray(parsed)) {
+      throw new Error(
+        `Parameter "${paramName}" default value must be an array literal: "${raw}"`,
+      );
+    }
+    for (const el of parsed) {
+      if (typeof el !== elementType) {
+        throw new Error(
+          `Parameter "${paramName}" default array element "${el}" does not match element type "${elementType}"`,
+        );
+      }
+    }
+    return parsed;
   }
   return null;
 }
@@ -208,13 +267,21 @@ export function parseCodeHeader(srcCode) {
       );
     }
     const { name, hasOptionalMarker, tsType, defaultRaw } = parsed;
-    const type = tsTypeToValueType(tsType);
-    const defaultValue = parseDefaultLiteral(defaultRaw, type, name);
-    return {
+    const { valueType, elementType } = tsTypeToValueInfo(tsType);
+    const defaultValue = parseDefaultLiteral(
+      defaultRaw,
+      valueType,
       name,
-      type,
+      elementType,
+    );
+    /** @type {ParsedArg} */
+    const result = {
+      name,
+      type: valueType,
       isOptional: hasOptionalMarker || defaultRaw !== undefined,
       defaultValue,
     };
+    if (elementType) result.elementType = elementType;
+    return result;
   });
 }

--- a/src/prototypes/atom.js
+++ b/src/prototypes/atom.js
@@ -1477,15 +1477,26 @@ export default class Atom extends ObservableEntity {
             },
           };
         } else if (input.valueType === "array") {
-          // Handle select controls for array inputs
+          // Handle array editor controls for array inputs
+          // Value is the actual array; fall back to options (legacy
+          // comma-separated default values) or an empty array.
+          const arrVal = Array.isArray(input.value)
+            ? input.value
+            : Array.isArray(input.options)
+              ? [...input.options]
+              : [];
           inputParams[this.uniqueID + input.name] = {
-            type: "select",
-            value: input.value,
+            type: "array",
+            value: arrVal,
             label: input.name,
-            options: Array.isArray(input.options) ? input.options : [],
+            disabled: hasConnector,
+            elementType: input.elementType,
             onChange: (value) => {
+              const newArr = Array.isArray(value) ? [...value] : [];
               if (!GlobalVariables.isUndoing && this.parent) {
-                const oldVal = input.value;
+                const oldVal = Array.isArray(input.value)
+                  ? [...input.value]
+                  : input.value;
                 const inputName = input.name;
                 GlobalVariables.pushUndoCommand(
                   new ValueChangeCommand(
@@ -1501,7 +1512,7 @@ export default class Atom extends ObservableEntity {
                   ),
                 );
               }
-              input.setValue(value);
+              input.setValue(newArr);
             },
           };
         } else if (input.valueType === "range") {

--- a/src/worker/actions.ts
+++ b/src/worker/actions.ts
@@ -17,6 +17,15 @@ async function extrude(
   if (util.is3D(toExtrude)) {
     throw new Error("Cannot extrude a 3D geometry.");
   }
+  if (util.isWireGeometry(toExtrude)) {
+    throw new Error("Cannot extrude a Wire. Use a sweep operation to create a surface from a Wire profile.");
+  }
+  if (util.isSurface(toExtrude)) {
+    throw new Error("Cannot extrude a Surface geometry.");
+  }
+  if (util.isPoint3D(toExtrude)) {
+    throw new Error("Cannot extrude a Point3D.");
+  }
   await util.init();
   return util.actOnLeafs(toExtrude, async (leaf: AbundanceLeaf) => {
     return {
@@ -134,7 +143,7 @@ async function move(
     z,
     context,
   );
-  if (util.is3D(toMove)) {
+  if (util.is3D(toMove) || util.isWireGeometry(toMove) || util.isSurface(toMove) || util.isPoint3D(toMove)) {
     return util.actOnLeafs(
       toMove,
       async (leaf: AbundanceLeaf) => {
@@ -316,7 +325,7 @@ async function rotate(
   if (toRotate.nonReplicadSerialized) {
     toRotate.nonReplicadSerialized = handleNonReplicadRotate(toRotate, x, y, z);
   }
-  if (util.is3D(toRotate)) {
+  if (util.is3D(toRotate) || util.isWireGeometry(toRotate) || util.isSurface(toRotate) || util.isPoint3D(toRotate)) {
     return util.actOnLeafs(
       toRotate,
       async (leaf: AbundanceLeaf) => {

--- a/src/worker/actions.ts
+++ b/src/worker/actions.ts
@@ -18,9 +18,7 @@ async function extrude(
     throw new Error("Cannot extrude a 3D geometry.");
   }
   if (util.isWireGeometry(toExtrude)) {
-    throw new Error(
-      "Cannot extrude a Wire. Use a sweep operation to create a surface from a Wire profile.",
-    );
+    throw new Error("Cannot extrude a Wire.");
   }
   if (util.isPoint3D(toExtrude)) {
     throw new Error("Cannot extrude a Point3D.");

--- a/src/worker/actions.ts
+++ b/src/worker/actions.ts
@@ -18,10 +18,9 @@ async function extrude(
     throw new Error("Cannot extrude a 3D geometry.");
   }
   if (util.isWireGeometry(toExtrude)) {
-    throw new Error("Cannot extrude a Wire. Use a sweep operation to create a surface from a Wire profile.");
-  }
-  if (util.isSurface(toExtrude)) {
-    throw new Error("Cannot extrude a Surface geometry.");
+    throw new Error(
+      "Cannot extrude a Wire. Use a sweep operation to create a surface from a Wire profile.",
+    );
   }
   if (util.isPoint3D(toExtrude)) {
     throw new Error("Cannot extrude a Point3D.");
@@ -143,7 +142,11 @@ async function move(
     z,
     context,
   );
-  if (util.is3D(toMove) || util.isWireGeometry(toMove) || util.isSurface(toMove) || util.isPoint3D(toMove)) {
+  if (
+    util.is3D(toMove) ||
+    util.isWireGeometry(toMove) ||
+    util.isPoint3D(toMove)
+  ) {
     return util.actOnLeafs(
       toMove,
       async (leaf: AbundanceLeaf) => {
@@ -325,7 +328,11 @@ async function rotate(
   if (toRotate.nonReplicadSerialized) {
     toRotate.nonReplicadSerialized = handleNonReplicadRotate(toRotate, x, y, z);
   }
-  if (util.is3D(toRotate) || util.isWireGeometry(toRotate) || util.isSurface(toRotate) || util.isPoint3D(toRotate)) {
+  if (
+    util.is3D(toRotate) ||
+    util.isWireGeometry(toRotate) ||
+    util.isPoint3D(toRotate)
+  ) {
     return util.actOnLeafs(
       toRotate,
       async (leaf: AbundanceLeaf) => {

--- a/src/worker/code-legacy.ts
+++ b/src/worker/code-legacy.ts
@@ -41,7 +41,7 @@ export type RealizedAssembly = RealizedLeaf | RealizedBranch;
 export type RealizedBranch = {
   geometry: RealizedAssembly[];
   plane: replicad.Plane;
-  dimension: "2D" | "3D" | "Wire";
+  dimension: "2D" | "3D" | "Wire" | "Surface" | "Point3D";
   color: string;
   tags: string[];
   bom: string[];
@@ -50,7 +50,7 @@ export type RealizedBranch = {
 export type RealizedLeaf = {
   geometry: ReplicadObject[]; // For backwards compatibility this is an array. But it always contains a single item.
   plane: replicad.Plane;
-  dimension: "2D" | "3D" | "Wire";
+  dimension: "2D" | "3D" | "Wire" | "Surface" | "Point3D";
   color: string;
   tags: string[];
   bom: string[];

--- a/src/worker/code-legacy.ts
+++ b/src/worker/code-legacy.ts
@@ -41,7 +41,7 @@ export type RealizedAssembly = RealizedLeaf | RealizedBranch;
 export type RealizedBranch = {
   geometry: RealizedAssembly[];
   plane: replicad.Plane;
-  dimension: "2D" | "3D" | "Wire" | "Surface" | "Point3D";
+  dimension: "2D" | "3D" | "Wire" | "Point3D";
   color: string;
   tags: string[];
   bom: string[];
@@ -50,7 +50,7 @@ export type RealizedBranch = {
 export type RealizedLeaf = {
   geometry: ReplicadObject[]; // For backwards compatibility this is an array. But it always contains a single item.
   plane: replicad.Plane;
-  dimension: "2D" | "3D" | "Wire" | "Surface" | "Point3D";
+  dimension: "2D" | "3D" | "Wire" | "Point3D";
   color: string;
   tags: string[];
   bom: string[];

--- a/src/worker/code.ts
+++ b/src/worker/code.ts
@@ -53,7 +53,7 @@ import { makeAbundanceFramework } from "./generated/ts-framework.generated.js";
 // so it's safe to bind these at module load time. The factory itself just
 // declares the class; replicad is only dereferenced when Assembly methods
 // are actually invoked, by which time `init()` has run.
-const { Assembly, __promoteInput } = makeAbundanceFramework(
+const { Assembly } = makeAbundanceFramework(
   util.replicad as any,
 );
 type Assembly<G = any> = InstanceType<typeof Assembly> & { geometry: G };
@@ -114,16 +114,6 @@ function isPrimitive(value: any): value is Primitive {
  */
 function isAssembly(value: any): boolean {
   return !!value && value.__abundance === "Assembly";
-}
-
-function isReplicadAnyShape(value: any): value is replicad.AnyShape {
-  return (
-    replicad.isShape3D(value) ||
-    value instanceof replicad.Wire ||
-    value instanceof replicad.Face ||
-    value instanceof replicad.Edge ||
-    value instanceof replicad.Vertex
-  );
 }
 
 /**

--- a/src/worker/code.ts
+++ b/src/worker/code.ts
@@ -220,7 +220,7 @@ function convertCodeAtomResult(
     return value;
   }
 
-  throw new Error("Unsupported return type: " + JSON.stringify(value));
+  throw new Error("Unsupported return type: " + value.constructor.name);
 }
 
 /**

--- a/src/worker/code.ts
+++ b/src/worker/code.ts
@@ -170,7 +170,6 @@ function extractRunParamNames(code: string): string[] {
  */
 function defaultProps() {
   return {
-    color: "#ffffff",
     tags: [] as string[],
     bom: [] as string[],
     plane: util.replicad.makePlane(),
@@ -195,11 +194,11 @@ function convertCodeAtomResult(
   if (value == null) return value;
   if (isPrimitive(value)) return value;
 
-  if (isReplicadAnyShape(value) || value instanceof replicad.Drawing) {
-    return new Assembly({ geometry: value, ...defaultProps() });
+  if (Array.isArray(value) && value.every(isPrimitive)) {
+    return value;
   }
 
-  if (Array.isArray(value) && value.every(isPrimitive)) {
+  if (isAssembly(value)) {
     return value;
   }
 
@@ -216,11 +215,21 @@ function convertCodeAtomResult(
     });
   }
 
-  if (isAssembly(value)) {
-    return value;
+  let simpleReplicadGeomDim = undefined;
+  try {
+    simpleReplicadGeomDim = util.dimensionLabel(value);
+    const isFacelessType =
+      simpleReplicadGeomDim === "Point3D" || simpleReplicadGeomDim === "Wire";
+    return new Assembly({
+      geometry: value,
+      dimension: simpleReplicadGeomDim,
+      color: isFacelessType ? "#3c5a6e" : util.defaultColor,
+      ...defaultProps(),
+    });
+  } catch (e) {
+    console.error(e);
+    throw new Error("Unsupported return type: " + value.constructor.name);
   }
-
-  throw new Error("Unsupported return type: " + value.constructor.name);
 }
 
 /**
@@ -236,21 +245,16 @@ async function addAssemblyPartsToCache(
     assembly: Assembly<AnyGeom>,
   ): Promise<AbundanceObject> => {
     if (assembly.isLeaf()) {
-      if (
-        !(assembly.geometry instanceof replicad.Drawing) &&
-        !replicad.isShape3D(assembly.geometry)
-      ) {
-        const typeName =
-          assembly.geometry && assembly.geometry.constructor
-            ? assembly.geometry.constructor.name
-            : typeof assembly.geometry;
-        throw new Error(
-          "Leaf geometry must be Shape3D or Drawing. But received " +
-            typeName +
-            (typeName === "Edge"
-              ? " (note: makeCircle returns Edge, consider drawCircle instead)"
-              : ""),
-        );
+      let dimensionLabel;
+      try {
+        dimensionLabel = util.dimensionLabel(assembly.geometry);
+      } catch (e: any) {
+        if (assembly.geometry instanceof replicad.Edge) {
+          e.message +=
+            " Raw Edges not supported. Consider returning a drawing, eg drawCircle instead of makeCircle. " +
+            " Or return a wire via replicad.assembleWire([edge, edge2, ...]) instead";
+        }
+        throw e;
       }
       return {
         ...assembly,
@@ -263,11 +267,7 @@ async function addAssemblyPartsToCache(
         plane: assembly.plane
           ? util.asSimplePlane(assembly.plane)
           : util.XYPlane,
-        // The Assembly class only has is2D()/is3D() methods, not a `dimension`
-        // property. Without this, util.is3D() sees `undefined` and treats even
-        // 3D code-atom outputs as 2D sketches, breaking fusion with extruded
-        // shapes ("Fusion must be composed from only sketches OR only solids").
-        dimension: assembly.is2D() ? "2D" : "3D",
+        dimension: dimensionLabel,
       };
     } else {
       const children = await Promise.all(
@@ -581,12 +581,14 @@ async function executeTsCode(
     }
 
     // Ensure not a mix of 2d and 3d parts.
-    const leafDims: boolean[] = [];
+    const leafDims: string[] = [];
     rawResult.onLeafs((leaf: Assembly<LeafGeom>) => {
-      leafDims.push(leaf.is2D());
+      leafDims.push(leaf.dimension);
     });
-    if (leafDims.includes(true) && leafDims.includes(false)) {
-      throw new Error("Mix of 2D and 3D parts is not allowed.");
+    if (new Set(leafDims).size > 1) {
+      throw new Error(
+        `Assemblies may not mix types. Found: ${leafDims.join(", ")}.`,
+      );
     }
 
     // Promote raw geometries into the cache as singletons.

--- a/src/worker/generated/ts-framework.generated.d.ts
+++ b/src/worker/generated/ts-framework.generated.d.ts
@@ -14,6 +14,7 @@ declare global {
     type Sketch = _replicad.Sketch;
     type Sketches = _replicad.Sketches;
     type Wire = _replicad.Wire;
+    type Vertex = _replicad.Vertex;
     type Face = _replicad.Face;
     type Solid = _replicad.Solid;
     type Shape<T> = _replicad.Shape<T>;
@@ -77,13 +78,12 @@ declare global {
        * leaf yielded by depth-first traversal; a branch with no leaves is
        * considered 3D.
        */
-      isDrawing2D(): boolean;
+      is2D(): this is Assembly<_replicad.Drawing>;
       /** True when this assembly's first leaf is a replicad Wire (1D curve). */
-      isWire(): boolean;
-      /** True when this assembly's first leaf is a replicad Shell (open surface). */
-      isSurface(): boolean;
+      isWire(): this is Assembly<_replicad.Wire>;
+      isPoint(): this is Assembly<_replicad.Vertex>;
       /** True when this assembly's first leaf is a 3D replicad solid (not a Wire or Point3D). */
-      isSolid3D(): boolean;
+      is3D(): this is Assembly<_replicad.AnyShape>;
       toJSON(): string;
   }
   /**

--- a/src/worker/generated/ts-framework.generated.d.ts
+++ b/src/worker/generated/ts-framework.generated.d.ts
@@ -82,9 +82,7 @@ declare global {
       isWire(): boolean;
       /** True when this assembly's first leaf is a replicad Shell (open surface). */
       isSurface(): boolean;
-      /** True when this assembly's first leaf is a replicad Vertex (Point3D). */
-      isPoint3D(): boolean;
-      /** True when this assembly's first leaf is a 3D replicad solid (not a Wire, Surface, or Point3D). */
+      /** True when this assembly's first leaf is a 3D replicad solid (not a Wire or Point3D). */
       isSolid3D(): boolean;
       toJSON(): string;
   }

--- a/src/worker/generated/ts-framework.generated.d.ts
+++ b/src/worker/generated/ts-framework.generated.d.ts
@@ -77,7 +77,7 @@ declare global {
        * leaf yielded by depth-first traversal; a branch with no leaves is
        * considered 3D.
        */
-      is2D(): this is Assembly<_replicad.Drawing>;
+      isDrawing2D(): boolean;
       /** True when this assembly's first leaf is a replicad Wire (1D curve). */
       isWire(): boolean;
       /** True when this assembly's first leaf is a replicad Shell (open surface). */
@@ -85,7 +85,7 @@ declare global {
       /** True when this assembly's first leaf is a replicad Vertex (Point3D). */
       isPoint3D(): boolean;
       /** True when this assembly's first leaf is a 3D replicad solid (not a Wire, Surface, or Point3D). */
-      is3D(): this is Assembly<_replicad.AnyShape>;
+      isSolid3D(): boolean;
       toJSON(): string;
   }
   /**

--- a/src/worker/generated/ts-framework.generated.d.ts
+++ b/src/worker/generated/ts-framework.generated.d.ts
@@ -78,7 +78,13 @@ declare global {
        * considered 3D.
        */
       is2D(): this is Assembly<_replicad.Drawing>;
-      /** True when this assembly's first leaf is a 3D replicad shape. */
+      /** True when this assembly's first leaf is a replicad Wire (1D curve). */
+      isWire(): boolean;
+      /** True when this assembly's first leaf is a replicad Shell (open surface). */
+      isSurface(): boolean;
+      /** True when this assembly's first leaf is a replicad Vertex (Point3D). */
+      isPoint3D(): boolean;
+      /** True when this assembly's first leaf is a 3D replicad solid (not a Wire, Surface, or Point3D). */
       is3D(): this is Assembly<_replicad.AnyShape>;
       toJSON(): string;
   }

--- a/src/worker/generated/ts-framework.generated.js
+++ b/src/worker/generated/ts-framework.generated.js
@@ -12,7 +12,7 @@ export function makeAbundanceFramework(replicad) {
       // `geometry: any` to `geometry: G` so callers see the generic parameter
       // narrowed to the proper replicad union. See scripts/build-ts-framework.mjs.
       __publicField(this, "geometry", []);
-      __publicField(this, "color", "#ffffff");
+      __publicField(this, "color", "#aad7f2");
       __publicField(this, "tags", []);
       __publicField(this, "bom", []);
       __publicField(this, "plane", replicad.makePlane());
@@ -69,9 +69,9 @@ export function makeAbundanceFramework(replicad) {
      * leaf yielded by depth-first traversal; a branch with no leaves is
      * considered 3D.
      */
-    is2D() {
+    isDrawing2D() {
       if (Array.isArray(this.geometry)) {
-        return this.geometry.length > 0 && this.geometry[0].is2D();
+        return this.geometry.length > 0 && this.geometry[0].isDrawing2D();
       }
       const g = this.geometry;
       return !!g && !("_wrapped" in g);
@@ -98,8 +98,11 @@ export function makeAbundanceFramework(replicad) {
       return this.geometry instanceof replicad.Vertex;
     }
     /** True when this assembly's first leaf is a 3D replicad solid (not a Wire, Surface, or Point3D). */
-    is3D() {
-      return !this.is2D() && !this.isWire() && !this.isSurface() && !this.isPoint3D();
+    isSolid3D() {
+      if (Array.isArray(this.geometry)) {
+        return this.geometry.length > 0 && this.geometry[0].isSolid3D();
+      }
+      return replicad.isShape3D(this.geometry) && !(this.geometry instanceof replicad.Shell);
     }
     toJSON() {
       let geomString = "unknown";

--- a/src/worker/generated/ts-framework.generated.js
+++ b/src/worker/generated/ts-framework.generated.js
@@ -69,9 +69,9 @@ export function makeAbundanceFramework(replicad) {
      * leaf yielded by depth-first traversal; a branch with no leaves is
      * considered 3D.
      */
-    isDrawing2D() {
+    is2D() {
       if (Array.isArray(this.geometry)) {
-        return this.geometry.length > 0 && this.geometry[0].isDrawing2D();
+        return this.geometry.length > 0 && this.geometry[0].is2D();
       }
       const g = this.geometry;
       return !!g && !("_wrapped" in g);
@@ -83,17 +83,16 @@ export function makeAbundanceFramework(replicad) {
       }
       return this.geometry instanceof replicad.Wire;
     }
-    /** True when this assembly's first leaf is a replicad Shell (open surface). */
-    isSurface() {
+    isPoint() {
       if (Array.isArray(this.geometry)) {
-        return this.geometry.length > 0 && this.geometry[0].isSurface();
+        return this.geometry.length > 0 && this.geometry[0].isPoint();
       }
-      return this.geometry instanceof replicad.Shell;
+      return this.geometry instanceof replicad.Vertex;
     }
     /** True when this assembly's first leaf is a 3D replicad solid (not a Wire or Point3D). */
-    isSolid3D() {
+    is3D() {
       if (Array.isArray(this.geometry)) {
-        return this.geometry.length > 0 && this.geometry[0].isSolid3D();
+        return this.geometry.length > 0 && this.geometry[0].is3D();
       }
       return replicad.isShape3D(this.geometry);
     }

--- a/src/worker/generated/ts-framework.generated.js
+++ b/src/worker/generated/ts-framework.generated.js
@@ -90,19 +90,12 @@ export function makeAbundanceFramework(replicad) {
       }
       return this.geometry instanceof replicad.Shell;
     }
-    /** True when this assembly's first leaf is a replicad Vertex (Point3D). */
-    isPoint3D() {
-      if (Array.isArray(this.geometry)) {
-        return this.geometry.length > 0 && this.geometry[0].isPoint3D();
-      }
-      return this.geometry instanceof replicad.Vertex;
-    }
-    /** True when this assembly's first leaf is a 3D replicad solid (not a Wire, Surface, or Point3D). */
+    /** True when this assembly's first leaf is a 3D replicad solid (not a Wire or Point3D). */
     isSolid3D() {
       if (Array.isArray(this.geometry)) {
         return this.geometry.length > 0 && this.geometry[0].isSolid3D();
       }
-      return replicad.isShape3D(this.geometry) && !(this.geometry instanceof replicad.Shell);
+      return replicad.isShape3D(this.geometry);
     }
     toJSON() {
       let geomString = "unknown";

--- a/src/worker/generated/ts-framework.generated.js
+++ b/src/worker/generated/ts-framework.generated.js
@@ -76,9 +76,30 @@ export function makeAbundanceFramework(replicad) {
       const g = this.geometry;
       return !!g && !("_wrapped" in g);
     }
-    /** True when this assembly's first leaf is a 3D replicad shape. */
+    /** True when this assembly's first leaf is a replicad Wire (1D curve). */
+    isWire() {
+      if (Array.isArray(this.geometry)) {
+        return this.geometry.length > 0 && this.geometry[0].isWire();
+      }
+      return this.geometry instanceof replicad.Wire;
+    }
+    /** True when this assembly's first leaf is a replicad Shell (open surface). */
+    isSurface() {
+      if (Array.isArray(this.geometry)) {
+        return this.geometry.length > 0 && this.geometry[0].isSurface();
+      }
+      return this.geometry instanceof replicad.Shell;
+    }
+    /** True when this assembly's first leaf is a replicad Vertex (Point3D). */
+    isPoint3D() {
+      if (Array.isArray(this.geometry)) {
+        return this.geometry.length > 0 && this.geometry[0].isPoint3D();
+      }
+      return this.geometry instanceof replicad.Vertex;
+    }
+    /** True when this assembly's first leaf is a 3D replicad solid (not a Wire, Surface, or Point3D). */
     is3D() {
-      return !this.is2D();
+      return !this.is2D() && !this.isWire() && !this.isSurface() && !this.isPoint3D();
     }
     toJSON() {
       let geomString = "unknown";

--- a/src/worker/generated/ts-framework.generated.js
+++ b/src/worker/generated/ts-framework.generated.js
@@ -87,7 +87,7 @@ export function makeAbundanceFramework(replicad) {
       } else if (this.geometry instanceof replicad.Shape || this.geometry instanceof replicad.Drawing) {
         geomString = this.geometry.constructor.name;
       }
-      let planeString = this.plane ? "replicad.plane" : "null";
+      const planeString = this.plane ? "replicad.plane" : "null";
       return `{__isRawAbundanceObj: true, color: ${this.color}, tags: ${JSON.stringify(this.tags)}, bom: ${JSON.stringify(this.bom)}, plane: ${planeString}, geometry: ${geomString}}`;
     }
   }

--- a/src/worker/geometryProvider.ts
+++ b/src/worker/geometryProvider.ts
@@ -16,7 +16,11 @@ import {
   filter,
 } from "./indexeddbUtils";
 
-type ReplicadObject = replicad.Shape3D | replicad.Drawing | replicad.Wire | replicad.Vertex;
+type ReplicadObject =
+  | replicad.Shape3D
+  | replicad.Drawing
+  | replicad.Wire
+  | replicad.Vertex;
 
 type RequestContext = {
   project: string;
@@ -423,7 +427,10 @@ class GeometryProvider {
     const filletId = this._makeId("fillet", id, radius);
     await this.createIfAbsent(filletId, context, async () => {
       const geometry = await this.get(id, context);
-      if (geometry instanceof replicad.Wire || geometry instanceof replicad.Vertex) {
+      if (
+        geometry instanceof replicad.Wire ||
+        geometry instanceof replicad.Vertex
+      ) {
         throw new Error("Cannot fillet a wire or Point3D");
       }
       return (geometry as replicad.Shape3D | replicad.Drawing).fillet(radius);
@@ -439,7 +446,10 @@ class GeometryProvider {
     const chamferId = this._makeId("chamfer", id, size);
     await this.createIfAbsent(chamferId, context, async () => {
       const geometry = await this.get(id, context);
-      if (geometry instanceof replicad.Wire || geometry instanceof replicad.Vertex) {
+      if (
+        geometry instanceof replicad.Wire ||
+        geometry instanceof replicad.Vertex
+      ) {
         throw new Error("Cannot chamfer a wire or Point3D");
       }
       return (geometry as replicad.Shape3D | replicad.Drawing).chamfer(size);

--- a/src/worker/geometryProvider.ts
+++ b/src/worker/geometryProvider.ts
@@ -9,6 +9,7 @@ import {
 import {
   getShape,
   putShape,
+  deleteShape,
   deleteProjectCache,
   shapeExists,
   getAllProjectIds,

--- a/src/worker/geometryProvider.ts
+++ b/src/worker/geometryProvider.ts
@@ -706,21 +706,40 @@ class GeometryProvider {
     const shrinkWrapId = this._makeId("shrinkWrap", compositeSketchId, points);
     await this.createIfAbsent(shrinkWrapId, context, async () => {
       const geometry = await this.get(compositeSketchId, context);
-      //@ts-ignore
       return shrinkWrap(geometry, points);
     });
     return shrinkWrapId;
   }
 
+  async _getAsPoint(
+    id: string,
+    context: RequestContext,
+  ): Promise<replicad.Vertex> {
+    const geom = await this.get(id, context);
+    if (geom instanceof replicad.Vertex) {
+      return geom;
+    } else {
+      throw new Error("Expected a Point3D but got " + typeof geom);
+    }
+  }
+
   async loftSketches(
     sketchIds: string[],
     planes: SimplePlane[],
+    startPoint: string | undefined,
+    endPoint: string | undefined,
     context: RequestContext,
   ): Promise<string> {
     if (sketchIds.length != planes.length) {
       throw new Error("Number of sketches and planes must match");
     }
-    const loftId = this._makeId("loft", ...sketchIds, ...planes);
+    const loftId = this._makeId(
+      "loft",
+      ...sketchIds,
+      ...planes,
+      startPoint,
+      endPoint,
+    );
     await this.createIfAbsent(loftId, context, async () => {
       const sketches = [];
       for (let i = 0; i < sketchIds.length; i++) {
@@ -737,7 +756,44 @@ class GeometryProvider {
           );
         }
       }
-      return sketches[0].loftWith(sketches.slice(1), {});
+      const config = {
+        startPoint: startPoint
+          ? (await this._getAsPoint(startPoint, context)).asTuple()
+          : undefined,
+        endPoint: endPoint
+          ? (await this._getAsPoint(endPoint, context)).asTuple()
+          : undefined,
+      };
+      return sketches[0].loftWith(sketches.slice(1), config);
+    });
+    return loftId;
+  }
+
+  async loftWires(
+    wireIds: string[],
+    startPoint: string | undefined,
+    endPoint: string | undefined,
+    context: RequestContext,
+  ): Promise<string> {
+    const loftId = this._makeId("loftWire", ...wireIds, startPoint, endPoint);
+    await this.createIfAbsent(loftId, context, async () => {
+      const wires = [];
+      for (let i = 0; i < wireIds.length; i++) {
+        const partObj = (await this.get(wireIds[i], context)) as replicad.Wire;
+        if (!partObj.isClosed) {
+          throw new Error("Only closed wires may be lofted");
+        }
+        wires.push(partObj);
+      }
+      const config = {
+        startPoint: startPoint
+          ? (await this._getAsPoint(startPoint, context)).asTuple()
+          : undefined,
+        endPoint: endPoint
+          ? (await this._getAsPoint(endPoint, context)).asTuple()
+          : undefined,
+      };
+      return replicad.loft(wires, config);
     });
     return loftId;
   }

--- a/src/worker/geometryProvider.ts
+++ b/src/worker/geometryProvider.ts
@@ -9,7 +9,6 @@ import {
 import {
   getShape,
   putShape,
-  deleteShape,
   deleteProjectCache,
   shapeExists,
   getAllProjectIds,

--- a/src/worker/geometryProvider.ts
+++ b/src/worker/geometryProvider.ts
@@ -16,7 +16,7 @@ import {
   filter,
 } from "./indexeddbUtils";
 
-type ReplicadObject = replicad.Shape3D | replicad.Drawing | replicad.Wire;
+type ReplicadObject = replicad.Shape3D | replicad.Drawing | replicad.Wire | replicad.Vertex;
 
 type RequestContext = {
   project: string;
@@ -423,10 +423,10 @@ class GeometryProvider {
     const filletId = this._makeId("fillet", id, radius);
     await this.createIfAbsent(filletId, context, async () => {
       const geometry = await this.get(id, context);
-      if (geometry instanceof replicad.Wire) {
-        throw new Error("Cannot fillet a wire");
+      if (geometry instanceof replicad.Wire || geometry instanceof replicad.Vertex) {
+        throw new Error("Cannot fillet a wire or Point3D");
       }
-      return geometry.fillet(radius);
+      return (geometry as replicad.Shape3D | replicad.Drawing).fillet(radius);
     });
     return filletId;
   }
@@ -439,10 +439,10 @@ class GeometryProvider {
     const chamferId = this._makeId("chamfer", id, size);
     await this.createIfAbsent(chamferId, context, async () => {
       const geometry = await this.get(id, context);
-      if (geometry instanceof replicad.Wire) {
-        throw new Error("Cannot chamfer a wire");
+      if (geometry instanceof replicad.Wire || geometry instanceof replicad.Vertex) {
+        throw new Error("Cannot chamfer a wire or Point3D");
       }
-      return geometry.chamfer(size);
+      return (geometry as replicad.Shape3D | replicad.Drawing).chamfer(size);
     });
     return chamferId;
   }

--- a/src/worker/interaction.ts
+++ b/src/worker/interaction.ts
@@ -20,13 +20,9 @@ async function loftShapes(
   await util.init();
   const sketchAndPlane = await Promise.all(
     sketches.map(async (sketch) => {
-      if (
-        util.isWireGeometry(sketch) ||
-        util.isSurface(sketch) ||
-        util.isPoint3D(sketch)
-      ) {
+      if (util.isWireGeometry(sketch) || util.isPoint3D(sketch)) {
         throw new Error(
-          "Parts to be lofted must be 2D sketches, not Wire, Surface, or Point3D.",
+          "Parts to be lofted must be 2D sketches, not Wire or Point3D.",
         );
       }
       if (util.is3D(sketch)) {
@@ -67,22 +63,14 @@ async function difference(
   context: RequestContext,
 ): Promise<AbundanceObject> {
   await util.init();
-  if (
-    util.isWireGeometry(target) ||
-    util.isSurface(target) ||
-    util.isPoint3D(target)
-  ) {
+  if (util.isWireGeometry(target) || util.isPoint3D(target)) {
     throw new Error(
-      "difference() target must be a 3D solid or 2D sketch, not Wire, Surface, or Point3D.",
+      "difference() target must be a 3D solid or 2D sketch, not Wire or Point3D.",
     );
   }
-  if (
-    util.isWireGeometry(cutter) ||
-    util.isSurface(cutter) ||
-    util.isPoint3D(cutter)
-  ) {
+  if (util.isWireGeometry(cutter) || util.isPoint3D(cutter)) {
     throw new Error(
-      "difference() cutter must be a 3D solid or 2D sketch, not Wire, Surface, or Point3D.",
+      "difference() cutter must be a 3D solid or 2D sketch, not Wire or Point3D.",
     );
   }
   if (
@@ -109,14 +97,11 @@ async function shrinkWrapSketches(
   const BOM: any[] = [];
   if (
     sketches.some(
-      (sketch) =>
-        util.isWireGeometry(sketch) ||
-        util.isSurface(sketch) ||
-        util.isPoint3D(sketch),
+      (sketch) => util.isWireGeometry(sketch) || util.isPoint3D(sketch),
     )
   ) {
     throw new Error(
-      "Parts to be shrink wrapped must be 2D sketches, not Wire, Surface, or Point3D.",
+      "Parts to be shrink wrapped must be 2D sketches, not Wire or Point3D.",
     );
   }
   if (sketches.some((sketch) => util.is3D(sketch))) {
@@ -172,14 +157,12 @@ async function intersect(
   await util.init();
   if (
     util.isWireGeometry(shape1) ||
-    util.isSurface(shape1) ||
     util.isPoint3D(shape1) ||
     util.isWireGeometry(shape2) ||
-    util.isSurface(shape2) ||
     util.isPoint3D(shape2)
   ) {
     throw new Error(
-      "intersect() requires 3D solids or 2D sketches, not Wire, Surface, or Point3D.",
+      "intersect() requires 3D solids or 2D sketches, not Wire or Point3D.",
     );
   }
   return util.actOnLeafs(shape1, async (leaf: AbundanceLeaf) => {
@@ -212,13 +195,9 @@ async function fusion(
 ): Promise<AbundanceLeaf> {
   await util.init();
   for (const shape of shapes) {
-    if (
-      util.isWireGeometry(shape) ||
-      util.isSurface(shape) ||
-      util.isPoint3D(shape)
-    ) {
+    if (util.isWireGeometry(shape) || util.isPoint3D(shape)) {
       throw new Error(
-        "fusion() requires 3D solids or 2D sketches, not Wire, Surface, or Point3D.",
+        "fusion() requires 3D solids or 2D sketches, not Wire or Point3D.",
       );
     }
   }

--- a/src/worker/interaction.ts
+++ b/src/worker/interaction.ts
@@ -18,39 +18,104 @@ async function loftShapes(
   context: RequestContext,
 ): Promise<AbundanceObject> {
   await util.init();
-  const sketchAndPlane = await Promise.all(
-    sketches.map(async (sketch) => {
-      if (util.isWireGeometry(sketch) || util.isPoint3D(sketch)) {
-        throw new Error(
-          "Parts to be lofted must be 2D sketches, not Wire or Point3D.",
-        );
-      }
-      if (util.is3D(sketch)) {
+  const loftArgsDeep = await Promise.all(
+    sketches.map(async (geom, index) => {
+      if (util.is3D(geom)) {
         throw new Error("Parts to be lofted must be sketches");
       }
-      const result = await fuseAssembly(sketch, context);
-      return {
-        geometry: result.geometry,
-        plane: result.plane,
-      };
+      if (util.is2D(geom)) {
+        // Drawing assemblies should be fused before lofting.
+        const result = await fuseAssembly(geom, context);
+        return {
+          type: "sketch",
+          geometry: result.geometry,
+          plane: result.plane,
+        };
+      }
+      // Wires and points
+      if (util.isWireGeometry(geom) || util.isPoint3D(geom)) {
+        return util.flattenAssembly(geom).map((leaf) => {
+          return {
+            type: util.isPoint3D(leaf) ? "point" : "wire",
+            geometry: leaf.geometry,
+            plane: leaf.plane,
+          };
+        });
+      }
+      throw new Error("Unsupported geometry type for lofting. input #" + index);
     }),
   );
 
-  const sketchList = sketchAndPlane.map((sp) => sp.geometry);
-  const planes = sketchAndPlane.map((sp) => sp.plane);
+  const sketchAndPlane = loftArgsDeep.flat();
+  // Structural checks. Not all mixtures of inputs are allowed.
+  if (
+    sketchAndPlane.some((sp) => sp.type === "wire") &&
+    sketchAndPlane.some((sp) => sp.type === "sketch")
+  ) {
+    throw new Error("Cannot loft a mixture of wires and sketches");
+  }
 
-  return {
-    geometry: await util.geometryProvider!.loftSketches(
-      sketchList,
-      planes,
-      context,
-    ),
-    dimension: "3D",
-    tags: [],
-    plane: util.XYPlane,
-    color: util.defaultColor,
-    bom: [],
-  };
+  // Points act as breaks in the loft structure since replicad only supports
+  // point as the start/end of a loft. We try to handle this invisibly for users.
+  const loftSegments: {
+    type: string;
+    geometry: string;
+    plane: util.SimplePlane;
+  }[][] = [];
+  loftSegments.push([sketchAndPlane[0]]);
+  for (let i = 1; i < sketchAndPlane.length; i++) {
+    loftSegments[loftSegments.length - 1].push(sketchAndPlane[i]);
+    if (sketchAndPlane[i].type === "point" && i != sketchAndPlane.length - 1) {
+      // A point not at the start or end of the loft arg list.
+      loftSegments.push([sketchAndPlane[i]]);
+    }
+  }
+
+  const results = [];
+  for (const segment of loftSegments) {
+    // Structure check
+    if (segment.every((g) => g.type === "point")) {
+      throw new Error(
+        "Loft cannot have consecutive points with no sketches/wires in between",
+      );
+    }
+
+    const startPoint = segment[0].type == "point" ? segment[0] : undefined;
+    const endpoint =
+      segment[segment.length - 1].type == "point"
+        ? segment[segment.length - 1]
+        : undefined;
+    const targets = segment.filter((g) => g.type !== "point");
+    let geometry;
+    if (targets[0].type === "wire") {
+      geometry = await util.geometryProvider!.loftWires(
+        targets.map((t) => t.geometry),
+        startPoint ? startPoint.geometry : undefined,
+        endpoint ? endpoint.geometry : undefined,
+        context,
+      );
+    } else {
+      geometry = await util.geometryProvider!.loftSketches(
+        targets.map((t) => t.geometry),
+        targets.map((t) => t.plane),
+        startPoint ? startPoint.geometry : undefined,
+        endpoint ? endpoint.geometry : undefined,
+        context,
+      );
+    }
+    results.push({
+      geometry: geometry,
+      dimension: "3D",
+      tags: [],
+      plane: util.XYPlane,
+      color: util.defaultColor,
+      bom: [],
+    });
+  }
+  if (results.length === 1) {
+    return results[0] as AbundanceObject;
+  }
+  return assembly(results as AbundanceObject[], context);
 }
 
 /**

--- a/src/worker/interaction.ts
+++ b/src/worker/interaction.ts
@@ -280,6 +280,21 @@ async function assembly(
   if (!Array.isArray(geometries) || geometries.length === 0) {
     throw new Error("inputIDs must be a non-empty array");
   }
+
+  // Dimension assertions:
+  // Allowed inputs -> all 2d, all 3d, or just wires/points
+
+  const all3D = geometries.every((geom) => util.is3D(geom));
+  const all2D = geometries.every((geom) => util.is2D(geom));
+  const allWireOrPoint = geometries.every(
+    (geom) => util.isWireGeometry(geom) || util.isPoint3D(geom),
+  );
+  if (!(all2D || all3D || allWireOrPoint)) {
+    throw new Error(
+      "Input geometries must be all 2D, all 3D, or just wires/points.",
+    );
+  }
+
   await util.init();
 
   let startedBatch = false;
@@ -318,38 +333,27 @@ async function assembly(
   const bomAssembly: any[] = [];
   const nonReplicadGeoms: any[] = [];
 
-  let all3D = false;
-  let all2D = false;
   if (geometries.length > 1) {
-    all3D = geometries.every((geom) => util.is3D(geom));
-    all2D = geometries.every((geom) => !util.is3D(geom));
-
-    if (all3D || all2D) {
-      // Always clear arrays before populating
-      bomAssembly.length = 0;
-      nonReplicadGeoms.length = 0;
-      for (let i = 0; i < geometries.length; i++) {
-        const geometry = geometries[i];
-        assembly.push(
-          await cutAssembly(geometry, geometries.slice(i + 1), context),
-        );
-      }
-      // Gather all nonReplicadSerialized and bom from input geometries
-      for (const geometry of geometries) {
-        if (
-          Array.isArray(geometry.nonReplicadSerialized) &&
-          geometry.nonReplicadSerialized.length > 0
-        ) {
-          nonReplicadGeoms.push(...geometry.nonReplicadSerialized);
-        }
-        if (Array.isArray(geometry.bom) && geometry.bom.length > 0) {
-          bomAssembly.push(...geometry.bom);
-        }
-      }
-    } else {
-      throw new Error(
-        "Assemblies must be composed from only sketches OR only solids",
+    // Always clear arrays before populating
+    bomAssembly.length = 0;
+    nonReplicadGeoms.length = 0;
+    for (let i = 0; i < geometries.length; i++) {
+      const geometry = geometries[i];
+      assembly.push(
+        await cutAssembly(geometry, geometries.slice(i + 1), context),
       );
+    }
+    // Gather all nonReplicadSerialized and bom from input geometries
+    for (const geometry of geometries) {
+      if (
+        Array.isArray(geometry.nonReplicadSerialized) &&
+        geometry.nonReplicadSerialized.length > 0
+      ) {
+        nonReplicadGeoms.push(...geometry.nonReplicadSerialized);
+      }
+      if (Array.isArray(geometry.bom) && geometry.bom.length > 0) {
+        bomAssembly.push(...geometry.bom);
+      }
     }
   } else {
     // Always clear arrays before populating
@@ -376,7 +380,6 @@ async function assembly(
     tags: [],
     color: util.defaultColor,
     bom: bomAssembly,
-    dimension: all3D ? "3D" : "2D",
     nonReplicadSerialized: nonReplicadGeoms,
   };
   if (startedBatch) {

--- a/src/worker/interaction.ts
+++ b/src/worker/interaction.ts
@@ -20,6 +20,15 @@ async function loftShapes(
   await util.init();
   const sketchAndPlane = await Promise.all(
     sketches.map(async (sketch) => {
+      if (
+        util.isWireGeometry(sketch) ||
+        util.isSurface(sketch) ||
+        util.isPoint3D(sketch)
+      ) {
+        throw new Error(
+          "Parts to be lofted must be 2D sketches, not Wire, Surface, or Point3D.",
+        );
+      }
       if (util.is3D(sketch)) {
         throw new Error("Parts to be lofted must be sketches");
       }
@@ -59,6 +68,24 @@ async function difference(
 ): Promise<AbundanceObject> {
   await util.init();
   if (
+    util.isWireGeometry(target) ||
+    util.isSurface(target) ||
+    util.isPoint3D(target)
+  ) {
+    throw new Error(
+      "difference() target must be a 3D solid or 2D sketch, not Wire, Surface, or Point3D.",
+    );
+  }
+  if (
+    util.isWireGeometry(cutter) ||
+    util.isSurface(cutter) ||
+    util.isPoint3D(cutter)
+  ) {
+    throw new Error(
+      "difference() cutter must be a 3D solid or 2D sketch, not Wire, Surface, or Point3D.",
+    );
+  }
+  if (
     (util.is3D(target) && util.is3D(cutter)) ||
     (!util.is3D(target) && !util.is3D(cutter))
   ) {
@@ -80,6 +107,18 @@ async function shrinkWrapSketches(
 ): Promise<AbundanceLeaf> {
   await util.init();
   const BOM: any[] = [];
+  if (
+    sketches.some(
+      (sketch) =>
+        util.isWireGeometry(sketch) ||
+        util.isSurface(sketch) ||
+        util.isPoint3D(sketch),
+    )
+  ) {
+    throw new Error(
+      "Parts to be shrink wrapped must be 2D sketches, not Wire, Surface, or Point3D.",
+    );
+  }
   if (sketches.some((sketch) => util.is3D(sketch))) {
     throw new Error("Parts to be shrink wrapped must be sketches");
   }
@@ -131,6 +170,18 @@ async function intersect(
   context: RequestContext,
 ): Promise<AbundanceObject> {
   await util.init();
+  if (
+    util.isWireGeometry(shape1) ||
+    util.isSurface(shape1) ||
+    util.isPoint3D(shape1) ||
+    util.isWireGeometry(shape2) ||
+    util.isSurface(shape2) ||
+    util.isPoint3D(shape2)
+  ) {
+    throw new Error(
+      "intersect() requires 3D solids or 2D sketches, not Wire, Surface, or Point3D.",
+    );
+  }
   return util.actOnLeafs(shape1, async (leaf: AbundanceLeaf) => {
     const shapeToIntersectWith = await fuseAssembly(shape2, context);
     const resultGeom = await util.geometryProvider!.intersect(
@@ -160,6 +211,17 @@ async function fusion(
   context: RequestContext,
 ): Promise<AbundanceLeaf> {
   await util.init();
+  for (const shape of shapes) {
+    if (
+      util.isWireGeometry(shape) ||
+      util.isSurface(shape) ||
+      util.isPoint3D(shape)
+    ) {
+      throw new Error(
+        "fusion() requires 3D solids or 2D sketches, not Wire, Surface, or Point3D.",
+      );
+    }
+  }
   const all2D = shapes.every((shape) => !util.is3D(shape));
   const all3D = shapes.every((shape) => util.is3D(shape));
   if (!all2D && !all3D) {

--- a/src/worker/meshWorker.ts
+++ b/src/worker/meshWorker.ts
@@ -8,8 +8,8 @@ import * as util from "./util";
 
 type DisplayMesh = {
   cameraZoom: number;
-  faces: ShapeMesh;
-  edges: {
+  faces?: ShapeMesh;
+  edges?: {
     lines: number[];
     edgeGroups: {
       start: number;
@@ -18,6 +18,8 @@ type DisplayMesh = {
     }[];
   };
   color: string;
+  surface?: boolean;
+  point?: [number, number, number];
 };
 
 let defaultMesh: any = undefined;
@@ -232,7 +234,13 @@ async function generateDisplayMesh(
 
     let cameraZoom;
     try {
-      cameraZoom = generateCameraPosition(meshArray.map((m) => m.geometry));
+      // Exclude Vertex (Point3D) geometries from bounding box — they produce a
+      // degenerate single-point box that would skew or zero-out the zoom level.
+      const cameraGeoms = meshArray
+        .map((m) => m.geometry)
+        .filter((g) => !(g instanceof replicad.Vertex));
+      cameraZoom =
+        cameraGeoms.length > 0 ? generateCameraPosition(cameraGeoms) : 1;
     } catch (e) {
       console.error("Error generating camera position:", e);
       cameraZoom = 1;
@@ -242,8 +250,25 @@ async function generateDisplayMesh(
     // Iterate through the meshArray and create final meshes with faces, edges and color to pass to display
     for (const [index, meshObj] of meshArray.entries()) {
       try {
-        const sketchPlane = util.asReplicadPlane(geom.plane);
-        if (meshObj.geometry instanceof replicad.Drawing) {
+        if (meshObj.geometry instanceof replicad.Vertex) {
+          // Point3D — emit a point coordinate, no mesh geometry
+          finalMeshes.push({
+            cameraZoom: cameraZoom,
+            point: (meshObj.geometry as replicad.Vertex).asTuple(),
+            color: meshObj.color,
+          });
+        } else if (meshObj.geometry instanceof replicad.Wire) {
+          // Wire — edges only, no faces
+          finalMeshes.push({
+            cameraZoom: cameraZoom,
+            edges: meshObj.geometry.meshEdges({
+              tolerance: 0.1,
+              angularTolerance: 0.5,
+            }),
+            color: meshObj.color,
+          });
+        } else if (meshObj.geometry instanceof replicad.Drawing) {
+          const sketchPlane = util.asReplicadPlane(geom.plane);
           const threeDShape = meshObj.geometry
             .sketchOnPlane(sketchPlane)
             .extrude(0.0001);
@@ -257,6 +282,8 @@ async function generateDisplayMesh(
             color: meshObj.color,
           });
         } else {
+          // Shape3D or Shell (Surface) — mesh normally; flag Surface for double-sided rendering
+          const isShell = meshObj.geometry instanceof replicad.Shell;
           finalMeshes.push({
             cameraZoom: cameraZoom,
             faces: meshObj.geometry.mesh({
@@ -268,6 +295,7 @@ async function generateDisplayMesh(
               angularTolerance: 0.5,
             }),
             color: meshObj.color,
+            ...(isShell ? { surface: true } : {}),
           });
         }
       } catch (e) {

--- a/src/worker/meshWorker.ts
+++ b/src/worker/meshWorker.ts
@@ -261,8 +261,8 @@ async function generateDisplayMesh(
           finalMeshes.push({
             cameraZoom: cameraZoom,
             edges: meshObj.geometry.meshEdges({
-              tolerance: 0.1,
-              angularTolerance: 0.5,
+              tolerance: 0.03,
+              angularTolerance: 0.1,
             }),
             color: meshObj.color,
           });

--- a/src/worker/meshWorker.ts
+++ b/src/worker/meshWorker.ts
@@ -18,7 +18,6 @@ type DisplayMesh = {
     }[];
   };
   color: string;
-  surface?: boolean;
   point?: [number, number, number];
 };
 
@@ -282,8 +281,7 @@ async function generateDisplayMesh(
             color: meshObj.color,
           });
         } else {
-          // Shape3D or Shell (Surface) — mesh normally; flag Surface for double-sided rendering
-          const isShell = meshObj.geometry instanceof replicad.Shell;
+          // Shape3D — mesh normally
           finalMeshes.push({
             cameraZoom: cameraZoom,
             faces: meshObj.geometry.mesh({
@@ -295,7 +293,6 @@ async function generateDisplayMesh(
               angularTolerance: 0.5,
             }),
             color: meshObj.color,
-            ...(isShell ? { surface: true } : {}),
           });
         }
       } catch (e) {

--- a/src/worker/ts-framework.ts
+++ b/src/worker/ts-framework.ts
@@ -59,7 +59,7 @@ export class Assembly<G = any> {
   // `geometry: any` to `geometry: G` so callers see the generic parameter
   // narrowed to the proper replicad union. See scripts/build-ts-framework.mjs.
   geometry: any = [];
-  color: string = "#ffffff";
+  color: string = "#aad7f2";
   tags: string[] = [];
   bom: string[] = [];
   plane: any = replicad.makePlane();
@@ -127,9 +127,9 @@ export class Assembly<G = any> {
    * leaf yielded by depth-first traversal; a branch with no leaves is
    * considered 3D.
    */
-  is2D(): boolean {
+  isDrawing2D(): boolean {
     if (Array.isArray(this.geometry)) {
-      return this.geometry.length > 0 && this.geometry[0].is2D();
+      return this.geometry.length > 0 && this.geometry[0].isDrawing2D();
     }
     const g = this.geometry as any;
     return !!g && !("_wrapped" in g);
@@ -160,8 +160,14 @@ export class Assembly<G = any> {
   }
 
   /** True when this assembly's first leaf is a 3D replicad solid (not a Wire, Surface, or Point3D). */
-  is3D(): boolean {
-    return !this.is2D() && !this.isWire() && !this.isSurface() && !this.isPoint3D();
+  isSolid3D(): boolean {
+    if (Array.isArray(this.geometry)) {
+      return this.geometry.length > 0 && this.geometry[0].isSolid3D();
+    }
+    return (
+      replicad.isShape3D(this.geometry) &&
+      !(this.geometry instanceof replicad.Shell)
+    );
   }
 
   toJSON() {

--- a/src/worker/ts-framework.ts
+++ b/src/worker/ts-framework.ts
@@ -135,9 +135,33 @@ export class Assembly<G = any> {
     return !!g && !("_wrapped" in g);
   }
 
-  /** True when this assembly's first leaf is a 3D replicad shape. */
+  /** True when this assembly's first leaf is a replicad Wire (1D curve). */
+  isWire(): boolean {
+    if (Array.isArray(this.geometry)) {
+      return this.geometry.length > 0 && this.geometry[0].isWire();
+    }
+    return this.geometry instanceof replicad.Wire;
+  }
+
+  /** True when this assembly's first leaf is a replicad Shell (open surface). */
+  isSurface(): boolean {
+    if (Array.isArray(this.geometry)) {
+      return this.geometry.length > 0 && this.geometry[0].isSurface();
+    }
+    return this.geometry instanceof replicad.Shell;
+  }
+
+  /** True when this assembly's first leaf is a replicad Vertex (Point3D). */
+  isPoint3D(): boolean {
+    if (Array.isArray(this.geometry)) {
+      return this.geometry.length > 0 && this.geometry[0].isPoint3D();
+    }
+    return this.geometry instanceof replicad.Vertex;
+  }
+
+  /** True when this assembly's first leaf is a 3D replicad solid (not a Wire, Surface, or Point3D). */
   is3D(): boolean {
-    return !this.is2D();
+    return !this.is2D() && !this.isWire() && !this.isSurface() && !this.isPoint3D();
   }
 
   toJSON() {

--- a/src/worker/ts-framework.ts
+++ b/src/worker/ts-framework.ts
@@ -151,23 +151,12 @@ export class Assembly<G = any> {
     return this.geometry instanceof replicad.Shell;
   }
 
-  /** True when this assembly's first leaf is a replicad Vertex (Point3D). */
-  isPoint3D(): boolean {
-    if (Array.isArray(this.geometry)) {
-      return this.geometry.length > 0 && this.geometry[0].isPoint3D();
-    }
-    return this.geometry instanceof replicad.Vertex;
-  }
-
-  /** True when this assembly's first leaf is a 3D replicad solid (not a Wire, Surface, or Point3D). */
+  /** True when this assembly's first leaf is a 3D replicad solid (not a Wire or Point3D). */
   isSolid3D(): boolean {
     if (Array.isArray(this.geometry)) {
       return this.geometry.length > 0 && this.geometry[0].isSolid3D();
     }
-    return (
-      replicad.isShape3D(this.geometry) &&
-      !(this.geometry instanceof replicad.Shell)
-    );
+    return replicad.isShape3D(this.geometry);
   }
 
   toJSON() {

--- a/src/worker/ts-framework.ts
+++ b/src/worker/ts-framework.ts
@@ -127,9 +127,9 @@ export class Assembly<G = any> {
    * leaf yielded by depth-first traversal; a branch with no leaves is
    * considered 3D.
    */
-  isDrawing2D(): boolean {
+  is2D(): boolean {
     if (Array.isArray(this.geometry)) {
-      return this.geometry.length > 0 && this.geometry[0].isDrawing2D();
+      return this.geometry.length > 0 && this.geometry[0].is2D();
     }
     const g = this.geometry as any;
     return !!g && !("_wrapped" in g);
@@ -143,18 +143,17 @@ export class Assembly<G = any> {
     return this.geometry instanceof replicad.Wire;
   }
 
-  /** True when this assembly's first leaf is a replicad Shell (open surface). */
-  isSurface(): boolean {
+  isPoint(): boolean {
     if (Array.isArray(this.geometry)) {
-      return this.geometry.length > 0 && this.geometry[0].isSurface();
+      return this.geometry.length > 0 && this.geometry[0].isPoint();
     }
-    return this.geometry instanceof replicad.Shell;
+    return this.geometry instanceof replicad.Vertex;
   }
 
   /** True when this assembly's first leaf is a 3D replicad solid (not a Wire or Point3D). */
-  isSolid3D(): boolean {
+  is3D(): boolean {
     if (Array.isArray(this.geometry)) {
-      return this.geometry.length > 0 && this.geometry[0].isSolid3D();
+      return this.geometry.length > 0 && this.geometry[0].is3D();
     }
     return replicad.isShape3D(this.geometry);
   }

--- a/src/worker/util.ts
+++ b/src/worker/util.ts
@@ -79,7 +79,7 @@ interface AbundanceBranch {
 
 interface AbundanceLeaf {
   geometry: string;
-  dimension: "2D" | "3D" | "Wire" | "Surface" | "Point3D";
+  dimension: "2D" | "3D" | "Wire" | "Point3D";
   plane: SimplePlane;
   color: string;
   tags: string[];
@@ -87,15 +87,11 @@ interface AbundanceLeaf {
   nonReplicadSerialized?: any;
 }
 
-function dimensionLabel(
-  geom: any,
-): "2D" | "3D" | "Wire" | "Surface" | "Point3D" {
+function dimensionLabel(geom: any): "2D" | "3D" | "Wire" | "Point3D" {
   if (geom instanceof replicad.Drawing) {
     return "2D";
   } else if (geom instanceof replicad.Wire) {
     return "Wire";
-  } else if (geom instanceof replicad.Shell) {
-    return "Surface";
   } else if (geom instanceof replicad.Vertex) {
     return "Point3D";
   } else if (replicad.isShape3D(geom)) {
@@ -115,16 +111,8 @@ function is3D(part: AbundanceObject): boolean {
   if (isAssembly(part)) {
     return part.geometry.some((input: any) => is3D(input));
   } else {
-    // leaf — Surface, Wire, and Point3D are not solids for boolean purposes
+    // leaf — Wire and Point3D are not solids for boolean purposes
     return part.dimension === "3D";
-  }
-}
-
-function isSurface(part: AbundanceObject): boolean {
-  if (isAssembly(part)) {
-    return part.geometry.some((input: any) => isSurface(input));
-  } else {
-    return part.dimension === "Surface";
   }
 }
 
@@ -368,7 +356,6 @@ export {
   isAssembly,
   isLeaf,
   isPoint3D,
-  isSurface,
   isWireGeometry,
   replicad,
   SimplePlane,

--- a/src/worker/util.ts
+++ b/src/worker/util.ts
@@ -79,7 +79,7 @@ interface AbundanceBranch {
 
 interface AbundanceLeaf {
   geometry: string;
-  dimension: "2D" | "3D" | "Wire";
+  dimension: "2D" | "3D" | "Wire" | "Surface" | "Point3D";
   plane: SimplePlane;
   color: string;
   tags: string[];
@@ -94,8 +94,24 @@ function is3D(part: AbundanceObject): boolean {
   if (isAssembly(part)) {
     return part.geometry.some((input: any) => is3D(input));
   } else {
-    // leaf
+    // leaf — Surface, Wire, and Point3D are not solids for boolean purposes
     return part.dimension === "3D";
+  }
+}
+
+function isSurface(part: AbundanceObject): boolean {
+  if (isAssembly(part)) {
+    return part.geometry.some((input: any) => isSurface(input));
+  } else {
+    return part.dimension === "Surface";
+  }
+}
+
+function isPoint3D(part: AbundanceObject): boolean {
+  if (isAssembly(part)) {
+    return part.geometry.some((input: any) => isPoint3D(input));
+  } else {
+    return part.dimension === "Point3D";
   }
 }
 
@@ -329,6 +345,8 @@ export {
   isAbundanceObject,
   isAssembly,
   isLeaf,
+  isPoint3D,
+  isSurface,
   isWireGeometry,
   replicad,
   SimplePlane,

--- a/src/worker/util.ts
+++ b/src/worker/util.ts
@@ -87,6 +87,27 @@ interface AbundanceLeaf {
   nonReplicadSerialized?: any;
 }
 
+function dimensionLabel(
+  geom: any,
+): "2D" | "3D" | "Wire" | "Surface" | "Point3D" {
+  if (geom instanceof replicad.Drawing) {
+    return "2D";
+  } else if (geom instanceof replicad.Wire) {
+    return "Wire";
+  } else if (geom instanceof replicad.Shell) {
+    return "Surface";
+  } else if (geom instanceof replicad.Vertex) {
+    return "Point3D";
+  } else if (replicad.isShape3D(geom)) {
+    return "3D";
+  } else {
+    throw new Error(
+      "Unsupported geometry type: " +
+        (geom && geom.constructor ? geom.constructor.name : typeof geom),
+    );
+  }
+}
+
 function is3D(part: AbundanceObject): boolean {
   if (part === undefined || part.geometry === undefined) {
     return false;
@@ -334,6 +355,7 @@ export {
   asReplicadPlane,
   asSimplePlane,
   defaultColor,
+  dimensionLabel,
   flattenAssembly,
   generateUniqueID,
   geometryProvider,

--- a/src/worker/util.ts
+++ b/src/worker/util.ts
@@ -104,24 +104,33 @@ function dimensionLabel(geom: any): "2D" | "3D" | "Wire" | "Point3D" {
   }
 }
 
-function is3D(part: AbundanceObject): boolean {
-  if (part === undefined || part.geometry === undefined) {
-    return false;
-  }
+function _checkFirstDimIs(
+  part: AbundanceObject,
+  dimension: "2D" | "3D" | "Wire" | "Point3D",
+): boolean {
   if (isAssembly(part)) {
-    return part.geometry.some((input: any) => is3D(input));
+    return part.geometry.some((input: AbundanceObject) =>
+      _checkFirstDimIs(input, dimension),
+    );
   } else {
-    // leaf — Wire and Point3D are not solids for boolean purposes
-    return part.dimension === "3D";
+    return part && part.dimension === dimension;
   }
 }
 
+function is2D(part: AbundanceObject): boolean {
+  return _checkFirstDimIs(part, "2D");
+}
+
+function is3D(part: AbundanceObject): boolean {
+  return _checkFirstDimIs(part, "3D");
+}
+
 function isPoint3D(part: AbundanceObject): boolean {
-  if (isAssembly(part)) {
-    return part.geometry.some((input: any) => isPoint3D(input));
-  } else {
-    return part.dimension === "Point3D";
-  }
+  return _checkFirstDimIs(part, "Point3D");
+}
+
+function isWireGeometry(part: AbundanceObject): boolean {
+  return _checkFirstDimIs(part, "Wire");
 }
 
 async function getBounds(
@@ -269,14 +278,6 @@ function generateUniqueID(): string {
   return uuidv4();
 }
 
-function isWireGeometry(inputs: AbundanceObject): boolean {
-  if (isAssembly(inputs)) {
-    return inputs.geometry.some((input: any) => isWireGeometry(input));
-  } else {
-    return inputs.dimension === "Wire";
-  }
-}
-
 function isAssembly(part: AbundanceObject): part is AbundanceBranch {
   return Array.isArray(part.geometry);
 }
@@ -351,6 +352,7 @@ export {
   hashFileContents,
   hashString,
   init,
+  is2D,
   is3D,
   isAbundanceObject,
   isAssembly,

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -627,9 +627,11 @@ async function generateThumbnail(
     ) {
       projectionShape = prettyProjection(fusedGeometry);
       svg = projectionShape.visible.toSVG();
+    } else if (fusedGeometry instanceof replicad.Vertex) {
+      throw new Error("Cannot generate an SVG projection for a Point3D geometry.");
     } else {
       projectionShape = util.replicad.drawProjection(
-        fusedGeometry.sketchOnPlane("XY").extrude(0.0001),
+        (fusedGeometry as replicad.Drawing).sketchOnPlane("XY").extrude(0.0001),
         "top",
       ).visible;
       svg = projectionShape.toSVG();

--- a/tests/primitives-type-guards.test.js
+++ b/tests/primitives-type-guards.test.js
@@ -62,10 +62,14 @@ describe("isWireGeometry()", () => {
     expect(isWireGeometry(makeLeaf("Point3D"))).toBe(false);
   });
   it("returns true for branch containing a Wire leaf", () => {
-    expect(isWireGeometry(makeBranch([makeLeaf("Wire"), makeLeaf("Wire")]))).toBe(true);
+    expect(
+      isWireGeometry(makeBranch([makeLeaf("Wire"), makeLeaf("Wire")])),
+    ).toBe(true);
   });
   it("returns false for branch with no Wire leaves", () => {
-    expect(isWireGeometry(makeBranch([makeLeaf("3D"), makeLeaf("3D")]))).toBe(false);
+    expect(isWireGeometry(makeBranch([makeLeaf("3D"), makeLeaf("3D")]))).toBe(
+      false,
+    );
   });
 });
 
@@ -86,7 +90,9 @@ describe("isSurface()", () => {
     expect(isSurface(makeLeaf("2D"))).toBe(false);
   });
   it("returns true for branch containing a Surface leaf", () => {
-    expect(isSurface(makeBranch([makeLeaf("Surface"), makeLeaf("3D")]))).toBe(true);
+    expect(isSurface(makeBranch([makeLeaf("Surface"), makeLeaf("3D")]))).toBe(
+      true,
+    );
   });
 });
 
@@ -196,14 +202,14 @@ describe("interaction rejection for new primitive types", () => {
       ).rejects.toThrow("fusion()");
     });
     it("throws for Surface inputs", async () => {
-      await expect(
-        fusion([makeLeaf("Surface")], {}),
-      ).rejects.toThrow("fusion()");
+      await expect(fusion([makeLeaf("Surface")], {})).rejects.toThrow(
+        "fusion()",
+      );
     });
     it("throws for Point3D inputs", async () => {
-      await expect(
-        fusion([makeLeaf("Point3D")], {}),
-      ).rejects.toThrow("fusion()");
+      await expect(fusion([makeLeaf("Point3D")], {})).rejects.toThrow(
+        "fusion()",
+      );
     });
   });
 

--- a/tests/primitives-type-guards.test.js
+++ b/tests/primitives-type-guards.test.js
@@ -2,7 +2,6 @@ import {
   init,
   is3D,
   isWireGeometry,
-  isSurface,
   isPoint3D,
   defaultColor,
   XYPlane,
@@ -55,9 +54,6 @@ describe("isWireGeometry()", () => {
   it("returns false for 3D leaf", () => {
     expect(isWireGeometry(makeLeaf("3D"))).toBe(false);
   });
-  it("returns false for Surface leaf", () => {
-    expect(isWireGeometry(makeLeaf("Surface"))).toBe(false);
-  });
   it("returns false for Point3D leaf", () => {
     expect(isWireGeometry(makeLeaf("Point3D"))).toBe(false);
   });
@@ -73,29 +69,6 @@ describe("isWireGeometry()", () => {
   });
 });
 
-describe("isSurface()", () => {
-  it("returns true for Surface leaf", () => {
-    expect(isSurface(makeLeaf("Surface"))).toBe(true);
-  });
-  it("returns false for 3D leaf", () => {
-    expect(isSurface(makeLeaf("3D"))).toBe(false);
-  });
-  it("returns false for Wire leaf", () => {
-    expect(isSurface(makeLeaf("Wire"))).toBe(false);
-  });
-  it("returns false for Point3D leaf", () => {
-    expect(isSurface(makeLeaf("Point3D"))).toBe(false);
-  });
-  it("returns false for 2D leaf", () => {
-    expect(isSurface(makeLeaf("2D"))).toBe(false);
-  });
-  it("returns true for branch containing a Surface leaf", () => {
-    expect(isSurface(makeBranch([makeLeaf("Surface"), makeLeaf("3D")]))).toBe(
-      true,
-    );
-  });
-});
-
 describe("isPoint3D()", () => {
   it("returns true for Point3D leaf", () => {
     expect(isPoint3D(makeLeaf("Point3D"))).toBe(true);
@@ -105,9 +78,6 @@ describe("isPoint3D()", () => {
   });
   it("returns false for Wire leaf", () => {
     expect(isPoint3D(makeLeaf("Wire"))).toBe(false);
-  });
-  it("returns false for Surface leaf", () => {
-    expect(isPoint3D(makeLeaf("Surface"))).toBe(false);
   });
   it("returns false for 2D leaf", () => {
     expect(isPoint3D(makeLeaf("2D"))).toBe(false);
@@ -127,9 +97,6 @@ describe("is3D()", () => {
   it("returns false for Wire leaf", () => {
     expect(is3D(makeLeaf("Wire"))).toBe(false);
   });
-  it("returns false for Surface leaf", () => {
-    expect(is3D(makeLeaf("Surface"))).toBe(false);
-  });
   it("returns false for Point3D leaf", () => {
     expect(is3D(makeLeaf("Point3D"))).toBe(false);
   });
@@ -143,11 +110,6 @@ describe("extrude() rejects new primitive types", () => {
   it("throws when extruding a Wire", async () => {
     await expect(extrude(makeLeaf("Wire"), 10, {})).rejects.toThrow(
       "Cannot extrude a Wire",
-    );
-  });
-  it("throws when extruding a Surface", async () => {
-    await expect(extrude(makeLeaf("Surface"), 10, {})).rejects.toThrow(
-      "Cannot extrude a Surface",
     );
   });
   it("throws when extruding a Point3D", async () => {
@@ -173,11 +135,6 @@ describe("interaction rejection for new primitive types", () => {
         difference(makeLeaf("Wire"), makeLeaf("3D"), {}),
       ).rejects.toThrow("difference() target");
     });
-    it("throws when target is a Surface", async () => {
-      await expect(
-        difference(makeLeaf("Surface"), makeLeaf("3D"), {}),
-      ).rejects.toThrow("difference() target");
-    });
     it("throws when target is a Point3D", async () => {
       await expect(
         difference(makeLeaf("Point3D"), makeLeaf("3D"), {}),
@@ -188,11 +145,6 @@ describe("interaction rejection for new primitive types", () => {
         difference(makeLeaf("3D"), makeLeaf("Wire"), {}),
       ).rejects.toThrow("difference() cutter");
     });
-    it("throws when cutter is a Surface", async () => {
-      await expect(
-        difference(makeLeaf("3D"), makeLeaf("Surface"), {}),
-      ).rejects.toThrow("difference() cutter");
-    });
   });
 
   describe("fusion()", () => {
@@ -200,11 +152,6 @@ describe("interaction rejection for new primitive types", () => {
       await expect(
         fusion([makeLeaf("Wire"), makeLeaf("Wire")], {}),
       ).rejects.toThrow("fusion()");
-    });
-    it("throws for Surface inputs", async () => {
-      await expect(fusion([makeLeaf("Surface")], {})).rejects.toThrow(
-        "fusion()",
-      );
     });
     it("throws for Point3D inputs", async () => {
       await expect(fusion([makeLeaf("Point3D")], {})).rejects.toThrow(
@@ -219,11 +166,6 @@ describe("interaction rejection for new primitive types", () => {
         loftShapes([makeLeaf("Wire"), makeLeaf("2D")], {}),
       ).rejects.toThrow("2D sketches");
     });
-    it("throws for Surface inputs", async () => {
-      await expect(
-        loftShapes([makeLeaf("Surface"), makeLeaf("2D")], {}),
-      ).rejects.toThrow("2D sketches");
-    });
     it("throws for Point3D inputs", async () => {
       await expect(
         loftShapes([makeLeaf("Point3D"), makeLeaf("2D")], {}),
@@ -235,11 +177,6 @@ describe("interaction rejection for new primitive types", () => {
     it("throws when shape1 is a Wire", async () => {
       await expect(
         intersect(makeLeaf("Wire"), makeLeaf("3D"), {}),
-      ).rejects.toThrow("intersect()");
-    });
-    it("throws when shape2 is a Surface", async () => {
-      await expect(
-        intersect(makeLeaf("3D"), makeLeaf("Surface"), {}),
       ).rejects.toThrow("intersect()");
     });
     it("throws when shape1 is a Point3D", async () => {

--- a/tests/primitives-type-guards.test.js
+++ b/tests/primitives-type-guards.test.js
@@ -1,0 +1,245 @@
+import {
+  init,
+  is3D,
+  isWireGeometry,
+  isSurface,
+  isPoint3D,
+  defaultColor,
+  XYPlane,
+} from "../src/worker/util.ts";
+import { extrude } from "../src/worker/actions.ts";
+import {
+  difference,
+  fusion,
+  loftShapes,
+  intersect,
+} from "../src/worker/interaction.ts";
+
+/**
+ * Create a minimal AbundanceLeaf mock with the given dimension.
+ * The geometry string is a placeholder — these tests only need the
+ * dimension discriminant field, not a real replicad object.
+ */
+function makeLeaf(dimension) {
+  return {
+    dimension,
+    geometry: "mock-id",
+    tags: [],
+    color: defaultColor,
+    bom: [],
+    plane: XYPlane,
+  };
+}
+
+function makeBranch(leaves) {
+  return {
+    geometry: leaves,
+    tags: [],
+    color: defaultColor,
+    bom: [],
+    plane: XYPlane,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Type guard correctness — no replicad init needed (pure field checks)
+// ---------------------------------------------------------------------------
+
+describe("isWireGeometry()", () => {
+  it("returns true for Wire leaf", () => {
+    expect(isWireGeometry(makeLeaf("Wire"))).toBe(true);
+  });
+  it("returns false for 2D leaf", () => {
+    expect(isWireGeometry(makeLeaf("2D"))).toBe(false);
+  });
+  it("returns false for 3D leaf", () => {
+    expect(isWireGeometry(makeLeaf("3D"))).toBe(false);
+  });
+  it("returns false for Surface leaf", () => {
+    expect(isWireGeometry(makeLeaf("Surface"))).toBe(false);
+  });
+  it("returns false for Point3D leaf", () => {
+    expect(isWireGeometry(makeLeaf("Point3D"))).toBe(false);
+  });
+  it("returns true for branch containing a Wire leaf", () => {
+    expect(isWireGeometry(makeBranch([makeLeaf("Wire"), makeLeaf("Wire")]))).toBe(true);
+  });
+  it("returns false for branch with no Wire leaves", () => {
+    expect(isWireGeometry(makeBranch([makeLeaf("3D"), makeLeaf("3D")]))).toBe(false);
+  });
+});
+
+describe("isSurface()", () => {
+  it("returns true for Surface leaf", () => {
+    expect(isSurface(makeLeaf("Surface"))).toBe(true);
+  });
+  it("returns false for 3D leaf", () => {
+    expect(isSurface(makeLeaf("3D"))).toBe(false);
+  });
+  it("returns false for Wire leaf", () => {
+    expect(isSurface(makeLeaf("Wire"))).toBe(false);
+  });
+  it("returns false for Point3D leaf", () => {
+    expect(isSurface(makeLeaf("Point3D"))).toBe(false);
+  });
+  it("returns false for 2D leaf", () => {
+    expect(isSurface(makeLeaf("2D"))).toBe(false);
+  });
+  it("returns true for branch containing a Surface leaf", () => {
+    expect(isSurface(makeBranch([makeLeaf("Surface"), makeLeaf("3D")]))).toBe(true);
+  });
+});
+
+describe("isPoint3D()", () => {
+  it("returns true for Point3D leaf", () => {
+    expect(isPoint3D(makeLeaf("Point3D"))).toBe(true);
+  });
+  it("returns false for 3D leaf", () => {
+    expect(isPoint3D(makeLeaf("3D"))).toBe(false);
+  });
+  it("returns false for Wire leaf", () => {
+    expect(isPoint3D(makeLeaf("Wire"))).toBe(false);
+  });
+  it("returns false for Surface leaf", () => {
+    expect(isPoint3D(makeLeaf("Surface"))).toBe(false);
+  });
+  it("returns false for 2D leaf", () => {
+    expect(isPoint3D(makeLeaf("2D"))).toBe(false);
+  });
+  it("returns true for branch containing a Point3D leaf", () => {
+    expect(isPoint3D(makeBranch([makeLeaf("Point3D")]))).toBe(true);
+  });
+});
+
+describe("is3D()", () => {
+  it("returns true for 3D leaf", () => {
+    expect(is3D(makeLeaf("3D"))).toBe(true);
+  });
+  it("returns false for 2D leaf", () => {
+    expect(is3D(makeLeaf("2D"))).toBe(false);
+  });
+  it("returns false for Wire leaf", () => {
+    expect(is3D(makeLeaf("Wire"))).toBe(false);
+  });
+  it("returns false for Surface leaf", () => {
+    expect(is3D(makeLeaf("Surface"))).toBe(false);
+  });
+  it("returns false for Point3D leaf", () => {
+    expect(is3D(makeLeaf("Point3D"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rejection in actions — extrude() type checks run before util.init()
+// ---------------------------------------------------------------------------
+
+describe("extrude() rejects new primitive types", () => {
+  it("throws when extruding a Wire", async () => {
+    await expect(extrude(makeLeaf("Wire"), 10, {})).rejects.toThrow(
+      "Cannot extrude a Wire",
+    );
+  });
+  it("throws when extruding a Surface", async () => {
+    await expect(extrude(makeLeaf("Surface"), 10, {})).rejects.toThrow(
+      "Cannot extrude a Surface",
+    );
+  });
+  it("throws when extruding a Point3D", async () => {
+    await expect(extrude(makeLeaf("Point3D"), 10, {})).rejects.toThrow(
+      "Cannot extrude a Point3D",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rejection in interaction — these call util.init() before the checks so
+// replicad must be initialised.
+// ---------------------------------------------------------------------------
+
+describe("interaction rejection for new primitive types", () => {
+  beforeAll(async () => {
+    await init();
+  });
+
+  describe("difference()", () => {
+    it("throws when target is a Wire", async () => {
+      await expect(
+        difference(makeLeaf("Wire"), makeLeaf("3D"), {}),
+      ).rejects.toThrow("difference() target");
+    });
+    it("throws when target is a Surface", async () => {
+      await expect(
+        difference(makeLeaf("Surface"), makeLeaf("3D"), {}),
+      ).rejects.toThrow("difference() target");
+    });
+    it("throws when target is a Point3D", async () => {
+      await expect(
+        difference(makeLeaf("Point3D"), makeLeaf("3D"), {}),
+      ).rejects.toThrow("difference() target");
+    });
+    it("throws when cutter is a Wire", async () => {
+      await expect(
+        difference(makeLeaf("3D"), makeLeaf("Wire"), {}),
+      ).rejects.toThrow("difference() cutter");
+    });
+    it("throws when cutter is a Surface", async () => {
+      await expect(
+        difference(makeLeaf("3D"), makeLeaf("Surface"), {}),
+      ).rejects.toThrow("difference() cutter");
+    });
+  });
+
+  describe("fusion()", () => {
+    it("throws for Wire inputs", async () => {
+      await expect(
+        fusion([makeLeaf("Wire"), makeLeaf("Wire")], {}),
+      ).rejects.toThrow("fusion()");
+    });
+    it("throws for Surface inputs", async () => {
+      await expect(
+        fusion([makeLeaf("Surface")], {}),
+      ).rejects.toThrow("fusion()");
+    });
+    it("throws for Point3D inputs", async () => {
+      await expect(
+        fusion([makeLeaf("Point3D")], {}),
+      ).rejects.toThrow("fusion()");
+    });
+  });
+
+  describe("loftShapes()", () => {
+    it("throws for Wire inputs", async () => {
+      await expect(
+        loftShapes([makeLeaf("Wire"), makeLeaf("2D")], {}),
+      ).rejects.toThrow("2D sketches");
+    });
+    it("throws for Surface inputs", async () => {
+      await expect(
+        loftShapes([makeLeaf("Surface"), makeLeaf("2D")], {}),
+      ).rejects.toThrow("2D sketches");
+    });
+    it("throws for Point3D inputs", async () => {
+      await expect(
+        loftShapes([makeLeaf("Point3D"), makeLeaf("2D")], {}),
+      ).rejects.toThrow("2D sketches");
+    });
+  });
+
+  describe("intersect()", () => {
+    it("throws when shape1 is a Wire", async () => {
+      await expect(
+        intersect(makeLeaf("Wire"), makeLeaf("3D"), {}),
+      ).rejects.toThrow("intersect()");
+    });
+    it("throws when shape2 is a Surface", async () => {
+      await expect(
+        intersect(makeLeaf("3D"), makeLeaf("Surface"), {}),
+      ).rejects.toThrow("intersect()");
+    });
+    it("throws when shape1 is a Point3D", async () => {
+      await expect(
+        intersect(makeLeaf("Point3D"), makeLeaf("3D"), {}),
+      ).rejects.toThrow("intersect()");
+    });
+  });
+});


### PR DESCRIPTION
Adds wires and points as first-class types that we allow within Abundance objects.

Among other things allows code atoms to return Points (behind the scenes a replicad.Vertex) and/or Wires. These elements can be put into assemblies and moved and rotated just like other geometries.