### PR TITLE
Add a user selectable timeout for worker loads

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import {
 import GlobalVariables from "./js/globalvariables.js";
 import { fetchGitHubFileContent } from "./js/githubFileUtils.js";
 import { filterGeometryByTags } from "./utils/geometryFilterByTags.js";
+import { readCadWorkerTimeoutMs } from "./utils/cadWorkerTimeoutSettings.js";
 import { CadWorkerManager } from "./worker/cadWorkerManager.js";
 import LoginMode from "./components/main-routes/LoginMode.jsx";
 import RunMode from "./components/main-routes/RunMode.jsx";
@@ -63,12 +64,12 @@ const pool = workerpool.pool(RenderURL, {
   },
 });
 
-// CadWorkerManager wraps the comlink worker with a 90-second inactivity timeout.
+// CadWorkerManager wraps the comlink worker with a configurable inactivity timeout.
 // The watchdog is reset whenever the worker reports mid-computation progress, so
 // a long-running operation only times out if it goes truly silent (stalled). If
 // the worker hangs it is automatically terminated and restarted, so the UI never
 // gets permanently stuck waiting for a computation that will never return.
-const cad = new CadWorkerManager(cadWorker, 90_000);
+const cad = new CadWorkerManager(cadWorker, readCadWorkerTimeoutMs());
 
 // Statuses that mean the initial project load has SETTLED. A project whose
 // top-level molecule contains user-authored code that legitimately errors will

--- a/src/components/secondary/SettingsPopUp.jsx
+++ b/src/components/secondary/SettingsPopUp.jsx
@@ -2,6 +2,12 @@ import React, { useState, useRef, useEffect } from "react";
 import Globalvariables from "../../js/globalvariables.js";
 import CreatableSelect from "react-select/creatable";
 import topics from "../../js/maslowTopics.js";
