### PR TITLE
Fix to batch operation?

### DIFF
--- a/src/worker/code-legacy.ts
+++ b/src/worker/code-legacy.ts
@@ -167,6 +167,9 @@ async function executeCode(
   argumentsArray: { [key: string]: any },
   context: RequestContext,
 ): Promise<AbundanceObject | number | string | boolean | null | undefined> {
+  let startedBatch = false;
+  let finishedBatch = false;
+  let batchContext: RequestContext | null = null;
   try {
     // Validate input parameters
     if (typeof code !== "string") {
@@ -218,6 +221,8 @@ async function executeCode(
 
     context = batch;
     context.nextId = 0;
+    startedBatch = true;
+    batchContext = context;
 
     // Validate code for dangerous patterns
     // TODO: we probably want to allow some of these but still need to warn about them before executing
@@ -404,6 +409,7 @@ async function executeCode(
       // Clean up the warm cache without caching the result
       // Primitive and array (point) results are not cached - only geometry results are cached
       util.geometryProvider!.cleanupBatchWithoutCaching(context);
+      finishedBatch = true;
       return rawResult;
     }
 
@@ -415,8 +421,19 @@ async function executeCode(
       cacheId,
     );
     await util.geometryProvider!.endBatchOperation(context, abundanceObj);
+    finishedBatch = true;
     return abundanceObj;
   } catch (error) {
+    if (startedBatch && !finishedBatch && batchContext?.operationId) {
+      try {
+        util.geometryProvider!.cleanupBatchWithoutCaching(batchContext);
+      } catch (cleanupError) {
+        console.warn(
+          "Failed to cleanup legacy code batch operation",
+          cleanupError,
+        );
+      }
+    }
     console.error("Code execution error:", error);
     throw new Error(`Code execution failed: ${(error as Error).message}`);
   }

--- a/src/worker/code.ts
+++ b/src/worker/code.ts
@@ -356,6 +356,9 @@ async function executeTsCode(
   atomUniqueId: string | number,
   onLog?: CodeAtomLogCallback,
 ): Promise<AbundanceObject | Primitive | Primitive[]> {
+  let startedBatch = false;
+  let finishedBatch = false;
+  let batchContext: RequestContext | null = null;
   try {
     if (typeof code !== "string") {
       throw new Error("Code must be a string");
@@ -418,6 +421,8 @@ async function executeTsCode(
 
     context = batch;
     context.nextId = 0;
+    startedBatch = true;
+    batchContext = context;
 
     // Convert incoming Abundance geometry arguments into raw POJOs marked
     // with `__isRawAbundanceObj`. The prepended framework's `__promoteInput`
@@ -577,6 +582,7 @@ async function executeTsCode(
       // Clean up the warm cache without caching the result
       // Primitive and array (point) results are not cached - only geometry results are cached
       await util.geometryProvider!.cleanupBatchWithoutCaching(context);
+      finishedBatch = true;
       return rawResult;
     }
 
@@ -607,12 +613,21 @@ async function executeTsCode(
         }
       });
       await util.geometryProvider!.endBatchOperation(context, disjointAssembly);
+      finishedBatch = true;
       return disjointAssembly;
     } else {
       await util.geometryProvider!.endBatchOperation(context, abundanceObj);
+      finishedBatch = true;
       return abundanceObj;
     }
   } catch (error) {
+    if (startedBatch && !finishedBatch && batchContext?.operationId) {
+      try {
+        util.geometryProvider!.cleanupBatchWithoutCaching(batchContext);
+      } catch (cleanupError) {
+        console.warn("Failed to cleanup TS code batch operation", cleanupError);
+      }
+    }
     console.error("Code execution error:", error);
     if (Number.isInteger(error)) {
       throw new Error(`OpenCascade kernel error code: ${error}`);

--- a/src/worker/geometryProvider.ts
+++ b/src/worker/geometryProvider.ts
@@ -814,33 +814,38 @@ class GeometryProvider {
       throw new Error("provided context is not a batch operation " + context);
     }
     this.batchMetrics = [0, 0];
-    if (!context.persistIntermediates) {
-      // For all intermediate shapes which are part of the result assembly,
-      // promote them to the serialized cache.
-      for (const leaf of flattenAssembly(result)) {
-        if (leaf.geometry === this.EMPTY_SHAPE_SENTINEL) {
-          continue; // Empty shapes don't exist in the cache
-        }
-        const geom = this.getFromWarmCache(leaf.geometry, context);
-        if (geom) {
-          await putShape(
-            context.project,
-            leaf.geometry,
-            this.getFromWarmCache(leaf.geometry, context)!.serialize(),
-          );
-        } else {
-          // check that it's already in the serialized cache
-          const exists = await shapeExists(context.project, leaf.geometry);
-          if (!exists) {
-            throw new Error(
-              "Batch operation references unknown geometry: " + leaf.geometry,
+    try {
+      if (!context.persistIntermediates) {
+        // For all intermediate shapes which are part of the result assembly,
+        // promote them to the serialized cache.
+        for (const leaf of flattenAssembly(result)) {
+          if (leaf.geometry === this.EMPTY_SHAPE_SENTINEL) {
+            continue; // Empty shapes don't exist in the cache
+          }
+          const geom = this.getFromWarmCache(leaf.geometry, context);
+          if (geom) {
+            await putShape(
+              context.project,
+              leaf.geometry,
+              this.getFromWarmCache(leaf.geometry, context)!.serialize(),
             );
+          } else {
+            // check that it's already in the serialized cache
+            const exists = await shapeExists(context.project, leaf.geometry);
+            if (!exists) {
+              throw new Error(
+                "Batch operation references unknown geometry: " + leaf.geometry,
+              );
+            }
           }
         }
       }
+      await this.cacheAssemblyStructure(context.operationId, result, context);
+    } finally {
+      // Always clear the warm-cache entry so retries cannot get stuck behind
+      // stale "already exists" state after a failed end-batch path.
+      this.warmCache.delete(context.operationId);
     }
-    await this.cacheAssemblyStructure(context.operationId, result, context);
-    this.warmCache.delete(context.operationId);
   }
 
   /**

--- a/src/worker/interaction.ts
+++ b/src/worker/interaction.ts
@@ -364,6 +364,7 @@ async function assembly(
     ),
   );
   const insideOtherBatch = !!context.operationId;
+  let startedOwnBatch = false;
   if (!insideOtherBatch) {
     const batchId = "assembly-" + util.hashString(JSON.stringify(geometries));
     const batch: RequestContext | AbundanceObject =
@@ -396,39 +397,54 @@ async function assembly(
 
     // cache miss on the batch operation.
     context = batch;
+    startedOwnBatch = true;
   }
 
-  // The general case of a cache miss assembly operation.
-  const assembly: AbundanceObject[] = [];
+  try {
+    // The general case of a cache miss assembly operation.
+    const assembly: AbundanceObject[] = [];
 
-  // Each geometry is cut by all following geometries.
-  // TODO: test if this is faster working back-to-front or front-to-back.
-  for (let i = 0; i < geometries.length - 1; i++) {
-    const geometry = geometries[i];
-    assembly.push(
-      await cutAssembly(geometry, geometries.slice(i + 1), context),
+    // Each geometry is cut by all following geometries.
+    // TODO: test if this is faster working back-to-front or front-to-back.
+    for (let i = 0; i < geometries.length - 1; i++) {
+      const geometry = geometries[i];
+      assembly.push(
+        await cutAssembly(geometry, geometries.slice(i + 1), context),
+      );
+    }
+    assembly.push(geometries[geometries.length - 1]); // Final entry is always unmodified.
+
+    // Build the initial assembly object with all children already having bounds
+    const assemblyObject: AbundanceObject = util.assemblyOf(
+      await Promise.all(assembly),
     );
-  }
-  assembly.push(geometries[geometries.length - 1]); // Final entry is always unmodified.
 
-  // Build the initial assembly object with all children already having bounds
-  const assemblyObject: AbundanceObject = util.assemblyOf(
-    await Promise.all(assembly),
-  );
-
-  // Safety check with recursive validation disabled (forceRecompute=false)
-  // Since we've already computed bounds eagerly, this will detect our computed bounds
-  // and return immediately without recursive traversal
-  const result = await util.withAssemblyBoundingBoxes(
-    assemblyObject,
-    context,
-    false, // forceRecompute=false, so it skips unnecessary recursion
-  );
-  if (!insideOtherBatch) {
-    console.trace("Ending batch operation with id " + context.operationId);
-    await util.geometryProvider!.endBatchOperation(context, result);
+    // Safety check with recursive validation disabled (forceRecompute=false)
+    // Since we've already computed bounds eagerly, this will detect our computed bounds
+    // and return immediately without recursive traversal
+    const result = await util.withAssemblyBoundingBoxes(
+      assemblyObject,
+      context,
+      false, // forceRecompute=false, so it skips unnecessary recursion
+    );
+    if (!insideOtherBatch) {
+      console.trace("Ending batch operation with id " + context.operationId);
+      await util.geometryProvider!.endBatchOperation(context, result);
+    }
+    return result;
+  } catch (error) {
+    if (startedOwnBatch) {
+      try {
+        util.geometryProvider!.cleanupBatchWithoutCaching(context);
+      } catch (cleanupError) {
+        console.warn(
+          "Failed to cleanup assembly batch operation",
+          cleanupError,
+        );
+      }
+    }
+    throw error;
   }
-  return result;
 }
 
 //// Helper Functions ////


### PR DESCRIPTION
I was having some issues with batch operations and this is what the AI came up with.

Unfortunately I wasn't really able to test it properly because the issue is so dependent on cache state and I ran into the issue on the deployed version.

Not sure if this is helpful or hot garbage so I'm passing this off to you @tristan-huber. Feel free to take anything good from this and close it.


## Summary
This PR fixes a worker-side batch lifecycle bug that could leave stale in-memory batch state after an exception.  
When that happened, retries hit:

`Batch operation with id batch-assembly-... already exists`

and the assembly never finished.

## Issue
Assembly and code-atom execution use deterministic batch IDs for cache reuse.  
If execution failed after `startBatchOperation(...)` but before successful completion, the warm-cache entry for that batch could remain in memory.  
A later retry with the same batch ID then failed immediately as a duplicate, creating a stuck loop.

## Root Cause
Batch cleanup was not guaranteed on all failure paths:

- `assembly(...)` could throw after starting its own batch, without cleanup.
- TS and legacy code-atom executors could throw after starting a batch, without cleanup.
- `endBatchOperation(...)` only removed warm-cache state on the success path.

## Fix
### 1) Always clear warm-cache state in `endBatchOperation(...)`
File: [src/worker/geometryProvider.ts](src/worker/geometryProvider.ts#L817)

- Wrapped batch finalization in `try/finally`.
- `warmCache.delete(context.operationId)` now always runs, even if persisting shapes or caching assembly structure throws.

### 2) Cleanup on assembly failure paths
File: [src/worker/interaction.ts](src/worker/interaction.ts#L367)

- Tracks whether `assembly(...)` started its own batch.
- Wraps main assembly work in `try/catch`.
- On error, calls `cleanupBatchWithoutCaching(context)` before rethrowing.

### 3) Cleanup on TS code-atom failure paths
File: [src/worker/code.ts](src/worker/code.ts#L359)

- Tracks `startedBatch` / `finishedBatch` and batch context.
- On catch, if batch started but not finalized, calls `cleanupBatchWithoutCaching(...)`.

### 4) Cleanup on legacy code-atom failure paths
File: [src/worker/code-legacy.ts](src/worker/code-legacy.ts#L170)

- Same started/finished lifecycle tracking.
- Ensures cleanup on any error before normal `endBatchOperation(...)`.

## Why this works
The duplicate-ID failure required stale in-memory batch state.  
This change guarantees that every started batch is either:

1. finalized successfully, or  
2. cleaned up explicitly on failure.

That removes the stale batch entry and allows retries to proceed normally.

## Impact
- Fixes sticky `"already exists"` batch errors for assemblies.
- Prevents retries from being blocked by leaked batch state.
- Improves resilience after transient geometry/code execution failures.

## Validation
- Checked changed files for new diagnostics: no new relevant issues in edited files.
- Full unit run in this workspace is currently blocked by an unrelated pre-existing test bundling/export issue, so full test confirmation is not available from this environment.

## Risk
Low to medium.

- Changes are scoped to batch lifecycle/error handling.
- Core geometry logic is unchanged.
- Cleanup is constrained to the active operation context.
