### PR TITLE
Tag filter top level

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -398,6 +398,7 @@ function AppContent() {
         }
       } else {
         targetMesh.current = moleculeValue;
+        filteredMeshCache.current.clear(); // Clear cached meshes when switching molecules
         setActiveTags(
           new Set(GlobalVariables.topLevelMolecule?.projectAvailableTags || []),
         ); // Trigger re-application of tag filtering to ensure correct tags are applied for new geometry
@@ -464,57 +465,44 @@ function AppContent() {
     activeTags,
   ]);
 
-  // TAG FILTERING
-  // When tags change, invalidate the cached background mesh so it's regenerated with new filtering
+  // TAG FILTERING - Apply tag filtering when tags change
   useEffect(() => {
-    // Trigger background molecule re-render if one is currently displayed
-    if (activeAtom?.topLevel) {
-      backgroundMesh.current = undefined;
-      topLevelMesh.current = undefined; // Also invalidate top-level wireframe cache
+    // Only filter if we're viewing the top-level molecule
+    if (activeAtom === GlobalVariables.topLevelMolecule && activeAtom?.value) {
+      const moleculeValue = activeAtom.value;
+      const context = activeAtom.getContext();
 
-      const moleculeValue = GlobalVariables.topLevelMolecule.value;
-      const context = GlobalVariables.topLevelMolecule.getContext();
-      setOutdatedMesh(true);
+      // Create a cache key from the active tags
+      const tagKey = Array.from(activeTags).sort().join(",");
 
-      // If the top-level output is currently being viewed as the main mesh,
-      // check cache first, then regenerate if needed
-      if (
-        targetMesh.current &&
-        JSON.stringify(targetMesh.current) === JSON.stringify(moleculeValue)
-      ) {
-        // Create a cache key from the active tags
-        const tagKey = Array.from(activeTags).sort().join(",");
-
-        // Check if we have this mesh combination cached
-        if (filteredMeshCache.current.has(tagKey)) {
-          setMesh(filteredMeshCache.current.get(tagKey));
-          setOutdatedMesh(false);
-          return;
-        }
-        pool
-          .proxy()
-          .then((worker) => {
-            const filteredGeometry = filterGeometryByTags(
-              moleculeValue,
-              activeTags,
-            );
-            return worker.generateDisplayMesh(filteredGeometry, context);
-          })
-          .then((m) => {
-            // Cache the generated mesh
-            filteredMeshCache.current.set(tagKey, m.mesh);
-            setMesh(m.mesh);
-            setOutdatedMesh(false);
-          })
-          .catch((e) => {
-            console.error(
-              "[activeTags effect] Error regenerating main mesh:",
-              e,
-            );
-          });
+      // Check if we have this mesh combination cached
+      if (filteredMeshCache.current.has(tagKey)) {
+        setMesh(filteredMeshCache.current.get(tagKey));
+        setOutdatedMesh(false);
+        return;
       }
+
+      // Generate filtered mesh
+      pool
+        .proxy()
+        .then((worker) => {
+          const filteredGeometry = filterGeometryByTags(
+            moleculeValue,
+            activeTags,
+          );
+          return worker.generateDisplayMesh(filteredGeometry, context);
+        })
+        .then((m) => {
+          // Cache the generated mesh
+          filteredMeshCache.current.set(tagKey, m.mesh);
+          setMesh(m.mesh);
+          setOutdatedMesh(false);
+        })
+        .catch((e) => {
+          console.error("[activeTags effect] Error regenerating mesh:", e);
+        });
     }
-  }, [activeTags]);
+  }, [activeTags, activeAtom, pool]);
 
   /**
    * Load a project from the repository

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -371,20 +371,22 @@ function AppContent() {
               activeTags,
             );
 
-            worker.generateDisplayMesh(moleculeValue, context).then((m) => {
-              console.log(m);
-              backgroundMesh.current.mesh = m.mesh;
-              setWireMesh(m.mesh);
-              // Also update top-level wireframe if this is the top-level molecule's mesh
-              if (
-                GlobalVariables.topLevelMolecule &&
-                JSON.stringify(moleculeValue) ===
-                  JSON.stringify(GlobalVariables.topLevelMolecule.value)
-              ) {
-                setTopLevelWireMesh(m.mesh);
-              }
-              setOutdatedMesh(false);
-            });
+            worker
+              .generateDisplayMesh(filteredGeometryBg, context)
+              .then((m) => {
+                console.log(m);
+                backgroundMesh.current.mesh = m.mesh;
+                setWireMesh(m.mesh);
+                // Also update top-level wireframe if this is the top-level molecule's mesh
+                if (
+                  GlobalVariables.topLevelMolecule &&
+                  JSON.stringify(moleculeValue) ===
+                    JSON.stringify(GlobalVariables.topLevelMolecule.value)
+                ) {
+                  setTopLevelWireMesh(m.mesh);
+                }
+                setOutdatedMesh(false);
+              });
           });
         }
         // We're showing wireframe background
@@ -492,7 +494,7 @@ function AppContent() {
               moleculeValue,
               activeTags,
             );
-            return worker.generateDisplayMesh(moleculeValue, context);
+            return worker.generateDisplayMesh(filteredGeometry, context);
           })
           .then((m) => {
             setMesh(m.mesh);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -89,6 +89,7 @@ function AppContent() {
     nonReplicadGeometry,
     setNonReplicadGeometry,
     activeTags,
+    setActiveTags,
   } = useRendering();
 
   const {
@@ -341,6 +342,7 @@ function AppContent() {
         );
         moleculeValue = { geometry: [] }; // use a non-null structure which still generates the default mesh
       }
+
       /* Handle non-Replicad geometry - if otherGeometry is provided*/
       if (
         nonReplicadGeometryFromAtom &&
@@ -366,27 +368,20 @@ function AppContent() {
         } else {
           backgroundMesh.current = { id: moleculeValue, mesh: undefined };
           pool.proxy().then((worker) => {
-            const filteredGeometryBg = filterGeometryByTags(
-              moleculeValue,
-              activeTags,
-            );
-
-            worker
-              .generateDisplayMesh(filteredGeometryBg, context)
-              .then((m) => {
-                console.log(m);
-                backgroundMesh.current.mesh = m.mesh;
-                setWireMesh(m.mesh);
-                // Also update top-level wireframe if this is the top-level molecule's mesh
-                if (
-                  GlobalVariables.topLevelMolecule &&
-                  JSON.stringify(moleculeValue) ===
-                    JSON.stringify(GlobalVariables.topLevelMolecule.value)
-                ) {
-                  setTopLevelWireMesh(m.mesh);
-                }
-                setOutdatedMesh(false);
-              });
+            worker.generateDisplayMesh(moleculeValue, context).then((m) => {
+              console.log(m);
+              backgroundMesh.current.mesh = m.mesh;
+              setWireMesh(m.mesh);
+              // Also update top-level wireframe if this is the top-level molecule's mesh
+              if (
+                GlobalVariables.topLevelMolecule &&
+                JSON.stringify(moleculeValue) ===
+                  JSON.stringify(GlobalVariables.topLevelMolecule.value)
+              ) {
+                setTopLevelWireMesh(m.mesh);
+              }
+              setOutdatedMesh(false);
+            });
           });
         }
         // We're showing wireframe background
@@ -401,6 +396,9 @@ function AppContent() {
         }
       } else {
         targetMesh.current = moleculeValue;
+        setActiveTags(
+          new Set(GlobalVariables.topLevelMolecule?.projectAvailableTags || []),
+        ); // Trigger re-application of tag filtering to ensure correct tags are applied for new geometry
 
         if (
           !nonReplicadGeometryFromAtom?.hideMainMesh &&
@@ -410,6 +408,7 @@ function AppContent() {
         ) {
           // Special case where we're trying to show the output and have already prepared it as the
           // wireframe background.
+
           setMesh(backgroundMesh.current.mesh);
           setOutdatedMesh(false);
           setPlane(targetMesh.current?.plane);
@@ -466,7 +465,6 @@ function AppContent() {
   // TAG FILTERING
   // When tags change, invalidate the cached background mesh so it's regenerated with new filtering
   useEffect(() => {
-    //console.log("[activeTags effect] Tags changed, invalidating cached meshes");
     backgroundMesh.current = undefined;
     topLevelMesh.current = undefined; // Also invalidate top-level wireframe cache
 
@@ -477,9 +475,10 @@ function AppContent() {
     ) {
       const moleculeValue = GlobalVariables.topLevelMolecule.value;
       const context = GlobalVariables.topLevelMolecule.getContext();
+      setOutdatedMesh(true);
 
       // Always update background/wireframe
-      GlobalVariables.writeToDisplay(moleculeValue, context, true);
+      //GlobalVariables.writeToDisplay(moleculeValue, context, true);
 
       // If the top-level output is currently being viewed as the main mesh,
       // also regenerate and update the main mesh with filtered geometry
@@ -487,6 +486,9 @@ function AppContent() {
         targetMesh.current &&
         JSON.stringify(targetMesh.current) === JSON.stringify(moleculeValue)
       ) {
+        console.log(
+          "[activeTags effect] Regenerating main mesh for top-level molecule with new tags",
+        );
         pool
           .proxy()
           .then((worker) => {
@@ -508,7 +510,7 @@ function AppContent() {
           });
       }
     }
-  }, [activeTags, setMesh, setOutdatedMesh, pool]);
+  }, [activeTags]);
 
   /**
    * Load a project from the repository

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -262,6 +262,7 @@ function AppContent() {
   const targetMesh = React.useRef(undefined); // id of most recently displayed mesh
   const backgroundMesh = React.useRef(undefined); // {id: atom.value, mesh: generated mesh}
   const topLevelMesh = React.useRef(undefined); // {id: molecule.uniqueID, mesh: generated mesh}
+  const filteredMeshCache = React.useRef(new Map()); // Cache: "tag1,tag2" -> mesh for filtered combinations
 
   function makeMesh() {
     setOutdatedMesh(true);
@@ -329,6 +330,7 @@ function AppContent() {
       setMesh([]);
       setWireMesh([]);
       setNonReplicadGeometry(null);
+      filteredMeshCache.current.clear(); // Clear mesh cache when resetting view
     };
     GlobalVariables.writeToDisplay = (
       moleculeValue,
@@ -465,30 +467,30 @@ function AppContent() {
   // TAG FILTERING
   // When tags change, invalidate the cached background mesh so it's regenerated with new filtering
   useEffect(() => {
-    backgroundMesh.current = undefined;
-    topLevelMesh.current = undefined; // Also invalidate top-level wireframe cache
-
     // Trigger background molecule re-render if one is currently displayed
-    if (
-      GlobalVariables.topLevelMolecule &&
-      GlobalVariables.topLevelMolecule.value
-    ) {
+    if (activeAtom?.topLevel) {
+      backgroundMesh.current = undefined;
+      topLevelMesh.current = undefined; // Also invalidate top-level wireframe cache
+
       const moleculeValue = GlobalVariables.topLevelMolecule.value;
       const context = GlobalVariables.topLevelMolecule.getContext();
       setOutdatedMesh(true);
 
-      // Always update background/wireframe
-      //GlobalVariables.writeToDisplay(moleculeValue, context, true);
-
       // If the top-level output is currently being viewed as the main mesh,
-      // also regenerate and update the main mesh with filtered geometry
+      // check cache first, then regenerate if needed
       if (
         targetMesh.current &&
         JSON.stringify(targetMesh.current) === JSON.stringify(moleculeValue)
       ) {
-        console.log(
-          "[activeTags effect] Regenerating main mesh for top-level molecule with new tags",
-        );
+        // Create a cache key from the active tags
+        const tagKey = Array.from(activeTags).sort().join(",");
+
+        // Check if we have this mesh combination cached
+        if (filteredMeshCache.current.has(tagKey)) {
+          setMesh(filteredMeshCache.current.get(tagKey));
+          setOutdatedMesh(false);
+          return;
+        }
         pool
           .proxy()
           .then((worker) => {
@@ -499,6 +501,8 @@ function AppContent() {
             return worker.generateDisplayMesh(filteredGeometry, context);
           })
           .then((m) => {
+            // Cache the generated mesh
+            filteredMeshCache.current.set(tagKey, m.mesh);
             setMesh(m.mesh);
             setOutdatedMesh(false);
           })

--- a/src/components/secondary/RenderMenu.jsx
+++ b/src/components/secondary/RenderMenu.jsx
@@ -122,7 +122,7 @@ export default function RenderMenu({
 
   /** Creates Leva panel with grid settings */
   const renderSettings = {
-    ...(availableTags.length > 0 && {
+    ...(activeAtom?.topLevel && {
       tagsGroup: {
         type: "group",
         label: "Tags",

--- a/src/components/secondary/RenderMenu.jsx
+++ b/src/components/secondary/RenderMenu.jsx
@@ -122,13 +122,15 @@ export default function RenderMenu({
 
   /** Creates Leva panel with grid settings */
   const renderSettings = {
-    /*tagsGroup: {
-      type: "group",
-      label: "Tags",
-      defaultCollapsed: false,
-      children: tagChildrenKeys,
-    },
-    ...tagControls,*/
+    ...(availableTags.length > 0 && {
+      tagsGroup: {
+        type: "group",
+        label: "Tags",
+        defaultCollapsed: false,
+        children: tagChildrenKeys,
+      },
+    }),
+    ...tagControls,
     grid: {
       value: gridParam,
       label: "Grid",


### PR DESCRIPTION
Fix tag filtering issues.
- Make sure we only show tag filters at the top level in render menu 
- Display generation only runs when tags change if the top molecule is on view.
- Active tags get reset on background click or when clicking on any molecule or atom
- Tag branch combinations are cached for improved display performance when toggling tags.