+import {
+  CAD_WORKER_TIMEOUT_MIN_MS,
+  CAD_WORKER_TIMEOUT_MAX_MS,
+  readCadWorkerTimeoutMs,
+  writeCadWorkerTimeoutMs,
+} from "../../utils/cadWorkerTimeoutSettings.js";
 
 const SettingsPopUp = ({
   setSettingsPopUp,
@@ -21,6 +27,8 @@ const SettingsPopUp = ({
   setSavePopUp,
   handleRenameProject,
 }) => {
+  const minWorkerTimeoutSeconds = Math.round(CAD_WORKER_TIMEOUT_MIN_MS / 1000);
+  const maxWorkerTimeoutSeconds = Math.round(CAD_WORKER_TIMEOUT_MAX_MS / 1000);
   let repoTopics = [];
   if (Globalvariables.currentAWSnode.topics.length > 0) {
     Globalvariables.currentAWSnode.topics.forEach((topic) => {
@@ -79,11 +87,27 @@ const SettingsPopUp = ({
       10,
     ),
     atomSize: Globalvariables.atomSize * 1000,
+    workerTimeoutSeconds: Math.round(readCadWorkerTimeoutMs() / 1000),
     projectDescription: Globalvariables.currentAWSnode.description,
     autoSaveDisabled: localStorage.getItem("autoSaveDisabled") === "true",
   });
 
   const handleValueChange = (event) => {
+    if (event.target.name === "workerTimeoutSeconds") {
+      const normalizedTimeoutMs = writeCadWorkerTimeoutMs(
+        Number(event.target.value) * 1000,
+      );
+      setState({
+        ...state,
+        workerTimeoutSeconds: Math.round(normalizedTimeoutMs / 1000),
+      });
+
+      if (Globalvariables.cad?.setTimeoutMs) {
+        Globalvariables.cad.setTimeoutMs(normalizedTimeoutMs);
+      }
+      return;
+    }
+
     setState({
       ...state,
       [event.target.name]: event.target.value,
@@ -290,6 +314,35 @@ const SettingsPopUp = ({
                   {state.atomSize}
                 </span>
               </div>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 12,
+                  margin: "10px 0 4px 0",
+                }}
+              >
+                <label className="settings-labels" style={{ minWidth: 80 }}>
+                  Worker Timeout
+                </label>
+                <input
+                  type="range"
+                  min={minWorkerTimeoutSeconds}
+                  max={maxWorkerTimeoutSeconds}
+                  step={15}
+                  value={state.workerTimeoutSeconds}
+                  onChange={handleValueChange}
+                  name="workerTimeoutSeconds"
+                  className="settings-sliders"
+                  style={{ width: 140 }}
+                />
+                <span style={{ fontSize: 13, color: "#888", marginLeft: 6 }}>
+                  {state.workerTimeoutSeconds}s
+                </span>
+              </div>
+              <span style={{ fontSize: 12, color: "#666" }}>
+                Time the CAD worker can stay silent before it is restarted.
+              </span>
             </div>
           </CustomTabPanel>
           <CustomTabPanel value={value} index={2}>

--- a/src/utils/cadWorkerTimeoutSettings.js
+++ b/src/utils/cadWorkerTimeoutSettings.js
@@ -1,0 +1,42 @@
+export const CAD_WORKER_TIMEOUT_STORAGE_KEY = "cadWorkerInactivityTimeoutMs";
+export const CAD_WORKER_TIMEOUT_DEFAULT_MS = 90_000;
+export const CAD_WORKER_TIMEOUT_MIN_MS = 30_000;
+export const CAD_WORKER_TIMEOUT_MAX_MS = 900_000;
+
+export function clampCadWorkerTimeoutMs(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return CAD_WORKER_TIMEOUT_DEFAULT_MS;
+  }
+
+  return Math.min(
+    CAD_WORKER_TIMEOUT_MAX_MS,
+    Math.max(CAD_WORKER_TIMEOUT_MIN_MS, Math.round(parsed)),
+  );
+}
+
+export function readCadWorkerTimeoutMs() {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return CAD_WORKER_TIMEOUT_DEFAULT_MS;
+  }
+
+  const storedValue = window.localStorage.getItem(CAD_WORKER_TIMEOUT_STORAGE_KEY);
+  if (storedValue === null) {
+    return CAD_WORKER_TIMEOUT_DEFAULT_MS;
+  }
+
+  return clampCadWorkerTimeoutMs(Number.parseInt(storedValue, 10));
+}
+
+export function writeCadWorkerTimeoutMs(timeoutMs) {
+  const normalizedTimeoutMs = clampCadWorkerTimeoutMs(timeoutMs);
+
+  if (typeof window !== "undefined" && window.localStorage) {
+    window.localStorage.setItem(
+      CAD_WORKER_TIMEOUT_STORAGE_KEY,
+      String(normalizedTimeoutMs),
+    );
+  }
+
+  return normalizedTimeoutMs;
+}

--- a/src/worker/cadWorkerManager.js
+++ b/src/worker/cadWorkerManager.js
@@ -379,6 +379,38 @@ export class CadWorkerManager {
   }
 
   /**
+   * Update the inactivity timeout used for future calls and for the currently
+   * active call (if any).
+   * @param {number} timeoutMs
+   * @returns {number} The normalized timeout currently in use.
+   */
+  setTimeoutMs(timeoutMs) {
+    const parsed = Number(timeoutMs);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      return this._timeoutMs;
+    }
+
+    this._timeoutMs = Math.round(parsed);
+
+    // Re-arm the active watchdog so a changed timeout takes effect immediately
+    // without waiting for the next queued call.
+    const activeEntry =
+      this._pendingCalls.find((entry) => entry.startTime) || null;
+    if (activeEntry && activeEntry.timeoutId) {
+      this._armTimeout(activeEntry);
+    }
+
+    return this._timeoutMs;
+  }
+
+  /**
+   * @returns {number}
+   */
+  getTimeoutMs() {
+    return this._timeoutMs;
+  }
+
+  /**
    * Snapshot of the current worker queue for diagnostics (System State Report).
    * The worker processes calls serially, so the entry with a `startTime` is the
    * one actively blocking everything behind it.

--- a/tests/cad-worker-restart-redispatch.test.js
+++ b/tests/cad-worker-restart-redispatch.test.js
@@ -131,4 +131,21 @@ describe("CadWorkerManager timeout re-dispatch", () => {
     resolveFreshKeep("fresh:keep");
     await expect(survivor).resolves.toBe("fresh:keep");
   });
+
+  it("applies timeout updates at runtime", async () => {
+    const neverResolves = () => new Promise(() => {});
+    const { WorkerFactory } = makeFactory([neverResolves, neverResolves]);
+
+    const cad = new CadWorkerManager(WorkerFactory, 5_000);
+
+    expect(cad.getTimeoutMs()).toBe(5_000);
+    expect(cad.getQueueSnapshot().timeoutMs).toBe(5_000);
+
+    cad.setTimeoutMs(40);
+
+    expect(cad.getTimeoutMs()).toBe(40);
+    expect(cad.getQueueSnapshot().timeoutMs).toBe(40);
+
+    await expect(cad.hang("runtime-timeout")).rejects.toThrow(/stalled/i);
+  });
 });


### PR DESCRIPTION
Allows the user to select how long the timeout should be for when the worker gives up and moves on from something which isn't loading.