### PR TITLE
Fix `Batch operation already exists` race in concurrent identical assemblies

### DIFF
--- a/src/worker/geometryProvider.ts
+++ b/src/worker/geometryProvider.ts
@@ -809,6 +809,10 @@ class GeometryProvider {
     // "already exists".
     const existing = this.inFlightBatches.get(batchId);
     if (existing) {
+      // Prevent self-deadlock if a batch tries to start itself again before settling.
+      if (context.operationId === batchId) {
+        throw new Error("Batch operation with id " + batchId + " is already in flight");
+      }
       await existing.promise;
       const afterWait = await this.getAssembly(batchId, context);
       if (afterWait) {

--- a/src/worker/geometryProvider.ts
+++ b/src/worker/geometryProvider.ts
@@ -64,6 +64,13 @@ class GeometryProvider {
   private projectLRU: string[] = [];
   private cacheHitMetrics: Record<string, [number, number, number]>; // hits, misses, total-miss-duration-ms
   private warmCache: Map<string, Map<string, ReplicadObject>> = new Map();
+  // Tracks batch operations that are currently running so that concurrent
+  // requests for an identical batch (same content-hashed id) share the first
+  // one's result instead of racing and throwing "already exists".
+  private inFlightBatches: Map<
+    string,
+    { promise: Promise<void>; resolve: () => void }
+  > = new Map();
   private batchMetrics: [number, number] = [0, 0];
 
   constructor(logMetrics: boolean = true) {
@@ -795,15 +802,49 @@ class GeometryProvider {
       return preparedResult;
     }
 
+    // If an identical batch is already running, wait for it to finish and
+    // reuse its cached result rather than racing it. Many identical
+    // sub-assemblies (e.g. repeated bolts) hash to the same batch id and are
+    // dispatched concurrently; without this the second caller would throw
+    // "already exists".
+    const existing = this.inFlightBatches.get(batchId);
+    if (existing) {
+      await existing.promise;
+      const afterWait = await this.getAssembly(batchId, context);
+      if (afterWait) {
+        return afterWait;
+      }
+      // The in-flight batch failed and cached nothing. Fall through and run
+      // the batch ourselves.
+    }
+
     if (this.warmCache.has(batchId)) {
       throw new Error("Batch operation with id " + batchId + " already exists");
     }
     this.warmCache.set(batchId, new Map());
+    let resolveInFlight!: () => void;
+    const promise = new Promise<void>((resolve) => {
+      resolveInFlight = resolve;
+    });
+    this.inFlightBatches.set(batchId, { promise, resolve: resolveInFlight });
     return {
       ...context,
       operationId: batchId,
       persistIntermediates: persistIntermediates,
     };
+  }
+
+  /**
+   * Resolve and remove the in-flight tracking entry for a batch so any
+   * concurrent waiters can proceed (and pick up the cached result if the
+   * batch succeeded).
+   */
+  private settleInFlightBatch(batchId: string): void {
+    const inFlight = this.inFlightBatches.get(batchId);
+    if (inFlight) {
+      this.inFlightBatches.delete(batchId);
+      inFlight.resolve();
+    }
   }
 
   async endBatchOperation(
@@ -845,6 +886,7 @@ class GeometryProvider {
       // Always clear the warm-cache entry so retries cannot get stuck behind
       // stale "already exists" state after a failed end-batch path.
       this.warmCache.delete(context.operationId);
+      this.settleInFlightBatch(context.operationId);
     }
   }
 
@@ -859,6 +901,7 @@ class GeometryProvider {
     }
     this.batchMetrics = [0, 0];
     this.warmCache.delete(context.operationId);
+    this.settleInFlightBatch(context.operationId);
   }
 
   async shrinkWrapSketches(

--- a/tests/batch-operation-dedup.test.js
+++ b/tests/batch-operation-dedup.test.js
@@ -1,0 +1,119 @@
+// Regression tests for GeometryProvider batch-operation concurrency.
+//
+// Many identical sub-assemblies (e.g. repeated bolts) hash to the SAME
+// content-based batch id and get dispatched concurrently. Previously the
+// second concurrent `startBatchOperation` for an in-flight id threw
+// "Batch operation with id ... already exists", cascading the whole branch
+// to error/upstream_error. These tests verify that concurrent identical
+// batches now share the first one's result, and that a failed batch lets a
+// later caller retry cleanly.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// These tests exercise only the batch bookkeeping (no geometry), so stub the
+// heavy replicad packages to keep the module loadable in a plain node env.
+vi.mock("replicad-shrink-wrap", () => ({ default: () => {} }));
+vi.mock("replicad", () => ({
+  GCWithScope: () => () => {},
+  measureVolume: () => 0,
+}));
+
+// In-memory stand-in for the IndexedDB shape store so we don't need a browser
+// or WASM. Keyed by `${projectId}::${shapeKey}`.
+const { store } = vi.hoisted(() => ({ store: new Map() }));
+
+vi.mock("../src/worker/indexeddbUtils", () => ({
+  getShape: async (projectId, shapeKey) =>
+    store.get(`${projectId}::${shapeKey}`),
+  putShape: async (
+    projectId,
+    shapeKey,
+    serialized,
+    isAbundanceObject = false,
+  ) => {
+    store.set(`${projectId}::${shapeKey}`, {
+      projectId,
+      shapeKey,
+      type: isAbundanceObject ? "AbundanceObject" : "ReplicadObject",
+      serialized,
+    });
+  },
+  shapeExists: async (projectId, shapeKey) =>
+    store.has(`${projectId}::${shapeKey}`),
+  deleteProjectCache: async () => {},
+  getAllProjectIds: async () => [],
+  filter: async () => {},
+}));
+
+import { GeometryProvider } from "../src/worker/geometryProvider";
+
+describe("GeometryProvider batch-operation concurrency", () => {
+  let gp;
+  const context = { project: "test" };
+
+  beforeEach(() => {
+    store.clear();
+    gp = new GeometryProvider(false);
+  });
+
+  it("shares a result between concurrent identical batches instead of throwing", async () => {
+    const result = { __cached: true, geometry: [] };
+
+    // Kick off two identical batches concurrently. The first wins and returns
+    // a fresh RequestContext; the second must wait (not throw).
+    const p1 = gp.startBatchOperation(context, "same-hash", true);
+    const p2 = gp.startBatchOperation(context, "same-hash", true);
+
+    const b1 = await p1;
+    expect(b1.operationId).toBe("batch-same-hash");
+    expect(b1).not.toHaveProperty("__cached");
+
+    // p2 should still be pending until the first batch ends.
+    await gp.endBatchOperation(b1, result);
+
+    const b2 = await p2;
+    // The second caller reuses the first batch's cached assembly.
+    expect(b2).toMatchObject({ __cached: true });
+    expect(b2).not.toHaveProperty("operationId");
+  });
+
+  it("lets a later caller retry after a failed batch (no stuck 'already exists')", async () => {
+    const b1 = await gp.startBatchOperation(context, "fail-hash", true);
+    expect(b1.operationId).toBe("batch-fail-hash");
+
+    // Simulate a failed batch: cleanup without caching any result.
+    gp.cleanupBatchWithoutCaching(b1);
+
+    // A subsequent start must NOT throw and must hand back a fresh context.
+    const b2 = await gp.startBatchOperation(context, "fail-hash", true);
+    expect(b2.operationId).toBe("batch-fail-hash");
+    expect(b2).not.toHaveProperty("__cached");
+  });
+
+  it("re-runs the batch when the in-flight one fails without caching", async () => {
+    const p1 = gp.startBatchOperation(context, "race-fail", true);
+    const p2 = gp.startBatchOperation(context, "race-fail", true);
+
+    const b1 = await p1;
+    expect(b1.operationId).toBe("batch-race-fail");
+
+    // First batch fails -> nothing cached. The waiting second caller should
+    // fall through and run the batch itself rather than getting a stale error.
+    gp.cleanupBatchWithoutCaching(b1);
+
+    const b2 = await p2;
+    expect(b2.operationId).toBe("batch-race-fail");
+    expect(b2).not.toHaveProperty("__cached");
+  });
+
+  it("returns the cached assembly immediately on a warm second call", async () => {
+    const result = { __cached: true, geometry: [] };
+    const b1 = await gp.startBatchOperation(context, "warm-hash", true);
+    await gp.endBatchOperation(b1, result);
+
+    // Now the assembly is persisted; a fresh start should short-circuit.
+    const cached = await gp.startBatchOperation(context, "warm-hash", true);
+    expect(cached).toMatchObject({ __cached: true });
+    expect(cached).not.toHaveProperty("operationId");
+  });
+});


### PR DESCRIPTION
@tristan-huber This seems to fix the issue, but I am not sure how it matches up with the way that the system should work.

## Summary

Projects with many **identical sub-assemblies** (e.g. repeated M3 bolts/locknuts)
could fail to load, leaving large branches of the graph stuck in
`error`/`upstream_error`. The root cause was a race in
`GeometryProvider.startBatchOperation`: two concurrent batch operations with the
**same content-hashed id** would collide, and the second one threw
`Batch operation with id batch-… already exists`. That error cascaded to every
downstream atom.

This PR makes concurrent identical batches **share** the first batch's result
instead of racing, eliminating the spurious failures (and saving redundant
geometry work).

## Why this happened

`startBatchOperation` deduplicates work by a content-based batch id
(`assembly-<hash>` / `code-atom-<key>`). The check was a classic
time-of-check/time-of-use race:

1. Two identical assemblies are dispatched at the same time.
2. Both `await getAssembly(batchId)` → cache miss.
3. The first sets `warmCache[batchId]` and proceeds.
4. The second sees `warmCache.has(batchId)` → **throws "already exists"**.

The existing catch-path cleanup (which prevents *leaked* batches) does not help
here, because the first batch is legitimately in flight — the second caller
simply should have waited for it.

## What changed

`src/worker/geometryProvider.ts`

- Added an `inFlightBatches` map tracking batches that are currently running,
  each with a deferred `promise`/`resolve`.
- `startBatchOperation` now, on a cache miss:
  - If an identical batch is already in flight, it `await`s that batch and then
    re-queries `getAssembly`, returning the shared cached result. If the
    in-flight batch produced nothing (it failed), it falls through and runs the
    batch itself.
  - When starting a fresh batch, it registers a deferred in `inFlightBatches`
    before returning the batch context.
- Added a private `settleInFlightBatch(batchId)` helper that resolves and
  removes the deferred. It is called from both:
  - `endBatchOperation` (in the `finally`, alongside the warm-cache cleanup), and
  - `cleanupBatchWithoutCaching` (the failed/primitive-result path),

  so waiters are always released whether the batch succeeds or fails.

Sharing is safe because the batch id is a content hash — identical id implies
identical inputs and therefore an identical result.

## Tests

`tests/batch-operation-dedup.test.js` (new) covers:

- Concurrent identical batches share a result instead of throwing.
- A failed batch lets a later caller retry cleanly (no stuck "already exists").
- A waiting concurrent caller re-runs the batch itself when the in-flight one
  fails without caching.
- A warm second call short-circuits to the cached assembly.

The test mocks `./indexeddbUtils` and the heavy `replicad` / `replicad-shrink-wrap`
imports, so it exercises only the batch bookkeeping (no WASM/geometry).

Run it as a single file under the browser config:

```bash
npx vitest run --config=vitest.browser.config.ts tests/batch-operation-dedup.test.js
```

> Note: the node config (`vitest.config.mjs`) cannot import `geometryProvider.ts`
> because `replicad-shrink-wrap` has no `main`/`exports` field for vite to resolve
> (existing geometry tests have the same constraint). Avoid running the full
> `npm run unit` suite casually — it spawns many browser instances.

## Validation

- `npm run build` succeeds (new worker bundle emitted).
- New regression test passes (4/4).
- No type or lint errors introduced.