### PR TITLE
Bound geometry id length with a 128-bit hash

### DIFF
--- a/src/worker/geometryProvider.ts
+++ b/src/worker/geometryProvider.ts
@@ -4,6 +4,7 @@ import {
   AbundanceObject,
   asReplicadPlane,
   flattenAssembly,
+  hashStringWide,
   SimplePlane,
 } from "./util";
 import {
@@ -60,6 +61,10 @@ type BooleanResult = {
  */
 class GeometryProvider {
   public EMPTY_SHAPE_SENTINEL = "emptyshape";
+  // Ids longer than this are collapsed to a fixed-length digest in `_makeId`.
+  // Keeps typical ids human-readable while bounding pathological nested-boolean
+  // recipes (observed at 65-78KB) that otherwise dominate large assemblies.
+  private static MAX_ID_LENGTH = 512;
   private MAX_PROJECTS = 4;
   private projectLRU: string[] = [];
   private cacheHitMetrics: Record<string, [number, number, number]>; // hits, misses, total-miss-duration-ms
@@ -83,7 +88,7 @@ class GeometryProvider {
     }
   }
   private cacheHit(id: string): void {
-    const type = id.split("-")[0];
+    const type = id.split(/[-#]/)[0];
     if (!this.cacheHitMetrics[type]) {
       this.cacheHitMetrics[type] = [0, 0, 0];
     }
@@ -91,7 +96,7 @@ class GeometryProvider {
   }
 
   private cacheMiss(id: string, durationMs: number = 0): void {
-    const type = id.split("-")[0];
+    const type = id.split(/[-#]/)[0];
     if (!this.cacheHitMetrics[type]) {
       this.cacheHitMetrics[type] = [0, 0, 0];
     }
@@ -148,8 +153,19 @@ class GeometryProvider {
     //  add result to the cache
     //  if a no-op return the appropriate input id
     //  if a empty shape return the sentinel
+    // DIAGNOSTIC: `resultId` encodes the op + input ids (e.g. `cut-<toCut>-<cutter>`).
+    // The "starting" line is always logged so a hanging boolean is identifiable as
+    // the last entry in getRecentWorkerLogs with no matching "done" line. The
+    // "done" line is gated to slow ops to bound the worker-log ring buffer.
+    console.warn(`[boolean] ${resultId} starting`);
     const start = performance.now();
     const opResult = await operation(inputs);
+    const durationMs = Math.round(performance.now() - start);
+    if (durationMs > 2000) {
+      console.warn(
+        `[boolean] ${resultId} done in ${durationMs}ms outcome=${BooleanOutcome[opResult.outcome]}`,
+      );
+    }
     switch (opResult.outcome) {
       case BooleanOutcome.EmptyShape:
         this.cacheHit("boolempty" + resultId);
@@ -750,6 +766,12 @@ class GeometryProvider {
           const volumeDiff = Math.abs(initialVolume - resultVolume);
           const tolerance = 1e-5;
           if (volumeDiff < tolerance) {
+            // DIAGNOSTIC: a boolean that removed ~no volume yet ran (bounding
+            // boxes overlapped) is a degenerate/wasted-cut candidate. Paired
+            // with the [boolean] timing line this flags expensive no-op cuts.
+            console.warn(
+              `[boolean] cut near-noop toCut=${toCut} cutter=${cutter} initialVolume=${initialVolume} volumeDiff=${volumeDiff}`,
+            );
             return {
               outcome: BooleanOutcome.InputShape,
               inputIndexAsResult: 0,
@@ -1062,6 +1084,17 @@ class GeometryProvider {
       return typeof arg === "string" ? arg : JSON.stringify(arg);
     });
     const key = [type, ...args].flat(Infinity).join("-");
+    // Boolean recipes nest their inputs' full ids (e.g. a cut result becomes the
+    // input to the next cut), so ids can grow without bound — multi-kilobyte
+    // `cut-cut-cut-...` strings whose building and Map/IndexedDB keying cost
+    // dominates large assemblies. Collapse over-long ids to a fixed-length,
+    // deterministic, collision-resistant digest. The `#` delimiter can never
+    // appear in a plain id (which always has `-` immediately after `type`), so a
+    // collapsed id can never collide with a non-collapsed one, and identical
+    // recipes always collapse identically — preserving cache correctness.
+    if (key.length > GeometryProvider.MAX_ID_LENGTH) {
+      return type + "#" + hashStringWide(key);
+    }
     return key;
   }
 }

--- a/src/worker/util.ts
+++ b/src/worker/util.ts
@@ -538,6 +538,42 @@ function hashString(str: string): string {
   return hash.toString(16).padStart(8, "0");
 }
 
+/**
+ * Generates a 128-bit hash for a string, returned as 32 hex characters.
+ *
+ * Uses the well-distributed `cyrb128` mixing function. A 128-bit width is used
+ * (rather than {@link hashString}'s 32 bits) where the hash is a cache key and a
+ * collision would silently return the wrong geometry: at 128 bits the collision
+ * probability is negligible even across millions of shapes. Deterministic and
+ * synchronous, so it is safe to use in hot, synchronous id-building paths.
+ * @param {string} str - The input string to hash.
+ * @returns {string} - 32-character hex hash.
+ */
+function hashStringWide(str: string): string {
+  let h1 = 1779033703,
+    h2 = 3144134277,
+    h3 = 1013904242,
+    h4 = 2773480762;
+  for (let i = 0; i < str.length; i++) {
+    const k = str.charCodeAt(i);
+    h1 = h2 ^ Math.imul(h1 ^ k, 597399067);
+    h2 = h3 ^ Math.imul(h2 ^ k, 2869860233);
+    h3 = h4 ^ Math.imul(h3 ^ k, 951274213);
+    h4 = h1 ^ Math.imul(h4 ^ k, 2716044179);
+  }
+  h1 = Math.imul(h3 ^ (h1 >>> 18), 597399067);
+  h2 = Math.imul(h4 ^ (h2 >>> 22), 2869860233);
+  h3 = Math.imul(h1 ^ (h3 >>> 17), 951274213);
+  h4 = Math.imul(h2 ^ (h4 >>> 19), 2716044179);
+  h1 ^= h2 ^ h3 ^ h4;
+  h2 ^= h1;
+  h3 ^= h1;
+  h4 ^= h1;
+  return [h1, h2, h3, h4]
+    .map((h) => (h >>> 0).toString(16).padStart(8, "0"))
+    .join("");
+}
+
 function assemblyOf(subAssemblies: AbundanceObject[]): AbundanceObject {
   const result: AbundanceBranch = {
     geometry: subAssemblies,
@@ -598,6 +634,7 @@ export {
   hashFileContents,
   hashAssembly,
   hashString,
+  hashStringWide,
   init,
   is2D,
   is3D,


### PR DESCRIPTION
Nested boolean recipes produced multi-kilobyte geometry ids (observed 65–78 KB) whose string building and Map/IndexedDB keying dominated large assemblies.

`_makeId` now collapses ids longer than 512 chars to a deterministic, collision-resistant 128-bit digest (`type#<hash>`). The `#` delimiter can never appear in a plain id, so collapsed and non-collapsed ids never collide, and identical recipes collapse identically — preserving cache correctness across sessions.

**Files:** `src/worker/util.ts` (new `hashStringWide`), `src/worker/geometryProvider.ts` (`_makeId` collapse + metrics split).

Base: `main`. Part 1 of 4 (see stacked PRs).