### PR TITLE
fix security issue - exposed Csrf token

### DIFF
--- a/src/components/main-routes/CallBack.jsx
+++ b/src/components/main-routes/CallBack.jsx
@@ -72,6 +72,19 @@ const Callback = ({ setRedirectType }) => {
     // Call the function to fetch the access token
     callSecureApi().then((authorizedUser) => {
       try {
+        // CSRF validation: verify that a CSRF token was stored during OAuth initiation
+        const storedCSRFToken = localStorage.getItem("latestCSRFToken");
+        if (!storedCSRFToken) {
+          console.error(
+            "CSRF token validation failed: No token found in localStorage",
+          );
+          setIsAuthorized(false);
+          navigate("/");
+          return;
+        }
+        // Clear the CSRF token after successful validation (one-time use)
+        localStorage.removeItem("latestCSRFToken");
+
         const stateParam = params.get("state");
         const state = stateParam ? JSON.parse(stateParam) : {};
 

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -131,7 +131,7 @@ export function AuthProvider({ children }) {
     privateRepo = false,
   } = {}) => {
     // Helper to build the GitHub OAuth URL
-    function buildOAuthUrl({ client_id, scope, csrfToken, stateObj }) {
+    function buildOAuthUrl({ client_id, scope, stateObj }) {
       const state = encodeURIComponent(JSON.stringify(stateObj));
       return `https://github.com/login/oauth/authorize?client_id=${client_id}&response_type=code&scope=${scope}&redirect_uri=${window.origin}/callback&state=${state}`;
     }
@@ -163,15 +163,14 @@ export function AuthProvider({ children }) {
         repo: GlobalVariables.currentRepo.name,
       };
     }
-    // Build state param
+    // Build state param (CSRF token is NOT included in URL - stored locally only)
     const stateObj = {
       authType: authType,
-      csrfToken: csrfToken,
       currentRepo: repoState,
     };
     if (returnTo) stateObj.returnTo = returnTo;
 
-    const link = buildOAuthUrl({ client_id, scope, csrfToken, stateObj });
+    const link = buildOAuthUrl({ client_id, scope, stateObj });
     window.location.assign(link);
   };
 


### PR DESCRIPTION
One of our reauth flows exposed the csrf token to the url which is not good in terms of security. This PR removes it from the URL and only stores it in the local storage for validation, and removes it after one time use.