### PR TITLE
Save import file type so it doesn't always reset to SVG

### DIFF
--- a/src/molecules/input.js
+++ b/src/molecules/input.js
@@ -97,6 +97,10 @@ export default class Input extends Atom {
     // Set values first to ensure type is set correctly
     this.setValues(values);
 
+    if (this.fileType && this.importOptions.includes(this.fileType)) {
+      this.importIndex = this.importOptions.indexOf(this.fileType);
+    }
+
     // Determine the output valueType (import type outputs geometry)
     const outputValueType = this.type === "import" ? "geometry" : this.type;
     this.addIO("number or geometry", outputValueType, this.value, "output");
@@ -1233,15 +1237,23 @@ export default class Input extends Atom {
 
     // If type is import, add controls for file upload
     if (this.type === "import") {
+      const selectedImportType = this.importOptions.includes(this.fileType)
+        ? this.fileType
+        : this.importOptions[this.importIndex] || this.importOptions[0];
+
+      this.importIndex = this.importOptions.indexOf(selectedImportType);
+
       if (this.fileName === null) {
         inputParams[this.uniqueID + "file_ops"] = {
           type: "select",
+          value: selectedImportType,
           options: this.importOptions,
           label: "File Type",
           onChange: (value) => {
             if (!value) {
               value = this.importOptions[0];
             }
+            this.fileType = value;
             this.importIndex = this.importOptions.indexOf(value);
           },
         };

--- a/tests/range-valuetype.test.js
+++ b/tests/range-valuetype.test.js
@@ -117,6 +117,25 @@ describe("Range valuetype for Input atoms", () => {
     expect(serialized.max).toBe(95);
   });
 
+  it("should preserve persisted import file type selection when rebuilding controls", () => {
+    const input = new Input({
+      x: 0.3,
+      y: 0.3,
+      parent: parentMolecule,
+      uniqueID: GlobalVariables.generateUniqueID(),
+      type: "import",
+      fileType: "STL",
+    });
+
+    const setInputChanged = vi.fn();
+    const params = input.createInputParams(setInputChanged);
+    const fileTypeParam = params[input.uniqueID + "file_ops"];
+
+    expect(input.importIndex).toBe(1);
+    expect(fileTypeParam).toBeDefined();
+    expect(fileTypeParam.value).toBe("STL");
+  });
+
   it("should propagate min/max to parent attachment point options", () => {
     const input = new Input({
       x: 0.3,


### PR DESCRIPTION
Small fix for issue where "import" type inputs would always revert to SVG instead of their set type.