### PR TITLE
Support array or vector in label

### DIFF
--- a/src/molecules/label.js
+++ b/src/molecules/label.js
@@ -140,6 +140,49 @@ export default class Label extends Atom {
   }
 
   /**
+   * Extract [x, y, z] coordinates from either an array or an Abundance Point3D object
+   * Handles both direct coordinates and hash-based geometry IDs via geometryProvider lookup
+   * @param {array|object} value - Either [x, y, z] array or Abundance Point3D object
+   * @returns {array} [x, y, z] coordinates
+   */
+  async extractCoordinates(value) {
+    // If it's already an array, return it
+    if (Array.isArray(value)) {
+      return [
+        Number(value[0]) || 0,
+        Number(value[1]) || 0,
+        Number(value[2]) || 0,
+      ];
+    }
+
+    // If it's a Point3D geometry object
+    if (value && typeof value === "object" && value.dimension === "Point3D") {
+      // If we have geometryProvider and context, use them for hash ID lookup
+      try {
+        const vertex = await GlobalVariables.cad.getAsPoint3D(
+          value.geometry,
+          this.getContext(),
+        );
+        const coords = vertex;
+        return [
+          Number(coords[0]) || 0,
+          Number(coords[1]) || 0,
+          Number(coords[2]) || 0,
+        ];
+      } catch (err) {
+        console.warn(
+          "Failed to lookup vertex from geometry provider:",
+          value.geometry,
+          err,
+        );
+        // Fall through to fallback methods below
+      }
+      // Final fallback
+      return [0, 0, 0];
+    }
+  }
+
+  /**
    * Build the ThreeJS geometries (line + text sprite) and store them in
    * this.nonReplicadGeom so they get sent to the renderer.
    * @param {THREE.Vector3} start - Start point of the line
@@ -147,14 +190,24 @@ export default class Label extends Atom {
    * @param {string} labelText - The text to display
    * @param {string} color - The hex color string for the line and text
    */
