### PR TITLE
Another update for cut atom

### DIFF
--- a/src/worker/code.ts
+++ b/src/worker/code.ts
@@ -590,8 +590,21 @@ async function executeTsCode(
       context,
       cacheId,
     );
-    await util.geometryProvider!.endBatchOperation(context, abundanceObj);
-    return abundanceObj;
+    if (util.isAssembly(abundanceObj)) {
+      const disjointAssembly = await assembly(abundanceObj.geometry, context);
+
+      // Copy all properties from abundanceObj except geometry
+      Object.keys(abundanceObj).forEach((key) => {
+        if (key !== "geometry") {
+          (disjointAssembly as any)[key] = (abundanceObj as any)[key];
+        }
+      });
+      await util.geometryProvider!.endBatchOperation(context, disjointAssembly);
+      return disjointAssembly;
+    } else {
+      await util.geometryProvider!.endBatchOperation(context, abundanceObj);
+      return abundanceObj;
+    }
   } catch (error) {
     console.error("Code execution error:", error);
     if (Number.isInteger(error)) {

--- a/src/worker/code.ts
+++ b/src/worker/code.ts
@@ -395,7 +395,8 @@ async function executeTsCode(
         })()
       : console;
 
-    // Check cache before materializing arguments or launching the sandbox.
+    // Check cache for result of this code atom before doing any heavy work like
+    // materializing arguments or launching the sandbox.
     const cacheId = composeCacheKey(code, argumentsArray);
     const cached = await util.geometryProvider!.getAssembly(cacheId, context);
     if (cached) return cached;
@@ -415,6 +416,7 @@ async function executeTsCode(
     // with `__isRawAbundanceObj`. The prepended framework's `__promoteInput`
     // helper will wrap these into real AbundanceObj instances inside the
     // sandbox before invoking `run()`.
+    // Trim out any empty geometries in the heirarchy.
     const assemblyAsPojo = async (
       assembly: AbundanceObject,
       context: RequestContext,

--- a/src/worker/code.ts
+++ b/src/worker/code.ts
@@ -590,22 +590,8 @@ async function executeTsCode(
       context,
       cacheId,
     );
-    if (util.isAssembly(abundanceObj)) {
-      const disjointAssembly = await assembly(abundanceObj.geometry, context);
-
-      // Copy all properties from abundanceObj except geometry
-      Object.keys(abundanceObj).forEach((key) => {
-        if (key !== "geometry") {
-          (disjointAssembly as any)[key] = (abundanceObj as any)[key];
-        }
-      });
-
-      await util.geometryProvider!.endBatchOperation(context, disjointAssembly);
-      return disjointAssembly;
-    } else {
-      await util.geometryProvider!.endBatchOperation(context, abundanceObj);
-      return abundanceObj;
-    }
+    await util.geometryProvider!.endBatchOperation(context, abundanceObj);
+    return abundanceObj;
   } catch (error) {
     console.error("Code execution error:", error);
     if (Number.isInteger(error)) {

--- a/src/worker/geometryProvider.ts
+++ b/src/worker/geometryProvider.ts
@@ -4,6 +4,7 @@ import {
   AbundanceObject,
   asReplicadPlane,
   flattenAssembly,
+  isEmptyShape,
   SimplePlane,
 } from "./util";
 import {
@@ -30,9 +31,23 @@ type RequestContext = {
   [key: string]: any; // Allows for additional props
 };
 
-type CutResult = {
-  didChange: boolean;
-  result: replicad.Shape3D;
+/**
+ * Possible outcome types of a boolean operation. No-op implies the
+ * input is == to the output. EmptyShape implies the output is an
+ * empty shape, eg intersection of disjoint shapes. NewShape is
+ * the typical case where the operation produces a non-empty shape
+ * distinct from it's inputs.
+ */
+enum BooleanOutcome {
+  EmptyShape,
+  InputShape,
+  NewShape,
+}
+
+type BooleanResult = {
+  outcome: BooleanOutcome;
+  inputIndexAsResult?: number; // if outcome is InputShape, which input shape is it.
+  result?: replicad.Shape3D | replicad.Drawing; // it outcome is NewShape, include that here.
 };
 
 /**
@@ -45,6 +60,7 @@ type CutResult = {
  * or retrieve the geometry via `get(id)`.
  */
 class GeometryProvider {
+  public EMPTY_SHAPE_SENTINEL = "emptyshape";
   private MAX_PROJECTS = 4;
   private projectLRU: string[] = [];
   private cacheHitMetrics: Record<string, [number, number, number]>; // hits, misses, total-miss-duration-ms
@@ -107,7 +123,50 @@ class GeometryProvider {
     });
   }
 
+  private async booleanOperation(
+    resultId: string,
+    inputs: string[],
+    context: RequestContext,
+    operation: (inputs: string[]) => Promise<BooleanResult>,
+  ): Promise<string> {
+    // Always use cache result if it's available
+    if (
+      this.getFromWarmCache(resultId, context) ||
+      (await shapeExists(context.project, resultId))
+    ) {
+      return resultId;
+    }
+
+    // Cache miss. Compute the operation then either:
+    //  add result to the cache
+    //  if a no-op return the appropriate input id
+    //  if a empty shape return the sentinel
+    const opResult = await operation(inputs);
+    switch (opResult.outcome) {
+      case BooleanOutcome.EmptyShape:
+        return this.EMPTY_SHAPE_SENTINEL;
+      case BooleanOutcome.InputShape:
+        if (opResult.inputIndexAsResult === undefined) {
+          throw new Error(
+            "Boolean operation returned InputShape without index: " +
+              JSON.stringify(opResult),
+          );
+        }
+        return inputs[opResult.inputIndexAsResult];
+      case BooleanOutcome.NewShape:
+        if (opResult.result) {
+          await putShape(
+            context.project,
+            resultId,
+            opResult.result.serialize(),
+          );
+        }
+        return resultId;
+    }
+  }
+
   // Returns the id of the geometry once it's been added to the cache.
+  // Or undefined if builder results in an empty object.
   private async createIfAbsent(
     id: string,
     context: RequestContext,
@@ -183,6 +242,10 @@ class GeometryProvider {
    * @returns The geometry object itself (ie ReplicadObject)
    */
   async get(id: string, context: RequestContext): Promise<ReplicadObject> {
+    if (id === this.EMPTY_SHAPE_SENTINEL) {
+      console.warn("Attempting to retrieve empty sentinel from the cache");
+      return replicad.makeCompound([]) as replicad.Shape3D;
+    }
     const warmCached = this.getFromWarmCache(id, context);
     if (warmCached) {
       this.cacheHit("deserialize");
@@ -345,6 +408,9 @@ class GeometryProvider {
     id: string,
     context: RequestContext,
   ): Promise<string[]> {
+    if (id === this.EMPTY_SHAPE_SENTINEL) {
+      return [this.EMPTY_SHAPE_SENTINEL];
+    }
     const compound = await this.get(id, context);
     if (!(compound instanceof replicad.Compound)) {
       return [id];
@@ -394,6 +460,9 @@ class GeometryProvider {
     dz: number,
     context: RequestContext,
   ): Promise<string> {
+    if (id === this.EMPTY_SHAPE_SENTINEL) {
+      return this.EMPTY_SHAPE_SENTINEL;
+    }
     const movedId = this._makeId("move", id, dx, dy, dz);
     await this.createIfAbsent(movedId, context, async () => {
       const geometry = await this.get(id, context);
@@ -409,11 +478,13 @@ class GeometryProvider {
     z: number,
     context: RequestContext,
   ): Promise<string> {
+    if (id === this.EMPTY_SHAPE_SENTINEL) {
+      return this.EMPTY_SHAPE_SENTINEL;
+    }
     const rotateId = this._makeId("rotate", id, x, y, z);
     await this.createIfAbsent(rotateId, context, async () => {
       const geometry = await this.get(id, context);
       if (geometry instanceof replicad.Drawing) {
-        // TODO(tristan): should this rotate around center of bounding box?
         return geometry.rotate(z, [0, 0]);
       } else {
         return geometry
@@ -430,6 +501,9 @@ class GeometryProvider {
     scaleFactor: number,
     context: RequestContext,
   ): Promise<string> {
+    if (id === this.EMPTY_SHAPE_SENTINEL) {
+      return this.EMPTY_SHAPE_SENTINEL;
+    }
     const scaleId = this._makeId("scale", id, scaleFactor);
     await this.createIfAbsent(scaleId, context, async () => {
       const geometry = await this.get(id, context);
@@ -443,6 +517,9 @@ class GeometryProvider {
     radius: number,
     context: RequestContext,
   ): Promise<string> {
+    if (id === this.EMPTY_SHAPE_SENTINEL) {
+      return this.EMPTY_SHAPE_SENTINEL;
+    }
     const filletId = this._makeId("fillet", id, radius);
     await this.createIfAbsent(filletId, context, async () => {
       const geometry = await this.get(id, context);
@@ -462,6 +539,9 @@ class GeometryProvider {
     size: number,
     context: RequestContext,
   ): Promise<string> {
+    if (id === this.EMPTY_SHAPE_SENTINEL) {
+      return this.EMPTY_SHAPE_SENTINEL;
+    }
     const chamferId = this._makeId("chamfer", id, size);
     await this.createIfAbsent(chamferId, context, async () => {
       const geometry = await this.get(id, context);
@@ -508,6 +588,12 @@ class GeometryProvider {
     inputID2: string,
     context: RequestContext,
   ): Promise<string | undefined> {
+    if (
+      input1ID === this.EMPTY_SHAPE_SENTINEL ||
+      inputID2 === this.EMPTY_SHAPE_SENTINEL
+    ) {
+      return this.EMPTY_SHAPE_SENTINEL;
+    }
     const id = this._makeId("intersect", input1ID, inputID2);
     return await this.createIfAbsent(id, context, async () => {
       const args = [
@@ -542,6 +628,12 @@ class GeometryProvider {
     inputID2: string,
     context: RequestContext,
   ): Promise<string> {
+    if (input1ID === this.EMPTY_SHAPE_SENTINEL) {
+      return inputID2;
+    }
+    if (inputID2 === this.EMPTY_SHAPE_SENTINEL) {
+      return input1ID;
+    }
     const sortedArgs = [input1ID, inputID2].sort();
     const resultId = this._makeId("fuse", sortedArgs[0], sortedArgs[1]);
 
@@ -571,7 +663,9 @@ class GeometryProvider {
     assembly: AbundanceObject,
     context: RequestContext,
   ): Promise<string> {
-    const partIds = flattenAssembly(assembly).map((part) => part.geometry);
+    const partIds = flattenAssembly(assembly)
+      .map((part) => part.geometry)
+      .filter((id) => id !== this.EMPTY_SHAPE_SENTINEL);
     if (partIds.length === 1) {
       return partIds[0];
     }
@@ -611,44 +705,62 @@ class GeometryProvider {
     toCut: string,
     cutter: string,
     context: RequestContext,
-  ): Promise<string> {
-    const toCutGeom = await this.get(toCut, context);
-    if (toCutGeom instanceof replicad.Wire) {
-      return toCut; // cutting wire is a no-op.
-    }
-    const cutterGeom = await this.get(cutter, context);
-    if (cutterGeom instanceof replicad.Wire) {
-      return toCut; // cutting with a wire is a no-op.
-    }
-
-    const args = [toCutGeom, cutterGeom];
-    const resultId = this._makeId("cut", toCut, cutter);
-    if (this.areAllDrawings(args)) {
-      if (args[0].boundingBox.isOut(args[1].boundingBox)) {
-        return toCut;
-      }
-      await this.createIfAbsent(resultId, context, async () => {
-        return args[0].cut(args[1]);
-      });
-      return resultId;
-    }
-    if (this.areAll3DShapes(args)) {
-      if (args[0].boundingBox.isOut(args[1].boundingBox)) {
-        return toCut;
-      }
-      // Special case for 3D Objects. Return the original object if
-      // the cut resulted in no change.
-      const id = await this.createIfAbsent(resultId, context, async () => {
-        const res = this._customCut(args[0], args[1]);
-        if (res.didChange) {
-          return res.result;
-        } else {
-          return undefined;
+  ): Promise<string | undefined> {
+    // Don't deserialize if it's a cache hit. Move checks inside the
+    // cache check operation.
+    return await this.booleanOperation(
+      this._makeId("cut", toCut, cutter),
+      [toCut, cutter],
+      context,
+      async () => {
+        // Empty shape special cases
+        if (toCut === this.EMPTY_SHAPE_SENTINEL) {
+          return { outcome: BooleanOutcome.EmptyShape };
+        } else if (cutter === this.EMPTY_SHAPE_SENTINEL) {
+          return {
+            outcome: BooleanOutcome.InputShape,
+            inputIndexAsResult: 0,
+          };
         }
-      });
-      return id === undefined ? toCut : id;
-    }
-    return toCut;
+
+        const toCutGeom = await this.get(toCut, context);
+        const cutterGeom = await this.get(cutter, context);
+
+        const args = [toCutGeom, cutterGeom];
+        if (this.areAllDrawings(args)) {
+          return {
+            outcome: BooleanOutcome.NewShape,
+            result: args[0].cut(args[1]),
+          };
+        } else if (this.areAll3DShapes(args)) {
+          const initialVolume = replicad.measureVolume(args[0]);
+          const result = args[0].cut(args[1]);
+          const resultVolume = replicad.measureVolume(result);
+          const volumeDiff = Math.abs(initialVolume - resultVolume);
+          const tolerance = 1e-5;
+          if (volumeDiff < tolerance) {
+            return {
+              outcome: BooleanOutcome.InputShape,
+              inputIndexAsResult: 0,
+            };
+          } else if (resultVolume < tolerance) {
+            return { outcome: BooleanOutcome.EmptyShape };
+          } else {
+            return {
+              outcome: BooleanOutcome.NewShape,
+              result: this.as3dShapeOrThrow(result),
+            };
+          }
+        } else {
+          throw new Error(
+            "Invalid types for cut: " +
+              typeof args[0] +
+              " and " +
+              typeof args[1],
+          );
+        }
+      },
+    );
   }
 
   /**
@@ -657,8 +769,9 @@ class GeometryProvider {
    * input geometry. Note that geometries which share a face usually will
    * indicate true even if the final geometry is logically equivalent.
    */
-  _customCut(part1: replicad.Shape3D, part2: replicad.Shape3D): CutResult {
+  _customCut(part1: replicad.Shape3D, part2: replicad.Shape3D): BooleanResult {
     const r = GCWithScope();
+    const initialVolume = replicad.measureVolume(part1);
     const progress = r(new part1.oc.Message_ProgressRange_1());
     // Note that part1.oc isn't significant here. could equally be part2.oc
     // we just need a reference to OpenCascade to make the differencing operation.
@@ -670,16 +783,34 @@ class GeometryProvider {
     cutter.SimplifyResult(true, true, 1e-3);
 
     const newShape = replicad.cast(cutter.Shape());
+    console.log(`timing: cut operation : ${performance.now() - start}`);
     if (!replicad.isShape3D(newShape))
       throw new Error("Could not cut as a 3d shape");
     const mod =
       cutter.HasModified() ||
       cutter.HasGenerated() ||
-      cutter.IsDeleted(part2.wrapped);
-    /*console.trace(
+      cutter.IsDeleted(part2.wrapped) ||
+      cutter.IsDeleted(part1.wrapped);
+    console.trace(
       `mod: ${cutter.HasModified()} gen: ${cutter.HasGenerated()} del: ${cutter.IsDeleted(part1.wrapped)} del p2: ${cutter.IsDeleted(part2.wrapped)}`,
-    );*/
+    );
+    start = performance.now();
+    const resultVol = replicad.measureVolume(newShape);
+    console.log(
+      `timing: result volume ${resultVol} : ${performance.now() - start}`,
+    );
+    console.log("result volume: ", resultVol);
 
+    // TODO: tristan
+    // volume calculation is fast, usually less than 1 ms
+    // So.. we can afford to use it to distinguish our modifiation case
+    // of which there are three:
+    // 1) happy case - cut resulted in a new shape, return it's id
+    // 2) no-op cut - cut resulted in the same shape, return original id
+    // 3) supercut - cut deleted the input shape entirely, <- what do we do here?
+    // old school is that we stored the empty object in the cache as if we were in case 1
+    // we could re-institute this. but now is also a chance to think about how none-shapes are
+    // dealt with.
     return { didChange: mod, result: newShape };
   }
 
@@ -734,6 +865,9 @@ class GeometryProvider {
       // For all intermediate shapes which are part of the result assembly,
       // promote them to the serialized cache.
       for (const leaf of flattenAssembly(result)) {
+        if (leaf.geometry === this.EMPTY_SHAPE_SENTINEL) {
+          continue; // Empty shapes don't exist in the cache
+        }
         const geom = this.getFromWarmCache(leaf.geometry, context);
         if (geom) {
           await putShape(
@@ -883,6 +1017,12 @@ class GeometryProvider {
     operationName: string,
     operationArgs: any[],
   ) {
+    if (
+      replicad.isShape3D(geometry) &&
+      replicad.measureVolume(geometry) === 0
+    ) {
+      return this.EMPTY_SHAPE_SENTINEL;
+    }
     const id: string = this._makeId(operationName, ...operationArgs);
     await this.createIfAbsent(id, context, () => Promise.resolve(geometry));
     return id;

--- a/src/worker/geometryProvider.ts
+++ b/src/worker/geometryProvider.ts
@@ -4,7 +4,6 @@ import {
   AbundanceObject,
   asReplicadPlane,
   flattenAssembly,
-  isEmptyShape,
   SimplePlane,
 } from "./util";
 import {
@@ -761,57 +760,6 @@ class GeometryProvider {
         }
       },
     );
-  }
-
-  /**
-   * Same as replicad's cut operation for Shape3ds but also includes
-   * a boolean indicating whether the cut resulted in a change to the
-   * input geometry. Note that geometries which share a face usually will
-   * indicate true even if the final geometry is logically equivalent.
-   */
-  _customCut(part1: replicad.Shape3D, part2: replicad.Shape3D): BooleanResult {
-    const r = GCWithScope();
-    const initialVolume = replicad.measureVolume(part1);
-    const progress = r(new part1.oc.Message_ProgressRange_1());
-    // Note that part1.oc isn't significant here. could equally be part2.oc
-    // we just need a reference to OpenCascade to make the differencing operation.
-    // The argument order is what controls which part is cut vs cutting.
-    const cutter = r(
-      new part1.oc.BRepAlgoAPI_Cut_3(part1.wrapped, part2.wrapped, progress),
-    );
-    cutter.Build(progress);
-    cutter.SimplifyResult(true, true, 1e-3);
-
-    const newShape = replicad.cast(cutter.Shape());
-    console.log(`timing: cut operation : ${performance.now() - start}`);
-    if (!replicad.isShape3D(newShape))
-      throw new Error("Could not cut as a 3d shape");
-    const mod =
-      cutter.HasModified() ||
-      cutter.HasGenerated() ||
-      cutter.IsDeleted(part2.wrapped) ||
-      cutter.IsDeleted(part1.wrapped);
-    console.trace(
-      `mod: ${cutter.HasModified()} gen: ${cutter.HasGenerated()} del: ${cutter.IsDeleted(part1.wrapped)} del p2: ${cutter.IsDeleted(part2.wrapped)}`,
-    );
-    start = performance.now();
-    const resultVol = replicad.measureVolume(newShape);
-    console.log(
-      `timing: result volume ${resultVol} : ${performance.now() - start}`,
-    );
-    console.log("result volume: ", resultVol);
-
-    // TODO: tristan
-    // volume calculation is fast, usually less than 1 ms
-    // So.. we can afford to use it to distinguish our modifiation case
-    // of which there are three:
-    // 1) happy case - cut resulted in a new shape, return it's id
-    // 2) no-op cut - cut resulted in the same shape, return original id
-    // 3) supercut - cut deleted the input shape entirely, <- what do we do here?
-    // old school is that we stored the empty object in the cache as if we were in case 1
-    // we could re-institute this. but now is also a chance to think about how none-shapes are
-    // dealt with.
-    return { didChange: mod, result: newShape };
   }
 
   /**

--- a/src/worker/geometryProvider.ts
+++ b/src/worker/geometryProvider.ts
@@ -133,6 +133,7 @@ class GeometryProvider {
       this.getFromWarmCache(resultId, context) ||
       (await shapeExists(context.project, resultId))
     ) {
+      this.cacheHit(resultId);
       return resultId;
     }
 
@@ -140,9 +141,11 @@ class GeometryProvider {
     //  add result to the cache
     //  if a no-op return the appropriate input id
     //  if a empty shape return the sentinel
+    const start = performance.now();
     const opResult = await operation(inputs);
     switch (opResult.outcome) {
       case BooleanOutcome.EmptyShape:
+        this.cacheHit("boolempty" + resultId);
         return this.EMPTY_SHAPE_SENTINEL;
       case BooleanOutcome.InputShape:
         if (opResult.inputIndexAsResult === undefined) {
@@ -151,8 +154,10 @@ class GeometryProvider {
               JSON.stringify(opResult),
           );
         }
+        this.cacheHit("boolnoop" + resultId);
         return inputs[opResult.inputIndexAsResult];
       case BooleanOutcome.NewShape:
+        this.cacheMiss(resultId, performance.now() - start);
         if (opResult.result) {
           await putShape(
             context.project,

--- a/src/worker/interaction.ts
+++ b/src/worker/interaction.ts
@@ -362,8 +362,8 @@ async function assembly(
       util.withAssemblyBoundingBoxes(geometry, context),
     ),
   );
-
-  if (!context.operationId) {
+  const insideOtherBatch = !!context.operationId;
+  if (!insideOtherBatch) {
     const batchId = "assembly-" + util.hashString(JSON.stringify(geometries));
     const batch: RequestContext | AbundanceObject =
       await util.geometryProvider!.startBatchOperation(context, batchId);
@@ -423,8 +423,10 @@ async function assembly(
     context,
     false, // forceRecompute=false, so it skips unnecessary recursion
   );
-
-  await util.geometryProvider!.endBatchOperation(context, result);
+  if (!insideOtherBatch) {
+    console.trace("Ending batch operation with id " + context.operationId);
+    await util.geometryProvider!.endBatchOperation(context, result);
+  }
   return result;
 }
 

--- a/src/worker/interaction.ts
+++ b/src/worker/interaction.ts
@@ -1,4 +1,4 @@
-import { Drawing } from "replicad";
+import { BoundingBox, Drawing } from "replicad";
 import * as util from "./util";
 import { AbundanceLeaf, AbundanceObject } from "./util";
 import { RequestContext } from "./geometryProvider";
@@ -314,40 +314,6 @@ async function fusion(
   };
 }
 
-/*
-
-where n is number of leafs and a is number of assemblies
-
-Current control flow:
-For each assembly do cutAssembly with all subsequent geometries
-
-cutAssembly:
-if an assembly recurse down to each part
-if a leaf:
-for each leaf in each input assembly - cut this leaf with that one
-
-
-Runtime:
-* O(n^2) for number of leafs
-
-
-behavior constraints - we need to to retain assembly structures
-
-Options:
-deserialize all then do same as we've done here
-fuse each assembly then cut parts with fused others
-  O(a) fuses
-  O(n) cuts
-
-
-deserialization options:
-1) deserialize into an (eg) realized assembly
-2) create a higher level cache which writes results into our main cache but doesn't
-   need deserialization
-
-
-*/
-
 /**
  * A function which takes in an array of target geometries and forms them into an assembly
  * Geometries will cut all geometries below them in the list to make sure that no parts intersect
@@ -361,9 +327,13 @@ async function assembly(
     throw new Error("inputIDs must be a non-empty array");
   }
 
+  // Assembly of a singleton is a no-op. Return the leaf as the result.
+  if (geometries.length == 1) {
+    return geometries[0];
+  }
+
   // Dimension assertions:
   // Allowed inputs -> all 2d, all 3d, or just wires/points
-
   const all3D = geometries.every((geom) => util.is3D(geom));
   const all2D = geometries.every((geom) => util.is2D(geom));
   const allWireOrPoint = geometries.every(
@@ -374,20 +344,27 @@ async function assembly(
       "Input geometries must be all 2D, all 3D, or just wires/points.",
     );
   }
+  // Fast return if all points or wires.
+  if (allWireOrPoint) {
+    return util.assemblyOf(geometries);
+  }
+  if (!(all2D || all3D)) {
+    throw new Error(
+      "Input geometries must be all 2D or all 3D (unless they are wires/points).",
+    );
+  }
 
   await util.init();
 
-  // Eagerly compute bounding boxes for all input geometries
-  const geometriesWithBounds = await Promise.all(
+  // Pre-emptively compute bounding boxes for all input geometries.
+  geometries = await Promise.all(
     geometries.map((geometry) =>
       util.withAssemblyBoundingBoxes(geometry, context),
     ),
   );
 
-  let startedBatch = false;
   if (!context.operationId) {
-    const batchId =
-      "assembly-" + util.hashString(JSON.stringify(geometriesWithBounds));
+    const batchId = "assembly-" + util.hashString(JSON.stringify(geometries));
     const batch: RequestContext | AbundanceObject =
       await util.geometryProvider!.startBatchOperation(context, batchId);
 
@@ -399,7 +376,7 @@ async function assembly(
       // Gather all nonReplicadSerialized and bom from input geometries
       const nonReplicadGeoms: any[] = [];
       const bomAssembly: any[] = [];
-      for (const geometry of geometriesWithBounds) {
+      for (const geometry of geometries) {
         if (
           Array.isArray(geometry.nonReplicadSerialized) &&
           geometry.nonReplicadSerialized.length > 0
@@ -416,100 +393,38 @@ async function assembly(
       return batchWithBounds;
     }
 
+    // cache miss on the batch operation.
     context = batch;
-    startedBatch = true;
   }
 
+  // The general case of a cache miss assembly operation.
   const assembly: AbundanceObject[] = [];
-  const bomAssembly: any[] = [];
-  const nonReplicadGeoms: any[] = [];
 
-  if (geometriesWithBounds.length > 1) {
-    const all3D = geometriesWithBounds.every((geom) => util.is3D(geom));
-    const all2D = geometriesWithBounds.every((geom) => !util.is3D(geom));
-
-    if (all3D || all2D) {
-      // Always clear arrays before populating
-      bomAssembly.length = 0;
-      nonReplicadGeoms.length = 0;
-      for (let i = 0; i < geometriesWithBounds.length; i++) {
-        const geometry = geometriesWithBounds[i];
-        assembly.push(
-          await cutAssembly(
-            geometry,
-            geometriesWithBounds.slice(i + 1),
-            context,
-          ),
-        );
-      }
-      // Gather all nonReplicadSerialized and bom from input geometries
-      for (const geometry of geometriesWithBounds) {
-        if (
-          Array.isArray(geometry.nonReplicadSerialized) &&
-          geometry.nonReplicadSerialized.length > 0
-        ) {
-          nonReplicadGeoms.push(...geometry.nonReplicadSerialized);
-        }
-        if (Array.isArray(geometry.bom) && geometry.bom.length > 0) {
-          bomAssembly.push(...geometry.bom);
-        }
-      }
-    } else {
-      throw new Error(
-        "Assemblies must be composed from only sketches OR only solids",
-      );
-    }
-  } else {
-    // Always clear arrays before populating
-    bomAssembly.length = 0;
-    nonReplicadGeoms.length = 0;
-    const geometry = geometriesWithBounds[0];
-    assembly.push(geometry);
-    // Gather all nonReplicadSerialized and bom from input geometries
-    for (const geometry of geometriesWithBounds) {
-      if (
-        Array.isArray(geometry.nonReplicadSerialized) &&
-        geometry.nonReplicadSerialized.length > 0
-      ) {
-        nonReplicadGeoms.push(...geometry.nonReplicadSerialized);
-      }
-      if (Array.isArray(geometry.bom) && geometry.bom.length > 0) {
-        bomAssembly.push(...geometry.bom);
-      }
-    }
+  // Each geometry is cut by all following geometries.
+  // TODO: test if this is faster working back-to-front or front-to-back.
+  for (let i = 0; i < geometries.length - 1; i++) {
+    const geometry = geometries[i];
+    assembly.push(
+      await cutAssembly(geometry, geometries.slice(i + 1), context),
+    );
   }
+  assembly.push(geometries[geometries.length - 1]); // Final entry is always unmodified.
 
   // Build the initial assembly object with all children already having bounds
-  const assemblyObject: AbundanceObject = {
-    geometry: await Promise.all(assembly),
-    plane: util.XYPlane,
-    tags: [],
-    color: util.defaultColor,
-    bom: bomAssembly,
-    dimension: geometriesWithBounds.every((geom) => util.is3D(geom))
-      ? "3D"
-      : geometriesWithBounds.every((geom) => !util.is3D(geom))
-        ? "2D"
-        : "Wire",
-    nonReplicadSerialized: nonReplicadGeoms,
-  };
-
-  // Eagerly compute assembly bounds by merging existing child bounds
-  // This is more efficient than withAssemblyBoundingBoxes because it doesn't
-  // recursively traverse - it assumes all children already have bounds
-  const assemblyWithBounds = util.computeAssemblyBounds(assemblyObject);
+  const assemblyObject: AbundanceObject = util.assemblyOf(
+    await Promise.all(assembly),
+  );
 
   // Safety check with recursive validation disabled (forceRecompute=false)
   // Since we've already computed bounds eagerly, this will detect our computed bounds
   // and return immediately without recursive traversal
   const result = await util.withAssemblyBoundingBoxes(
-    assemblyWithBounds,
+    assemblyObject,
     context,
     false, // forceRecompute=false, so it skips unnecessary recursion
   );
-  if (startedBatch) {
-    await util.geometryProvider!.endBatchOperation(context, result);
-  }
+
+  await util.geometryProvider!.endBatchOperation(context, result);
   return result;
 }
 
@@ -544,6 +459,8 @@ async function fuseAssembly(
 
 /**
  * Performs a boolean cut operation on an assembly or part with one or more cutting geometries.
+ * This function assumes that partToCut an cuttingParts are of the same dimensionality,
+ * either all 2D or all 3D.
  *
  * @param {Object} partToCut - The library object (part or assembly) that will be cut
  * @param {Object[]} cuttingParts - Array of geometries that will cut the part
@@ -565,29 +482,19 @@ async function cutAssembly(
 
   //If the partToCut is an assembly pass each part back into cutAssembly function to be cut separately
   if (util.isAssembly(partToCut)) {
-    const assemblyToCut = partToCut.geometry;
-    const assemblyCut: any[] = [];
-    for (const part of assemblyToCut) {
+    const partsAfterCut: AbundanceObject[] = [];
+    for (const part of partToCut.geometry) {
       // make new assembly from cut parts
-      assemblyCut.push(await cutAssembly(part, cuttingParts, context));
+      partsAfterCut.push(await cutAssembly(part, cuttingParts, context));
     }
 
-    //returns new assembly that has been cut
-    const newAssembly = {
-      geometry: assemblyCut,
-      tags: partToCut.tags,
-      bom: partToCut.bom,
-      plane: partToCut.plane,
-      color: partToCut.color,
-    };
+    const newAssembly = util.computeAssemblyBounds({
+      ...partToCut, // Retain metadata from original assembly top-level branch.
+      geometry: partsAfterCut,
+    });
     return newAssembly;
   } else {
-    // if part to cut is wire geometry, return it unchanged (wires should pass through assemblies)
-    if (util.isWireGeometry(partToCut)) {
-      return partToCut;
-    }
-
-    // if part to cut is a single part send to cutting function with cutting parts
+    // Part to cut is a single leaf.
     let partCutCopy = partToCut;
     for (const cuttingPart of cuttingParts) {
       // Check if bounding boxes overlap before attempting cut
@@ -630,16 +537,13 @@ async function recursiveCut(
   cuttingParts: AbundanceObject,
   context: RequestContext,
 ): Promise<AbundanceLeaf> {
-  if (util.isWireGeometry(partToCut)) {
-    return partToCut;
-  }
-
   let resultGeomId: string = partToCut.geometry;
+
+  // TODO: traversing leafs in this way isn't optimal for bounding box
+  // checks since we could find an entire branch of the assembly which doesn't
+  // intersect bounding box. This is simpler implemenation but may someday warrant
+  // a change.
   for (const cuttingPart of util.flattenAssembly(cuttingParts)) {
-    if (partToCut.dimension != cuttingPart.dimension) {
-      continue;
-      // skip this leaf. can't cut 2D with 3D or vice versa
-    }
     // --- Coplanarity check for 2D shapes ---
     if (
       partToCut.dimension === "2D" &&
@@ -647,35 +551,16 @@ async function recursiveCut(
       partToCut.plane &&
       cuttingPart.plane
     ) {
-      // Compare normals (should be parallel) and origins (should be on the same plane)
-      const p1 = partToCut.plane;
-      const p2 = cuttingPart.plane;
-      const normalsAreParallel =
-        Math.abs(p1.normal[0] * p2.normal[1] - p1.normal[1] * p2.normal[0]) <
-          1e-6 &&
-        Math.abs(p1.normal[0] * p2.normal[2] - p1.normal[2] * p2.normal[0]) <
-          1e-6 &&
-        Math.abs(p1.normal[1] * p2.normal[2] - p1.normal[2] * p2.normal[1]) <
-          1e-6;
-
-      // Check if origins are on the same plane (dot product of normal and vector between origins is zero)
-      const originDelta = [
-        p2.origin[0] - p1.origin[0],
-        p2.origin[1] - p1.origin[1],
-        p2.origin[2] - p1.origin[2],
-      ];
-      const originOnPlane =
-        Math.abs(
-          p1.normal[0] * originDelta[0] +
-            p1.normal[1] * originDelta[1] +
-            p1.normal[2] * originDelta[2],
-        ) < 1e-6;
-
-      if (!normalsAreParallel || !originOnPlane) {
+      // Compare normals (should be parallel) and origins (should be on the same plane)=
+      if (!util.coPlanar(partToCut.plane, cuttingPart.plane)) {
         continue; // skip: not coplanar
       }
     }
-    // --- end coplanarity check ---
+
+    // Bounding box check.
+    if (!util.boundsOverlap(partToCut.boundingBox, cuttingPart.boundingBox)) {
+      continue; // skip: bounding boxes don't overlap
+    }
 
     resultGeomId = await util.geometryProvider!.cut(
       resultGeomId,

--- a/src/worker/meshWorker.ts
+++ b/src/worker/meshWorker.ts
@@ -214,8 +214,13 @@ async function generateDisplayMesh(
       return { id: id, mesh: await generateDefaultMesh(context) };
     }
 
-    // Flatten the assembly to remove hierarchy
-    const flattened = util.flattenAssembly(geom);
+    // Flatten the assembly to remove hierarchy. Skip empty shapes
+    const flattened = util.flattenAssembly(geom).filter((part) => {
+      return part.geometry !== util.geometryProvider?.EMPTY_SHAPE_SENTINEL;
+    });
+    if (flattened.length === 0) {
+      return { id: id, mesh: await generateDefaultMesh(context) };
+    }
 
     const meshArray: { color: string; geometry: ReplicadObject }[] = [];
 

--- a/src/worker/util.ts
+++ b/src/worker/util.ts
@@ -557,20 +557,6 @@ function coPlanar(p1: SimplePlane, p2: SimplePlane): boolean {
   return normalsAreParallel && originOnPlane;
 }
 
-function isEmptyShape(shape: ReplicadObject): boolean {
-  if (shape instanceof replicad.Wire || shape instanceof replicad.Vertex) {
-    return false;
-  }
-  if (shape instanceof replicad.Drawing) {
-    //@ts-ignore
-    return shape.innerShape === null;
-  }
-  if (replicad.isShape3D(shape)) {
-    return replicad.measureVolume(shape) === 0;
-  }
-  return false;
-}
-
 export {
   AbundanceBounds,
   AbundanceLeaf,
@@ -606,5 +592,4 @@ export {
   withAssemblyBoundingBoxes,
   XYPlane,
   startHeapMonitor,
-  isEmptyShape,
 };

--- a/src/worker/util.ts
+++ b/src/worker/util.ts
@@ -2,7 +2,11 @@ import * as replicad from "replicad";
 import opencascade from "replicad-opencascadejs/src/replicad_single.js";
 import opencascadeWasm from "replicad-opencascadejs/src/replicad_single.wasm?url";
 import { v4 as uuidv4 } from "uuid";
-import { GeometryProvider, RequestContext } from "./geometryProvider";
+import {
+  GeometryProvider,
+  ReplicadObject,
+  RequestContext,
+} from "./geometryProvider";
 
 const defaultColor: string = "#aad7f2";
 let loaded: boolean = false;
@@ -514,6 +518,59 @@ function hashString(str: string): string {
   return hash.toString(16).padStart(8, "0");
 }
 
+function assemblyOf(subAssemblies: AbundanceObject[]): AbundanceObject {
+  const result: AbundanceBranch = {
+    geometry: subAssemblies,
+    plane: XYPlane,
+    color: defaultColor,
+    tags: [],
+    bom: [],
+    dimension: subAssemblies[0].dimension,
+    nonReplicadSerialized: subAssemblies
+      .map((a) => a.nonReplicadSerialized || [])
+      .flat(),
+  };
+  return computeAssemblyBounds(result);
+}
+
+function coPlanar(p1: SimplePlane, p2: SimplePlane): boolean {
+  const normalsAreParallel =
+    Math.abs(p1.normal[0] * p2.normal[1] - p1.normal[1] * p2.normal[0]) <
+      1e-6 &&
+    Math.abs(p1.normal[0] * p2.normal[2] - p1.normal[2] * p2.normal[0]) <
+      1e-6 &&
+    Math.abs(p1.normal[1] * p2.normal[2] - p1.normal[2] * p2.normal[1]) < 1e-6;
+
+  // Check if origins are on the same plane (dot product of normal and vector between origins is zero)
+  const originDelta = [
+    p2.origin[0] - p1.origin[0],
+    p2.origin[1] - p1.origin[1],
+    p2.origin[2] - p1.origin[2],
+  ];
+  const originOnPlane =
+    Math.abs(
+      p1.normal[0] * originDelta[0] +
+        p1.normal[1] * originDelta[1] +
+        p1.normal[2] * originDelta[2],
+    ) < 1e-6;
+
+  return normalsAreParallel && originOnPlane;
+}
+
+function isEmptyShape(shape: ReplicadObject): boolean {
+  if (shape instanceof replicad.Wire || shape instanceof replicad.Vertex) {
+    return false;
+  }
+  if (shape instanceof replicad.Drawing) {
+    //@ts-ignore
+    return shape.innerShape === null;
+  }
+  if (replicad.isShape3D(shape)) {
+    return replicad.measureVolume(shape) === 0;
+  }
+  return false;
+}
+
 export {
   AbundanceBounds,
   AbundanceLeaf,
@@ -522,8 +579,10 @@ export {
   actOnLeafsSync,
   asReplicadPlane,
   asSimplePlane,
+  assemblyOf,
   boundsOverlap,
   computeAssemblyBounds,
+  coPlanar,
   defaultColor,
   dimensionLabel,
   flattenAssembly,
@@ -547,4 +606,5 @@ export {
   withAssemblyBoundingBoxes,
   XYPlane,
   startHeapMonitor,
+  isEmptyShape,
 };

--- a/src/worker/util.ts
+++ b/src/worker/util.ts
@@ -165,7 +165,19 @@ async function getBounds(
     await actOnLeafs(geometry, async (leaf: AbundanceLeaf) => {
       const replicadbox = (await geometryProvider!.get(leaf.geometry, context))
         .boundingBox;
-      let bbox = replicadbox.bounds;
+      let bbox = undefined;
+      try {
+        bbox = replicadbox.bounds;
+      } catch (error) {
+        console.error(
+          "Failed to get bounds for geometry ID " + leaf.geometry,
+          error,
+        );
+        return {
+          min: [minX, minY, minZ],
+          max: [maxX, maxY, maxZ],
+        };
+      }
       minX = Math.min(minX, bbox[0][0]);
       minY = Math.min(minY, bbox[0][1]);
       maxX = Math.max(maxX, bbox[1][0]);


### PR DESCRIPTION
Updates logic around cut operations in abundance.

Specifically it turns out that Volume computation for 3d solids is fast. Fast enough that we can use it to double check the class of interaction which a cut operation falls into. The cases being:

1.  cut between two shapes that don't touch -> volume of both inputs is unchanged
2. cut which entirely removes the target shape -> volume of result is 0
3. cut removes some but not all of the target -> volume of result is < initial but > 0 

Only the third case requires a new entry in the cache.

Prior to this PR case 1 was fairly common and would lead us to re-instantiate identical objects. This was particularly pervasive in assemblies. In an initial effort to fix this I conflated cases 1 and 2 which would sometimes allow shapes to persist after when they should have been cut away to nothing.
