### PR TITLE
Assembly Bounding Box Optimization with non overlap Cut Skipping

### DIFF
--- a/src/worker/interaction.ts
+++ b/src/worker/interaction.ts
@@ -576,8 +576,17 @@ async function cutAssembly(
     // if part to cut is a single part send to cutting function with cutting parts
     let partCutCopy = partToCut;
     for (const cuttingPart of cuttingParts) {
-      // for each cutting part cut the part
-      partCutCopy = await recursiveCut(partCutCopy, cuttingPart, context);
+      // Check if bounding boxes overlap before attempting cut
+      // If they don't overlap, skip the cut operation entirely
+      if (util.boundsOverlap(partToCut.boundingBox, cuttingPart.boundingBox)) {
+        // for each cutting part cut the part
+        partCutCopy = await recursiveCut(partCutCopy, cuttingPart, context);
+      } else {
+        // Bounding boxes don't overlap - skipping cut operation
+        console.log(
+          "⏭️ Skipping cut operation (non-overlapping bounding boxes)",
+        );
+      }
     }
     // return new cut part, expand compound solid if it was cut into disconnected
     // parts

--- a/src/worker/interaction.ts
+++ b/src/worker/interaction.ts
@@ -362,18 +362,29 @@ async function assembly(
 
   await util.init();
 
+  // Eagerly compute bounding boxes for all input geometries
+  const geometriesWithBounds = await Promise.all(
+    geometries.map((geometry) =>
+      util.withAssemblyBoundingBoxes(geometry, context),
+    ),
+  );
+
   let startedBatch = false;
   if (!context.operationId) {
-    const batchId = "assembly-" + util.hashString(JSON.stringify(geometries));
+    const batchId =
+      "assembly-" + util.hashString(JSON.stringify(geometriesWithBounds));
     const batch: RequestContext | AbundanceObject =
       await util.geometryProvider!.startBatchOperation(context, batchId);
 
     // Full assembly cache hit. No work to do, but update nonReplicadSerialized if needed.
     if (util.isAbundanceObject(batch)) {
+      const batchWithBounds = batch.boundingBox
+        ? batch
+        : await util.withAssemblyBoundingBoxes(batch, context);
       // Gather all nonReplicadSerialized and bom from input geometries
       const nonReplicadGeoms: any[] = [];
       const bomAssembly: any[] = [];
-      for (const geometry of geometries) {
+      for (const geometry of geometriesWithBounds) {
         if (
           Array.isArray(geometry.nonReplicadSerialized) &&
           geometry.nonReplicadSerialized.length > 0
@@ -385,9 +396,9 @@ async function assembly(
         }
       }
       // Always update to reflect current state, even if empty
-      batch.nonReplicadSerialized = nonReplicadGeoms;
-      batch.bom = bomAssembly;
-      return batch;
+      batchWithBounds.nonReplicadSerialized = nonReplicadGeoms;
+      batchWithBounds.bom = bomAssembly;
+      return batchWithBounds;
     }
 
     context = batch;
@@ -398,36 +409,49 @@ async function assembly(
   const bomAssembly: any[] = [];
   const nonReplicadGeoms: any[] = [];
 
-  if (geometries.length > 1) {
-    // Always clear arrays before populating
-    bomAssembly.length = 0;
-    nonReplicadGeoms.length = 0;
-    for (let i = 0; i < geometries.length; i++) {
-      const geometry = geometries[i];
-      assembly.push(
-        await cutAssembly(geometry, geometries.slice(i + 1), context),
+  if (geometriesWithBounds.length > 1) {
+    const all3D = geometriesWithBounds.every((geom) => util.is3D(geom));
+    const all2D = geometriesWithBounds.every((geom) => !util.is3D(geom));
+
+    if (all3D || all2D) {
+      // Always clear arrays before populating
+      bomAssembly.length = 0;
+      nonReplicadGeoms.length = 0;
+      for (let i = 0; i < geometriesWithBounds.length; i++) {
+        const geometry = geometriesWithBounds[i];
+        assembly.push(
+          await cutAssembly(
+            geometry,
+            geometriesWithBounds.slice(i + 1),
+            context,
+          ),
+        );
+      }
+      // Gather all nonReplicadSerialized and bom from input geometries
+      for (const geometry of geometriesWithBounds) {
+        if (
+          Array.isArray(geometry.nonReplicadSerialized) &&
+          geometry.nonReplicadSerialized.length > 0
+        ) {
+          nonReplicadGeoms.push(...geometry.nonReplicadSerialized);
+        }
+        if (Array.isArray(geometry.bom) && geometry.bom.length > 0) {
+          bomAssembly.push(...geometry.bom);
+        }
+      }
+    } else {
+      throw new Error(
+        "Assemblies must be composed from only sketches OR only solids",
       );
-    }
-    // Gather all nonReplicadSerialized and bom from input geometries
-    for (const geometry of geometries) {
-      if (
-        Array.isArray(geometry.nonReplicadSerialized) &&
-        geometry.nonReplicadSerialized.length > 0
-      ) {
-        nonReplicadGeoms.push(...geometry.nonReplicadSerialized);
-      }
-      if (Array.isArray(geometry.bom) && geometry.bom.length > 0) {
-        bomAssembly.push(...geometry.bom);
-      }
     }
   } else {
     // Always clear arrays before populating
     bomAssembly.length = 0;
     nonReplicadGeoms.length = 0;
-    const geometry = geometries[0];
+    const geometry = geometriesWithBounds[0];
     assembly.push(geometry);
     // Gather all nonReplicadSerialized and bom from input geometries
-    for (const geometry of geometries) {
+    for (const geometry of geometriesWithBounds) {
       if (
         Array.isArray(geometry.nonReplicadSerialized) &&
         geometry.nonReplicadSerialized.length > 0
@@ -439,14 +463,35 @@ async function assembly(
       }
     }
   }
-  const result = {
+
+  // Build the initial assembly object with all children already having bounds
+  const assemblyObject: AbundanceObject = {
     geometry: await Promise.all(assembly),
     plane: util.XYPlane,
     tags: [],
     color: util.defaultColor,
     bom: bomAssembly,
+    dimension: geometriesWithBounds.every((geom) => util.is3D(geom))
+      ? "3D"
+      : geometriesWithBounds.every((geom) => !util.is3D(geom))
+        ? "2D"
+        : "Wire",
     nonReplicadSerialized: nonReplicadGeoms,
   };
+
+  // Eagerly compute assembly bounds by merging existing child bounds
+  // This is more efficient than withAssemblyBoundingBoxes because it doesn't
+  // recursively traverse - it assumes all children already have bounds
+  const assemblyWithBounds = util.computeAssemblyBounds(assemblyObject);
+
+  // Safety check with recursive validation disabled (forceRecompute=false)
+  // Since we've already computed bounds eagerly, this will detect our computed bounds
+  // and return immediately without recursive traversal
+  const result = await util.withAssemblyBoundingBoxes(
+    assemblyWithBounds,
+    context,
+    false, // forceRecompute=false, so it skips unnecessary recursion
+  );
   if (startedBatch) {
     await util.geometryProvider!.endBatchOperation(context, result);
   }

--- a/src/worker/util.ts
+++ b/src/worker/util.ts
@@ -222,6 +222,28 @@ function mergeBounds(bounds: AbundanceBounds[]): AbundanceBounds {
 }
 
 /**
+ * Checks if two bounding boxes overlap.
+ * Returns true if boxes intersect or touch, false if they are completely separated.
+ */
+function boundsOverlap(
+  bounds1: AbundanceBounds | undefined,
+  bounds2: AbundanceBounds | undefined,
+): boolean {
+  if (!bounds1 || !bounds2) {
+    return true; // If either is undefined, assume they might overlap
+  }
+
+  return !(
+    bounds1.max[0] < bounds2.min[0] || // bounds1 is completely to the left
+    bounds1.min[0] > bounds2.max[0] || // bounds1 is completely to the right
+    bounds1.max[1] < bounds2.min[1] || // bounds1 is completely below
+    bounds1.min[1] > bounds2.max[1] || // bounds1 is completely above
+    bounds1.max[2] < bounds2.min[2] || // bounds1 is completely in front
+    bounds1.min[2] > bounds2.max[2] // bounds1 is completely behind
+  );
+}
+
+/**
  * Eagerly computes bounding boxes for an assembly by merging existing child bounds.
  * This is more efficient than withAssemblyBoundingBoxes() because it doesn't recursively
  * traverse the tree - it assumes all children already have valid bounds from prior operations.
@@ -492,6 +514,7 @@ export {
   actOnLeafsSync,
   asReplicadPlane,
   asSimplePlane,
+  boundsOverlap,
   computeAssemblyBounds,
   defaultColor,
   dimensionLabel,

--- a/src/worker/util.ts
+++ b/src/worker/util.ts
@@ -66,6 +66,16 @@ interface SimplePlane {
   normal: [number, number, number];
 }
 
+interface AbundanceBounds {
+  min: [number, number, number];
+  max: [number, number, number];
+}
+
+const EMPTY_BOUNDS: AbundanceBounds = {
+  min: [Infinity, Infinity, Infinity],
+  max: [-Infinity, -Infinity, -Infinity],
+};
+
 type AbundanceObject = AbundanceLeaf | AbundanceBranch;
 
 interface AbundanceBranch {
@@ -74,7 +84,9 @@ interface AbundanceBranch {
   color: string;
   tags: string[];
   bom: string[];
+  dimension?: "2D" | "3D" | "Wire" | "Point3D";
   nonReplicadSerialized?: any;
+  boundingBox?: AbundanceBounds;
 }
 
 interface AbundanceLeaf {
@@ -85,6 +97,7 @@ interface AbundanceLeaf {
   tags: string[];
   bom: string[];
   nonReplicadSerialized?: any;
+  boundingBox?: AbundanceBounds;
 }
 
 function dimensionLabel(geom: any): "2D" | "3D" | "Wire" | "Point3D" {
@@ -175,6 +188,141 @@ async function getBounds(
     console.error("GetBounds error:", error);
     throw new Error(`GetBounds failed: ${error.message}`);
   }
+}
+
+/**
+ * Merges multiple bounding boxes into a single bounding box.
+ * Returns a new bounding box that encompasses all input bounds.
+ */
+function mergeBounds(bounds: AbundanceBounds[]): AbundanceBounds {
+  if (bounds.length === 0) {
+    return EMPTY_BOUNDS;
+  }
+
+  let minX = Infinity,
+    minY = Infinity,
+    minZ = Infinity;
+  let maxX = -Infinity,
+    maxY = -Infinity,
+    maxZ = -Infinity;
+
+  for (const bound of bounds) {
+    minX = Math.min(minX, bound.min[0]);
+    minY = Math.min(minY, bound.min[1]);
+    minZ = Math.min(minZ, bound.min[2]);
+    maxX = Math.max(maxX, bound.max[0]);
+    maxY = Math.max(maxY, bound.max[1]);
+    maxZ = Math.max(maxZ, bound.max[2]);
+  }
+
+  return {
+    min: [minX, minY, minZ],
+    max: [maxX, maxY, maxZ],
+  };
+}
+
+/**
+ * Eagerly computes bounding boxes for an assembly by merging existing child bounds.
+ * This is more efficient than withAssemblyBoundingBoxes() because it doesn't recursively
+ * traverse the tree - it assumes all children already have valid bounds from prior operations.
+ *
+ * Use this when creating assemblies or after operations where you know children have bounds.
+ */
+function computeAssemblyBounds(geometry: AbundanceObject): AbundanceObject {
+  if (isLeaf(geometry)) {
+    return geometry;
+  }
+
+  const childBounds = (geometry.geometry as AbundanceObject[])
+    .map((child) => child.boundingBox)
+    .filter((bounds): bounds is AbundanceBounds => bounds !== undefined);
+
+  const boundingBox =
+    childBounds.length > 0 ? mergeBounds(childBounds) : EMPTY_BOUNDS;
+
+  return {
+    ...geometry,
+    boundingBox,
+  };
+}
+
+/**
+ * Computes and caches bounding boxes for geometries.
+ *
+ * Optimization: If a geometry and all its children already have valid bounds,
+ * this function returns immediately without recursive traversal (unless forceRecompute=true).
+ *
+ * When to use forceRecompute=true:
+ * - When geometry children have been modified and bounds are stale
+ * - When bounds need to be recalculated for performance analysis
+ * - Normally, you should NOT use this - leaves bounds are only computed once,
+ *   and assembly bounds are eagerly computed when assemblies are created
+ *
+ * Normal usage: forceRecompute=false (default) - reuses existing bounds when available
+ */
+async function withAssemblyBoundingBoxes(
+  geometry: AbundanceObject,
+  context: RequestContext,
+  forceRecompute: boolean = false,
+): Promise<AbundanceObject> {
+  if (isLeaf(geometry)) {
+    if (geometry.boundingBox && !forceRecompute) {
+      return geometry;
+    }
+    let bounds: AbundanceBounds | undefined = undefined;
+    try {
+      const boundsResult = await getBounds(geometry, context);
+      bounds = {
+        min: boundsResult.min as [number, number, number],
+        max: boundsResult.max as [number, number, number],
+      };
+    } catch (_) {
+      // Bounds metadata is an optimization; keep geometry operation non-fatal.
+    }
+    return {
+      ...geometry,
+      ...(bounds ? { boundingBox: bounds } : {}),
+    };
+  }
+
+  // Optimization: if assembly already has bounds and all children have bounds, just return
+  // unless we're forced to recompute
+  if (!forceRecompute && geometry.boundingBox) {
+    const childBounds = (geometry.geometry as AbundanceObject[])
+      .map((child) => child.boundingBox)
+      .filter((bounds): bounds is AbundanceBounds => bounds !== undefined);
+
+    // All children have bounds, so assembly bounds are valid
+    if (childBounds.length === geometry.geometry.length) {
+      return geometry;
+    }
+  }
+
+  const childWithBounds = await Promise.all(
+    (geometry.geometry as AbundanceObject[]).map((child) =>
+      withAssemblyBoundingBoxes(child, context, forceRecompute),
+    ),
+  );
+  if (childWithBounds.length === 0) {
+    return {
+      ...geometry,
+      geometry: [],
+      boundingBox: EMPTY_BOUNDS,
+    };
+  }
+
+  const childBounds = childWithBounds
+    .map((child) => child.boundingBox)
+    .filter((bounds): bounds is AbundanceBounds => bounds !== undefined);
+
+  const boundingBox =
+    childBounds.length > 0 ? mergeBounds(childBounds) : EMPTY_BOUNDS;
+
+  return {
+    ...geometry,
+    geometry: childWithBounds,
+    boundingBox,
+  };
 }
 
 function isAbundanceObject(obj: any): obj is AbundanceObject {
@@ -337,12 +485,14 @@ function hashString(str: string): string {
 }
 
 export {
+  AbundanceBounds,
   AbundanceLeaf,
   AbundanceObject,
   actOnLeafs,
   actOnLeafsSync,
   asReplicadPlane,
   asSimplePlane,
+  computeAssemblyBounds,
   defaultColor,
   dimensionLabel,
   flattenAssembly,
@@ -359,9 +509,11 @@ export {
   isLeaf,
   isPoint3D,
   isWireGeometry,
+  mergeBounds,
   replicad,
   SimplePlane,
   NonReplicadGeom,
+  withAssemblyBoundingBoxes,
   XYPlane,
   startHeapMonitor,
 };


### PR DESCRIPTION
This PR introduces bounding box attributes to [AbundanceBranch](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [AbundanceLeaf](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) with an [AbundanceBounds](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface, enabling intelligent assembly operations that avoid cutting non-overlapping geometries.

- Introduced [AbundanceBounds](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface to track 3D bounding boxes with min/max coordinates

- Updated [AbundanceBranch](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [AbundanceLeaf](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) interfaces with optional [boundingBox](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) properties

- Added [mergeBounds()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to combine multiple bounding boxes efficiently

- Implemented [computeAssemblyBounds()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) for eager (non-recursive) assembly bounds computation

- Created [withAssemblyBoundingBoxes()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) with early-exit optimization to skip redundant tree traversal when all bounds are cached

- Refactored [assembly()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) function to compute bounds upfront on input geometries and merge them before assembly construction

- Integrated bounding box overlap checks into [cutAssembly()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to intelligently skip cut operations