### PR TITLE
Handle timeouts by restarting with live queue

### DIFF
--- a/src/worker/cadWorkerManager.js
+++ b/src/worker/cadWorkerManager.js
@@ -283,7 +283,8 @@ export class CadWorkerManager {
    * @param {object} entry
    */
   _dispatch(entry) {
-    entry.epoch = this._workerEpoch;
+    const dispatchEpoch = this._workerEpoch;
+    entry.epoch = dispatchEpoch;
 
     const cleanup = () => {
       clearInterval(entry.progressIntervalId);
@@ -296,7 +297,7 @@ export class CadWorkerManager {
       (result) => {
         // Stale settlement from a worker that was already replaced — the entry
         // has since been re-dispatched (or rejected) on the new worker.
-        if (entry.epoch !== this._workerEpoch) {
+        if (dispatchEpoch !== this._workerEpoch) {
           return;
         }
         cleanup();
@@ -321,7 +322,7 @@ export class CadWorkerManager {
       },
       (err) => {
         // Stale settlement from a worker that was already replaced.
-        if (entry.epoch !== this._workerEpoch) {
+        if (dispatchEpoch !== this._workerEpoch) {
           return;
         }
         cleanup();

--- a/src/worker/cadWorkerManager.js
+++ b/src/worker/cadWorkerManager.js
@@ -33,6 +33,14 @@ export class CadWorkerManager {
     /** @type {Array<{reject: Function, timeoutId: ReturnType<typeof setTimeout>}>} */
     this._pendingCalls = [];
     /**
+     * Monotonic counter identifying the live worker. It is bumped every time a
+     * fresh worker is created (initial spawn and every restart). Each dispatched
+     * call records the epoch it was issued under; when its comlink promise
+     * settles we ignore the result if the epoch no longer matches, because that
+     * settlement came from a worker that has since been terminated.
+     */
+    this._workerEpoch = 0;
+    /**
      * Optional callback invoked when the worker is restarted due to a timeout.
      * Assign this from outside (e.g. from AppContent) to show a UI notification.
      * Signature: (message: string) => void
@@ -62,6 +70,7 @@ export class CadWorkerManager {
   // ---------------------------------------------------------------------------
 
   _createWorker() {
+    this._workerEpoch += 1;
     this._rawWorker = new this._WorkerFactory();
     this._proxy = wrap(this._rawWorker);
     // Listen for intra-operation progress messages posted by the worker
@@ -228,14 +237,17 @@ export class CadWorkerManager {
       const { callArgs, taskMeta } = this._stripTaskMeta(args);
 
       const entry = {
+        resolve,
         reject,
         timeoutId: null,
         progressIntervalId: null,
         method,
+        callArgs,
         startTime: null,
         taskId,
         queuedAt,
         taskMeta,
+        epoch: null,
       };
 
       this._pendingCalls.push(entry);
@@ -256,59 +268,84 @@ export class CadWorkerManager {
         this._startTimers(entry);
       }
 
-      const cleanup = () => {
-        clearInterval(entry.progressIntervalId);
-        entry.progressIntervalId = null;
-        clearTimeout(entry.timeoutId);
-        entry.timeoutId = null;
-      };
-
-      this._proxy[method](...callArgs).then(
-        (result) => {
-          cleanup();
-          this._pendingCalls = this._pendingCalls.filter((c) => c !== entry);
-          const finishedAt = Date.now();
-          this._emitCadWorkerEvent("cad-worker-task-finish", {
-            taskId: entry.taskId,
-            method: String(entry.method),
-            queuedAt: entry.queuedAt,
-            startedAt: entry.startTime,
-            finishedAt,
-            durationMs: entry.startTime ? finishedAt - entry.startTime : null,
-            queueWaitMs: entry.startTime ? entry.startTime - entry.queuedAt : null,
-            queueDepth: this._pendingCalls.length,
-            atomId: entry.taskMeta?.atomId || null,
-            atomType: entry.taskMeta?.atomType || null,
-            moleculeName: entry.taskMeta?.moleculeName || null,
-            displayLabel: this._formatTaskLabel(entry.method, entry.taskMeta),
-          });
-          this._activateNextCall();
-          resolve(result);
-        },
-        (err) => {
-          cleanup();
-          this._pendingCalls = this._pendingCalls.filter((c) => c !== entry);
-          const failedAt = Date.now();
-          this._emitCadWorkerEvent("cad-worker-task-error", {
-            taskId: entry.taskId,
-            method: String(entry.method),
-            queuedAt: entry.queuedAt,
-            startedAt: entry.startTime,
-            failedAt,
-            durationMs: entry.startTime ? failedAt - entry.startTime : null,
-            queueWaitMs: entry.startTime ? entry.startTime - entry.queuedAt : null,
-            queueDepth: this._pendingCalls.length,
-            atomId: entry.taskMeta?.atomId || null,
-            atomType: entry.taskMeta?.atomType || null,
-            moleculeName: entry.taskMeta?.moleculeName || null,
-            displayLabel: this._formatTaskLabel(entry.method, entry.taskMeta),
-            error: err?.message || String(err),
-          });
-          this._activateNextCall();
-          reject(err);
-        },
-      );
+      this._dispatch(entry);
     });
+  }
+
+  /**
+   * Issue (or re-issue) an entry's call to the current comlink proxy and wire up
+   * its success/error handling. Used both for the initial dispatch and when a
+   * surviving queued entry is replayed on a fresh worker after a restart.
+   *
+   * The entry is stamped with the live `_workerEpoch`; if its comlink promise
+   * settles after the worker has been replaced (epoch mismatch), the settlement
+   * is ignored because it originates from a terminated worker.
+   * @param {object} entry
+   */
+  _dispatch(entry) {
+    entry.epoch = this._workerEpoch;
+
+    const cleanup = () => {
+      clearInterval(entry.progressIntervalId);
+      entry.progressIntervalId = null;
+      clearTimeout(entry.timeoutId);
+      entry.timeoutId = null;
+    };
+
+    this._proxy[entry.method](...entry.callArgs).then(
+      (result) => {
+        // Stale settlement from a worker that was already replaced — the entry
+        // has since been re-dispatched (or rejected) on the new worker.
+        if (entry.epoch !== this._workerEpoch) {
+          return;
+        }
+        cleanup();
+        this._pendingCalls = this._pendingCalls.filter((c) => c !== entry);
+        const finishedAt = Date.now();
+        this._emitCadWorkerEvent("cad-worker-task-finish", {
+          taskId: entry.taskId,
+          method: String(entry.method),
+          queuedAt: entry.queuedAt,
+          startedAt: entry.startTime,
+          finishedAt,
+          durationMs: entry.startTime ? finishedAt - entry.startTime : null,
+          queueWaitMs: entry.startTime ? entry.startTime - entry.queuedAt : null,
+          queueDepth: this._pendingCalls.length,
+          atomId: entry.taskMeta?.atomId || null,
+          atomType: entry.taskMeta?.atomType || null,
+          moleculeName: entry.taskMeta?.moleculeName || null,
+          displayLabel: this._formatTaskLabel(entry.method, entry.taskMeta),
+        });
+        this._activateNextCall();
+        entry.resolve(result);
+      },
+      (err) => {
+        // Stale settlement from a worker that was already replaced.
+        if (entry.epoch !== this._workerEpoch) {
+          return;
+        }
+        cleanup();
+        this._pendingCalls = this._pendingCalls.filter((c) => c !== entry);
+        const failedAt = Date.now();
+        this._emitCadWorkerEvent("cad-worker-task-error", {
+          taskId: entry.taskId,
+          method: String(entry.method),
+          queuedAt: entry.queuedAt,
+          startedAt: entry.startTime,
+          failedAt,
+          durationMs: entry.startTime ? failedAt - entry.startTime : null,
+          queueWaitMs: entry.startTime ? entry.startTime - entry.queuedAt : null,
+          queueDepth: this._pendingCalls.length,
+          atomId: entry.taskMeta?.atomId || null,
+          atomType: entry.taskMeta?.atomType || null,
+          moleculeName: entry.taskMeta?.moleculeName || null,
+          displayLabel: this._formatTaskLabel(entry.method, entry.taskMeta),
+          error: err?.message || String(err),
+        });
+        this._activateNextCall();
+        entry.reject(err);
+      },
+    );
   }
 
   /**
@@ -346,8 +383,14 @@ export class CadWorkerManager {
   }
 
   /**
-   * Terminate the hung worker, reject all in-flight calls, and create a fresh
-   * worker so the app can continue without a page reload.
+   * Terminate the hung worker and create a fresh one so the app can continue
+   * without a page reload.
+   *
+   * The hung call has already been removed from `_pendingCalls` and rejected by
+   * the inactivity watchdog (`_armTimeout`) before this runs. The remaining
+   * entries are therefore innocent queued/in-flight calls: rather than rejecting
+   * them (which errored valid atoms as collateral damage), they are re-dispatched
+   * to the fresh worker so the rest of the queue resumes automatically.
    */
   _restartWorker() {
     console.warn(
@@ -361,30 +404,41 @@ export class CadWorkerManager {
       console.error("[CadWorkerManager] Error while terminating worker:", e);
     }
 
-    // Reject every other pending call so callers get a clear error instead of
-    // hanging forever.
-    const pending = [...this._pendingCalls];
-    this._pendingCalls = [];
-    pending.forEach((entry) => {
+    // Snapshot the survivors (everything still queued after the hung call was
+    // already removed) and clear their stale timers. Their old comlink promises
+    // belong to the now-terminated worker and will never settle; even if one
+    // somehow did, the epoch stamp applied below makes `_dispatch` ignore it.
+    const survivors = [...this._pendingCalls];
+    survivors.forEach((entry) => {
       clearInterval(entry.progressIntervalId);
+      entry.progressIntervalId = null;
       clearTimeout(entry.timeoutId);
-      this._emitCadWorkerEvent("cad-worker-task-error", {
+      entry.timeoutId = null;
+      entry.startTime = null;
+    });
+
+    // Spawn the fresh worker (bumps `_workerEpoch`).
+    this._createWorker();
+
+    // Re-issue every survivor onto the new worker. Re-emit `cad-worker-task-queued`
+    // so the UI's queue depth reflects the replayed work.
+    survivors.forEach((entry) => {
+      this._emitCadWorkerEvent("cad-worker-task-queued", {
         taskId: entry.taskId,
         method: String(entry.method),
         queuedAt: entry.queuedAt,
-        failedAt: Date.now(),
+        queueDepth: Math.max(this._pendingCalls.indexOf(entry), 0),
         atomId: entry.taskMeta?.atomId || null,
         atomType: entry.taskMeta?.atomType || null,
         moleculeName: entry.taskMeta?.moleculeName || null,
         displayLabel: this._formatTaskLabel(entry.method, entry.taskMeta),
-        error: "CAD worker restarted because another call timed out",
       });
-      entry.reject(
-        new Error("CAD worker was restarted because another call timed out"),
-      );
+      this._dispatch(entry);
     });
 
-    this._createWorker();
+    // Start the inactivity watchdog for the new head of the queue.
+    this._activateNextCall();
+
     this._emitCadWorkerEvent("cad-worker-restarted", {
       restartedAt: Date.now(),
       reason: "timeout",
@@ -392,7 +446,7 @@ export class CadWorkerManager {
 
     if (this.onRestartCallback) {
       this.onRestartCallback(
-        "The geometry worker timed out and was restarted. Please re-run any affected atoms.",
+        "The geometry worker timed out. The offending operation was dropped and the remaining work resumed automatically.",
       );
     }
   }

--- a/tests/cad-worker-restart-redispatch.test.js
+++ b/tests/cad-worker-restart-redispatch.test.js
@@ -98,4 +98,37 @@ describe("CadWorkerManager timeout re-dispatch", () => {
     await expect(survivor).resolves.toBe("ok:keep");
     expect(survivorRejected).not.toHaveBeenCalled();
   });
+
+  it("ignores stale settlements from the terminated worker after re-dispatch", async () => {
+    const neverResolves = () => new Promise(() => {});
+    let resolveStaleKeep;
+    const staleKeep = new Promise((resolve) => {
+      resolveStaleKeep = resolve;
+    });
+    let resolveFreshKeep;
+    const freshKeep = new Promise((resolve) => {
+      resolveFreshKeep = resolve;
+    });
+
+    const { WorkerFactory } = makeFactory([
+      (method) => (method === "hang" ? neverResolves() : staleKeep),
+      (method) => (method === "keep" ? freshKeep : Promise.resolve(`ok:${method}`)),
+    ]);
+
+    const cad = new CadWorkerManager(WorkerFactory, 40);
+
+    const headPromise = cad.hang();
+    const survivor = cad.keep();
+    const survivorResolved = vi.fn();
+    survivor.then(survivorResolved);
+
+    await expect(headPromise).rejects.toThrow(/stalled/i);
+
+    resolveStaleKeep("stale:keep");
+    await Promise.resolve();
+    expect(survivorResolved).not.toHaveBeenCalled();
+
+    resolveFreshKeep("fresh:keep");
+    await expect(survivor).resolves.toBe("fresh:keep");
+  });
 });

--- a/tests/cad-worker-restart-redispatch.test.js
+++ b/tests/cad-worker-restart-redispatch.test.js
@@ -1,0 +1,101 @@
+// Regression tests for CadWorkerManager timeout -> restart behavior.
+//
+// Verifies that when the worker hangs and the inactivity watchdog fires, ONLY
+// the offending (head) call is rejected, while the remaining queued calls are
+// automatically re-dispatched onto the fresh worker and resolve normally —
+// instead of the whole queue being rejected as collateral damage.
+
+import { describe, it, expect, vi } from "vitest";
+
+// Mock comlink so `wrap(rawWorker)` returns a controllable per-worker proxy.
+// Each fake worker exposes its own `__proxy`, letting us make worker #1 hang
+// and worker #2 (the restarted one) resolve.
+vi.mock("comlink", () => ({
+  wrap: (rawWorker) => rawWorker.__proxy,
+}));
+
+import { CadWorkerManager } from "../src/worker/cadWorkerManager.js";
+
+class FakeWorker {
+  constructor(behavior) {
+    this.behavior = behavior;
+    this.terminated = false;
+    this.__proxy = new Proxy(
+      {},
+      {
+        get: (_target, method) => (...args) => this.behavior(method, args, this),
+      },
+    );
+  }
+  addEventListener() {}
+  removeEventListener() {}
+  terminate() {
+    this.terminated = true;
+  }
+  postMessage() {}
+}
+
+/**
+ * Build a WorkerFactory that hands out fake workers from `behaviors` in order,
+ * reusing the last behavior once exhausted.
+ */
+function makeFactory(behaviors) {
+  const created = [];
+  function WorkerFactory() {
+    const behavior = behaviors[Math.min(created.length, behaviors.length - 1)];
+    const worker = new FakeWorker(behavior);
+    created.push(worker);
+    return worker;
+  }
+  return { WorkerFactory, created };
+}
+
+describe("CadWorkerManager timeout re-dispatch", () => {
+  it("drops only the hung head call and re-runs survivors on the fresh worker", async () => {
+    const neverResolves = () => new Promise(() => {});
+    const { WorkerFactory, created } = makeFactory([
+      // Worker #1: every call hangs forever (simulates the stalled OCCT op).
+      neverResolves,
+      // Worker #2 (after restart): resolves immediately with a marker.
+      (method) => Promise.resolve(`done:${method}`),
+    ]);
+
+    const cad = new CadWorkerManager(WorkerFactory, 40);
+
+    const headPromise = cad.hang("head-arg");
+    const survivor1 = cad.alpha("s1-arg");
+    const survivor2 = cad.beta("s2-arg");
+
+    // The head call goes silent and the watchdog fires.
+    await expect(headPromise).rejects.toThrow(/stalled/i);
+
+    // Survivors are re-dispatched onto the restarted worker and resolve.
+    await expect(survivor1).resolves.toBe("done:alpha");
+    await expect(survivor2).resolves.toBe("done:beta");
+
+    // The original worker was terminated and exactly one replacement spawned.
+    expect(created).toHaveLength(2);
+    expect(created[0].terminated).toBe(true);
+    expect(created[1].terminated).toBe(false);
+  });
+
+  it("does not reject survivors when the head times out", async () => {
+    const neverResolves = () => new Promise(() => {});
+    const { WorkerFactory } = makeFactory([
+      neverResolves,
+      (method) => Promise.resolve(`ok:${method}`),
+    ]);
+
+    const cad = new CadWorkerManager(WorkerFactory, 40);
+
+    const headPromise = cad.hang();
+    const survivor = cad.keep();
+
+    const survivorRejected = vi.fn();
+    survivor.catch(survivorRejected);
+
+    await expect(headPromise).rejects.toThrow();
+    await expect(survivor).resolves.toBe("ok:keep");
+    expect(survivorRejected).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Previous we would dump the entire queue when something triggered the timeout making it hard to tell where the issue was. Now we only drop the item which triggered the timeout and resume with the rest of the queue live.