### PR TITLE
Tag filtering only for top level + fix assembly tag filtering

### DIFF
--- a/src/components/secondary/RenderMenu.jsx
+++ b/src/components/secondary/RenderMenu.jsx
@@ -3,6 +3,7 @@ import { SimpleControlPanel } from "./SimpleControlPanel";
 import GlobalVariables from "../../js/globalvariables.js";
 import { useControls } from "../../hooks/useControls";
 import { useRendering } from "../../contexts/index.js";
+import { useAppState } from "../../contexts/index.js";
 
 // Grid/Axis icon for RenderMenu
 const GridAxisIcon = ({ size = 22 }) => (
@@ -60,10 +61,11 @@ export default function RenderMenu({
     setShowTopLevelWireframe,
     activeTags,
     setActiveTags,
-    activeAtom,
   } = useRendering();
   const [inputChanged, setInputChanged] = useState("");
   const [availableTags, setAvailableTags] = useState([]);
+
+  const { activeAtom } = useAppState();
 
   // Sync available tags from molecule and keep activeTags in sync
   useEffect(() => {
@@ -95,35 +97,39 @@ export default function RenderMenu({
 
   // Create tag toggle controls for menu
   const tagControls = {};
-  availableTags.forEach((tag) => {
-    tagControls[`tag-${tag}`] = {
-      type: "boolean",
-      label: tag,
-      value: activeTags.has(tag),
-      onChange: (isActive) => {
-        const newActiveTags = new Set(activeTags);
-        if (isActive) {
-          newActiveTags.add(tag);
-        } else {
-          newActiveTags.delete(tag);
-        }
-        setActiveTags(newActiveTags);
-      },
-    };
-  });
+
+  if (activeAtom.topLevel) {
+    console.log(activeAtom.topLevel);
+    availableTags.forEach((tag) => {
+      tagControls[`tag-${tag}`] = {
+        type: "boolean",
+        label: tag,
+        value: activeTags.has(tag),
+        onChange: (isActive) => {
+          const newActiveTags = new Set(activeTags);
+          if (isActive) {
+            newActiveTags.add(tag);
+          } else {
+            newActiveTags.delete(tag);
+          }
+          setActiveTags(newActiveTags);
+        },
+      };
+    });
+  }
 
   // Children keys for the tag group
   const tagChildrenKeys = availableTags.map((tag) => `tag-${tag}`);
 
   /** Creates Leva panel with grid settings */
   const renderSettings = {
-    /*tagsGroup: {
+    tagsGroup: {
       type: "group",
       label: "Tags",
       defaultCollapsed: false,
       children: tagChildrenKeys,
     },
-    ...tagControls,*/
+    ...tagControls,
     grid: {
       value: gridParam,
       label: "Grid",
@@ -188,6 +194,7 @@ export default function RenderMenu({
     showTopLevelWireframe,
     availableTags,
     activeTags,
+    activeAtom,
   ]);
 
   const screenHeight = window.innerHeight;

--- a/src/components/secondary/RenderMenu.jsx
+++ b/src/components/secondary/RenderMenu.jsx
@@ -98,8 +98,7 @@ export default function RenderMenu({
   // Create tag toggle controls for menu
   const tagControls = {};
 
-  if (activeAtom.topLevel) {
-    console.log(activeAtom.topLevel);
+  if (activeAtom?.topLevel) {
     availableTags.forEach((tag) => {
       tagControls[`tag-${tag}`] = {
         type: "boolean",

--- a/src/prototypes/atom.js
+++ b/src/prototypes/atom.js
@@ -1438,7 +1438,7 @@ export default class Atom extends ObservableEntity {
           };
         } else if (input.valueType === "point3d") {
           const displayValue = hasConnector
-            ? this.extractCoordinates(input.currentEquation)
+            ? this.extractCoordinates(input.value)
             : input.value;
 
           inputParams[this.uniqueID + input.name] = {

--- a/src/prototypes/atom.js
+++ b/src/prototypes/atom.js
@@ -1357,6 +1357,7 @@ export default class Atom extends ObservableEntity {
       // Final fallback
       return [0, 0, 0];
     }
+    return [0, 0, 0];
   }
 
   createInputParams(setInputChanged) {
@@ -1436,10 +1437,10 @@ export default class Atom extends ObservableEntity {
             },
           };
         } else if (input.valueType === "point3d") {
-          // Handle 3D point inputs
           const displayValue = hasConnector
-            ? this.extractCoordinates(input.value)
+            ? this.extractCoordinates(input.currentEquation)
             : input.value;
+
           inputParams[this.uniqueID + input.name] = {
             type: "point",
             value: [
@@ -1453,7 +1454,9 @@ export default class Atom extends ObservableEntity {
             onChange: (value) => {
               console.log(value);
               if (!GlobalVariables.isUndoing && this.parent) {
-                const oldVal = input.value ? [...input.value] : [0, 0, 0];
+                const oldVal = Array.isArray(input.value)
+                  ? [...input.value]
+                  : [0, 0, 0];
                 const inputName = input.name;
                 GlobalVariables.pushUndoCommand(
                   new ValueChangeCommand(

--- a/src/utils/geometryFilterByTags.js
+++ b/src/utils/geometryFilterByTags.js
@@ -4,7 +4,9 @@
  * Rules:
  * - If activeTags is empty or all tags are OFF, show only untagged geometry (tags array is empty)
  * - If a tag is active, show geometry tagged with that tag
- * - For AbundanceBranch: recurse into children and filter them (don't hide whole branch)
+ * - For AbundanceBranch:
+ *   - If branch is tagged and any tag is inactive, hide entire branch (assembly-level filtering)
+ *   - If branch is untagged, recurse into children and show branch if any children match
  * - For AbundanceLeaf: check if leaf's tags match active tags
  *
  * @param {AbundanceLeaf|AbundanceBranch} geometry - The geometry tree to filter
@@ -27,7 +29,23 @@ function filterGeometryRecursive(geometry, activeTags, showUntaggedOnly) {
   const isBranch = Array.isArray(geometry.geometry);
 
   if (isBranch) {
-    // AbundanceBranch: recursively filter children
+    // AbundanceBranch: first check if the branch itself is tagged and inactive
+    const branchTags = geometry.tags || [];
+
+    // If branch has tags and any are inactive, hide the entire branch
+    if (branchTags.length > 0 && !showUntaggedOnly) {
+      const hasInactiveTag = branchTags.some((tag) => !activeTags.has(tag));
+      if (hasInactiveTag) {
+        return null;
+      }
+    }
+
+    // If showUntaggedOnly and branch has tags, hide it
+    if (showUntaggedOnly && branchTags.length > 0) {
+      return null;
+    }
+
+    // Branch is visible (either untagged or has active tags), now filter children
     const filteredChildren = geometry.geometry
       .map((child) =>
         filterGeometryRecursive(child, activeTags, showUntaggedOnly),


### PR DESCRIPTION
This addresses some issues with the tag filtering in assemblies and restricts the use of tags to the top level background level. 