-  buildLabelGeometry() {
+  async buildLabelGeometry() {
     // Dispose of old geometry before creating new one
     this.disposeLabelGeometry();
 
-    let startPoint = this.findIOValue("startPosition");
-    let endPoint = this.findIOValue("endPosition");
+    let startPointInput = this.findIOValue("startPosition");
+    let endPointInput = this.findIOValue("endPosition");
+    console.log(
+      "Label atom inputs - startPoint:",
+      startPointInput,
+      "endPoint:",
+      endPointInput,
+    );
     let text = this.findIOValue("text");
     let fontSize = Number(this.findIOValue("fontSize") || 10);
+
+    // Extract coordinates from either arrays or Abundance Point3D objects
+    const startPoint = await this.extractCoordinates(startPointInput);
+    const endPoint = await this.extractCoordinates(endPointInput);
 
     const start = new THREE.Vector3(
       Number(startPoint[0]) || 0,
@@ -383,8 +436,8 @@ export default class Label extends Atom {
    * @param {object} inputs - The resolved input values
    * @returns {Promise} The input geometry unchanged
    */
-  compute() {
-    this.serializedLabel = this.buildLabelGeometry();
+  async compute() {
+    this.serializedLabel = await this.buildLabelGeometry();
     let geom = this.findIOValue("geometry");
     return GlobalVariables.cad.addNonReplicadGeom(geom, this.serializedLabel);
   }
@@ -394,10 +447,10 @@ export default class Label extends Atom {
 
     if (this.inputs) {
       this.inputs.forEach((input) => {
+        const checkConnector = () => {
+          return input.connectors.length > 0;
+        };
         if (input.name === "text") {
-          const checkConnector = () => {
-            return input.connectors.length > 0;
-          };
           inputParams[this.uniqueID + "text"] = {
             type: "string",
             value: input.value,
@@ -422,21 +475,63 @@ export default class Label extends Atom {
             },
           };
         } else if (input.name === "startPosition") {
+          // Async coordinate extraction - get geometryProvider and context
+          const geometryProvider = GlobalVariables.cad?.geometryProvider;
+          const context = GlobalVariables.cad?.currentContext || {
+            project: "default",
+          };
+
+          // Extract coordinates (works with both arrays and Point3D objects)
+          this.extractCoordinates(input.value, geometryProvider, context).then(
+            (displayValue) => {
+              // Update the input params asynchronously
+              inputParams[this.uniqueID + "startPosition"].value = [
+                displayValue[0],
+                displayValue[1],
+                displayValue[2],
+              ];
+            },
+          );
+
           inputParams[this.uniqueID + "startPosition"] = {
             type: "point",
-            value: [input.value[0], input.value[1], input.value[2]],
+            value: Array.isArray(input.value)
+              ? [input.value[0], input.value[1], input.value[2]]
+              : [0, 0, 0], // Default while async lookup completes
             label: "Start position",
             step: 0.1,
+            disabled: checkConnector(),
             onChange: (value) => {
               input.setValue([value[0], value[1], value[2]]);
             },
           };
         } else if (input.name === "endPosition") {
+          // Async coordinate extraction - get geometryProvider and context
+          const geometryProvider = GlobalVariables.cad?.geometryProvider;
+          const context = GlobalVariables.cad?.currentContext || {
+            project: "default",
+          };
+
+          // Extract coordinates (works with both arrays and Point3D objects)
+          this.extractCoordinates(input.value, geometryProvider, context).then(
+            (displayValue) => {
+              // Update the input params asynchronously
+              inputParams[this.uniqueID + "endPosition"].value = [
+                displayValue[0],
+                displayValue[1],
+                displayValue[2],
+              ];
+            },
+          );
+
           inputParams[this.uniqueID + "endPosition"] = {
             type: "point",
-            value: [input.value[0], input.value[1], input.value[2]],
+            value: Array.isArray(input.value)
+              ? [input.value[0], input.value[1], input.value[2]]
+              : [10, 10, 0], // Default while async lookup completes
             label: "End position",
             step: 0.1,
+            disabled: checkConnector(),
             onChange: (value) => {
               input.setValue([value[0], value[1], value[2]]);
             },

--- a/src/molecules/label.js
+++ b/src/molecules/label.js
@@ -196,12 +196,6 @@ export default class Label extends Atom {
 
     let startPointInput = this.findIOValue("startPosition");
     let endPointInput = this.findIOValue("endPosition");
-    console.log(
-      "Label atom inputs - startPoint:",
-      startPointInput,
-      "endPoint:",
-      endPointInput,
-    );
     let text = this.findIOValue("text");
     let fontSize = Number(this.findIOValue("fontSize") || 10);
 

--- a/src/molecules/label.js
+++ b/src/molecules/label.js
@@ -469,24 +469,6 @@ export default class Label extends Atom {
             },
           };
         } else if (input.name === "startPosition") {
-          // Async coordinate extraction - get geometryProvider and context
-          const geometryProvider = GlobalVariables.cad?.geometryProvider;
-          const context = GlobalVariables.cad?.currentContext || {
-            project: "default",
-          };
-
-          // Extract coordinates (works with both arrays and Point3D objects)
-          this.extractCoordinates(input.value, geometryProvider, context).then(
-            (displayValue) => {
-              // Update the input params asynchronously
-              inputParams[this.uniqueID + "startPosition"].value = [
-                displayValue[0],
-                displayValue[1],
-                displayValue[2],
-              ];
-            },
-          );
-
           inputParams[this.uniqueID + "startPosition"] = {
             type: "point",
             value: Array.isArray(input.value)
@@ -500,29 +482,11 @@ export default class Label extends Atom {
             },
           };
         } else if (input.name === "endPosition") {
-          // Async coordinate extraction - get geometryProvider and context
-          const geometryProvider = GlobalVariables.cad?.geometryProvider;
-          const context = GlobalVariables.cad?.currentContext || {
-            project: "default",
-          };
-
-          // Extract coordinates (works with both arrays and Point3D objects)
-          this.extractCoordinates(input.value, geometryProvider, context).then(
-            (displayValue) => {
-              // Update the input params asynchronously
-              inputParams[this.uniqueID + "endPosition"].value = [
-                displayValue[0],
-                displayValue[1],
-                displayValue[2],
-              ];
-            },
-          );
-
           inputParams[this.uniqueID + "endPosition"] = {
             type: "point",
             value: Array.isArray(input.value)
               ? [input.value[0], input.value[1], input.value[2]]
-              : [10, 10, 0], // Default while async lookup completes
+              : [0, 0, 0],
             label: "End position",
             step: 0.1,
             disabled: checkConnector(),

--- a/src/prototypes/atom.js
+++ b/src/prototypes/atom.js
@@ -851,7 +851,7 @@ export default class Atom extends ObservableEntity {
         return;
       }
 
-      // Handle point2d and point3d values (which are arrays)
+      // Handle point3d values, save as arrays
       if (ap.valueType === "point3d" && Array.isArray(ap.getValue())) {
         const currentValue = ap.getValue();
         const isDifferentFromDefault =
@@ -1316,6 +1316,50 @@ export default class Atom extends ObservableEntity {
     return predictedParams;
   }
 
+  /**
+   * Extract [x, y, z] coordinates from either an array or an Abundance Point3D object
+   * Handles both direct coordinates and hash-based geometry IDs via geometryProvider lookup
+   * @param {array|object} value - Either [x, y, z] array or Abundance Point3D object
+   * @returns {array} [x, y, z] coordinates
+   */
+  async extractCoordinates(value) {
+    console.log("Extracting coordinates from value:", value);
+    // If it's already an array, return it
+    if (Array.isArray(value)) {
+      return [
+        Number(value[0]) || 0,
+        Number(value[1]) || 0,
+        Number(value[2]) || 0,
+      ];
+    }
+
+    // If it's a Point3D geometry object
+    if (value && typeof value === "object" && value.dimension === "Point3D") {
+      // If we have geometryProvider and context, use them for hash ID lookup
+      try {
+        const vertex = await GlobalVariables.cad.getAsPoint3D(
+          value.geometry,
+          this.getContext(),
+        );
+        const coords = vertex;
+        return [
+          Number(coords[0]) || 0,
+          Number(coords[1]) || 0,
+          Number(coords[2]) || 0,
+        ];
+      } catch (err) {
+        console.warn(
+          "Failed to lookup vertex from geometry provider:",
+          value.geometry,
+          err,
+        );
+        // Fall through to fallback methods below
+      }
+      // Final fallback
+      return [0, 0, 0];
+    }
+  }
+
   createInputParams(setInputChanged) {
     // Stash the React-side state setter so other code on this atom (e.g.
     // `Code#updateCode` after re-parsing its `Inputs = [...]` block, or
@@ -1394,7 +1438,10 @@ export default class Atom extends ObservableEntity {
           };
         } else if (input.valueType === "point3d") {
           // Handle 3D point inputs
-          const displayValue = hasConnector ? input.getValue() : input.value;
+          console.log(hasConnector, input.value);
+          const displayValue = hasConnector
+            ? this.extractCoordinates(input.value)
+            : input.value;
           inputParams[this.uniqueID + input.name] = {
             type: "point",
             value: [

--- a/src/prototypes/atom.js
+++ b/src/prototypes/atom.js
@@ -1438,7 +1438,6 @@ export default class Atom extends ObservableEntity {
           };
         } else if (input.valueType === "point3d") {
           // Handle 3D point inputs
-          console.log(hasConnector, input.value);
           const displayValue = hasConnector
             ? this.extractCoordinates(input.value)
             : input.value;

--- a/src/prototypes/atom.js
+++ b/src/prototypes/atom.js
@@ -1316,17 +1316,6 @@ export default class Atom extends ObservableEntity {
     return predictedParams;
   }
 
-  computePoint(input, pointValue) {
-    GlobalVariables.cad
-      .vertex(pointValue[0], pointValue[1], pointValue[2], this.getContext())
-      .then((vertex) => {
-        input.setValue(vertex);
-      })
-      .catch((err) => {
-        console.error("Error computing point geometry:", err);
-      });
-  }
-
   createInputParams(setInputChanged) {
     // Stash the React-side state setter so other code on this atom (e.g.
     // `Code#updateCode` after re-parsing its `Inputs = [...]` block, or
@@ -1403,36 +1392,6 @@ export default class Atom extends ObservableEntity {
               }
             },
           };
-        } else if (input.valueType === "point2d") {
-          // Handle 2D point inputs
-          const displayValue = hasConnector ? input.getValue() : input.value;
-          inputParams[this.uniqueID + input.name] = {
-            type: "point",
-            value: [displayValue?.[0] ?? 0, displayValue?.[1] ?? 0],
-            label: input.name,
-            step: 0.1,
-            disabled: hasConnector,
-            onChange: (value) => {
-              if (!GlobalVariables.isUndoing && this.parent) {
-                const oldVal = input.value ? [...input.value] : [0, 0];
-                const inputName = input.name;
-                GlobalVariables.pushUndoCommand(
-                  new ValueChangeCommand(
-                    this.uniqueID,
-                    this.parent,
-                    inputName,
-                    oldVal,
-                    (atom, val) => {
-                      const inp = atom.inputs.find((i) => i.name === inputName);
-                      if (inp) inp.setValue(val);
-                    },
-                    `Change ${this.name} "${input.name}"`,
-                  ),
-                );
-              }
-              input.setValue([value[0], value[1]]);
-            },
-          };
         } else if (input.valueType === "point3d") {
           // Handle 3D point inputs
           const displayValue = hasConnector ? input.getValue() : input.value;
@@ -1465,7 +1424,7 @@ export default class Atom extends ObservableEntity {
                   ),
                 );
               }
-              this.computePoint(input, value);
+              input.setValue([value[0], value[1], value[2]]);
             },
           };
         } else if (input.valueType === "array") {

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -31,7 +31,7 @@ import {
   extractTag,
   tag,
 } from "./tags";
-import type { AbundanceObject, AbundanceLeaf } from "./util";
+import { AbundanceObject, AbundanceLeaf, geometryProvider } from "./util";
 import * as util from "./util";
 
 // --- Type Definitions ---
@@ -104,7 +104,6 @@ function findFlatFaces(
     return filteredZValues;
   });
 }
-
 /**
  * Prepares geometry for visualization export in various file formats (STL, STEP, SVG, TXT).
  * @param {AbundanceObject|string} input - The geometry to export (AbundanceObject for 3D formats, string for TXT)
@@ -733,6 +732,17 @@ async function sweepCache(
   return util.geometryProvider!.sweepCache(idsToRetainSet, context);
 }
 
+// Expose a function to get a point as a tuple of [x, y, z] coordinates
+async function getAsPoint3D(
+  geometry: string,
+  context: RequestContext,
+): Promise<[number, number, number]> {
+  await started;
+  return (
+    await util.geometryProvider!._getAsPoint(geometry, context)
+  ).asTuple();
+}
+
 /**
  * Extracts all geometry except those tagged as "keepout".
  * Throws an error if no geometry remains after removing keepout geometry.
@@ -799,6 +809,7 @@ if (
     isAssembly,
     extractParts,
     sweepCache,
+    getAsPoint3D,
   });
 }
 
@@ -848,4 +859,5 @@ export {
   visualizeGcodeIncremental,
   visualizeGcodeIncrementalForced,
   visualizeGcodeAsAssembly,
+  getAsPoint3D,
 };


### PR DESCRIPTION
- This PR switches input atom with type point3d to create array x,y,z by default instead of creating a replicad vector. 
- The label atom now supports receiving either xyz arrays or an abundance vector as the starting and ending point inputs by adding an extractcoordinates function which retrieves the point array from the worker. 

There are still some issues with the menu parameter updates when using abundance objects. If connecting an abundance vector to a label the input field will be disabled but it will not display the correct value. 