### PR TITLE
Surface hanging boolean cuts as red parts instead of stalling

### DIFF
--- a/src/worker/cadWorkerManager.js
+++ b/src/worker/cadWorkerManager.js
@@ -1,5 +1,8 @@
 import { wrap } from "comlink";
-import { CAD_PROGRESS_MESSAGE_TYPE } from "./progress";
+import {
+  CAD_PROGRESS_MESSAGE_TYPE,
+  CAD_BOOLEAN_INFLIGHT_TYPE,
+} from "./progress";
 
 /**
  * Wraps a comlink-based Web Worker with a per-call timeout watchdog.
@@ -69,6 +72,26 @@ export class CadWorkerManager {
      */
     this._lastWorkerActivity = null;
 
+    /**
+     * The `(toCut, cutter)` ids of the boolean `.cut()` currently executing in
+     * the worker, or null when no cut is in flight. Set/cleared by the
+     * `cad-boolean-inflight` beacons the worker posts around each `.cut()`. If a
+     * cut hangs, the "clear" beacon never arrives (the worker thread is frozen),
+     * so this stays populated — telling the watchdog exactly which cut hung.
+     * @type {{toCut: string, cutter: string} | null}
+     */
+    this._lastBooleanInflight = null;
+
+    /**
+     * Boolean cuts known to hang the worker, keyed by `toCut\u0000cutter`. When
+     * a `.cut()` times out it is recorded here (and persisted), then injected
+     * into every worker so it is skipped on future runs — the assembly surfaces
+     * the two offending parts in red instead of hanging again.
+     * @type {Map<string, {toCut: string, cutter: string}>}
+     */
+    this._badCuts = new Map();
+    this._loadBadCuts();
+
     this._createWorker();
 
     // Return a Proxy so that `cad.anyMethod(args)` transparently goes through
@@ -99,6 +122,67 @@ export class CadWorkerManager {
     // `cad-worker-task-progress` CustomEvents. Comlink ignores them because
     // they do not match its request/response protocol.
     this._rawWorker.addEventListener("message", this._onWorkerMessage);
+    // Seed the fresh worker with the known-hanging cuts so it skips them
+    // (surfacing the two parts in red) instead of hanging again.
+    this._injectBadCuts();
+  }
+
+  /** localStorage key holding the persisted known-hanging cuts. */
+  static _BAD_CUTS_STORAGE_KEY = "abundance-known-hanging-cuts";
+
+  /** Load persisted known-hanging cuts (best-effort; safe outside a browser). */
+  _loadBadCuts() {
+    try {
+      if (typeof localStorage === "undefined") return;
+      const raw = localStorage.getItem(CadWorkerManager._BAD_CUTS_STORAGE_KEY);
+      if (!raw) return;
+      const pairs = JSON.parse(raw);
+      if (!Array.isArray(pairs)) return;
+      for (const p of pairs) {
+        if (p && p.toCut && p.cutter) {
+          this._badCuts.set(`${p.toCut}\u0000${p.cutter}`, {
+            toCut: p.toCut,
+            cutter: p.cutter,
+          });
+        }
+      }
+    } catch (e) {
+      console.warn("[CadWorkerManager] Failed to load known-hanging cuts:", e);
+    }
+  }
+
+  /** Persist the current known-hanging cuts (best-effort). */
+  _saveBadCuts() {
+    try {
+      if (typeof localStorage === "undefined") return;
+      localStorage.setItem(
+        CadWorkerManager._BAD_CUTS_STORAGE_KEY,
+        JSON.stringify([...this._badCuts.values()]),
+      );
+    } catch (e) {
+      console.warn("[CadWorkerManager] Failed to persist known-hanging cuts:", e);
+    }
+  }
+
+  /** Push the known-hanging cuts to the (current) worker so it skips them. */
+  _injectBadCuts() {
+    if (this._badCuts.size === 0) return;
+    try {
+      // Fire-and-forget; ordering vs. subsequent calls is preserved because
+      // comlink delivers messages in submission order and every handler is
+      // gated on the same `started` init promise in the worker.
+      this._proxy.setBadCuts([...this._badCuts.values()]);
+    } catch (e) {
+      console.warn("[CadWorkerManager] Failed to inject known-hanging cuts:", e);
+    }
+  }
+
+  /** Record a boolean cut that hung the worker, persist it, and remember it. */
+  _recordBadCut(pair) {
+    const key = `${pair.toCut}\u0000${pair.cutter}`;
+    if (this._badCuts.has(key)) return;
+    this._badCuts.set(key, { toCut: pair.toCut, cutter: pair.cutter });
+    this._saveBadCuts();
   }
 
   _onWorkerMessage = (event) => {
@@ -128,6 +212,14 @@ export class CadWorkerManager {
       if (this._workerLogs.length > 1000) {
         this._workerLogs.splice(0, this._workerLogs.length - 1000);
       }
+      return;
+    }
+    // Boolean `.cut()` in-flight beacon (see src/worker/progress.ts). Tracks the
+    // exact cut executing right now so a hang can be attributed to it precisely.
+    if (data.type === CAD_BOOLEAN_INFLIGHT_TYPE) {
+      this._lastBooleanInflight = data.active
+        ? { toCut: data.toCut, cutter: data.cutter }
+        : null;
       return;
     }
     if (data.type !== CAD_PROGRESS_MESSAGE_TYPE) {
@@ -234,6 +326,40 @@ export class CadWorkerManager {
     entry.timeoutId = setTimeout(() => {
       clearInterval(entry.progressIntervalId);
       entry.progressIntervalId = null;
+
+      // If a specific boolean `.cut()` was in flight when the worker went
+      // silent, that cut is the hang. Record it as known-hanging (persisted +
+      // injected into the restarted worker) and re-dispatch this same call
+      // rather than rejecting it: on the re-run the worker skips the cut and the
+      // assembly resolves to the two offending parts in red, so the atom
+      // succeeds (loudly) in this session instead of erroring.
+      const inflightCut = this._lastBooleanInflight;
+      if (inflightCut && inflightCut.toCut && inflightCut.cutter) {
+        this._recordBadCut(inflightCut);
+        this._lastBooleanInflight = null;
+        const degradedMessage = `CAD worker cut timed out; marking as hanging and retrying (parts will show red): ${inflightCut.toCut} cut by ${inflightCut.cutter}`;
+        this._emitCadWorkerEvent("cad-worker-task-error", {
+          taskId: entry.taskId,
+          method: String(entry.method),
+          queuedAt: entry.queuedAt,
+          startedAt: entry.startTime,
+          failedAt: Date.now(),
+          durationMs: entry.startTime ? Date.now() - entry.startTime : null,
+          queueWaitMs: entry.startTime ? entry.startTime - entry.queuedAt : null,
+          queueDepth: this._pendingCalls.length,
+          atomId: entry.taskMeta?.atomId || null,
+          atomType: entry.taskMeta?.atomType || null,
+          moleculeName: entry.taskMeta?.moleculeName || null,
+          displayLabel: this._formatTaskLabel(entry.method, entry.taskMeta),
+          badCut: inflightCut,
+          degraded: true,
+          error: degradedMessage,
+        });
+        // Keep `entry` in `_pendingCalls` so `_restartWorker` re-dispatches it
+        // onto the fresh worker (which now knows the cut is bad and skips it).
+        this._restartWorker();
+        return;
+      }
 
       this._pendingCalls = this._pendingCalls.filter((c) => c !== entry);
       // Fold in the last known worker activity so the stall message pinpoints the

--- a/src/worker/geometryProvider.ts
+++ b/src/worker/geometryProvider.ts
@@ -17,6 +17,7 @@ import {
   filter,
 } from "./indexeddbUtils";
 import { GCWithScope } from "replicad";
+import { reportBooleanInflight } from "./progress";
 
 type ReplicadObject =
   | replicad.Shape3D
@@ -65,6 +66,11 @@ class GeometryProvider {
   // Keeps typical ids human-readable while bounding pathological nested-boolean
   // recipes (observed at 65-78KB) that otherwise dominate large assemblies.
   private static MAX_ID_LENGTH = 512;
+  // Set of `toCut\u0000cutter` keys for boolean cuts that previously hung the
+  // worker (>watchdog). `recursiveCut` consults `isBadCut` and, rather than
+  // re-running a cut that will hang again, surfaces the two failing parts in red.
+  // Seeded from the main thread via `setBadCuts` on every (re)start.
+  private badCuts: Set<string> = new Set();
   private MAX_PROJECTS = 4;
   private projectLRU: string[] = [];
   private cacheHitMetrics: Record<string, [number, number, number]>; // hits, misses, total-miss-duration-ms
@@ -102,6 +108,26 @@ class GeometryProvider {
     }
     this.cacheHitMetrics[type][1]++;
     this.cacheHitMetrics[type][2] += durationMs;
+  }
+
+  private _badCutKey(toCut: string, cutter: string): string {
+    return toCut + "\u0000" + cutter;
+  }
+
+  /**
+   * Replace the set of known-hanging boolean cuts. Called from the main thread
+   * (CadWorkerManager) on every worker (re)start with the cuts that previously
+   * timed out, so this fresh worker skips them instead of hanging again.
+   */
+  setBadCuts(pairs: Array<{ toCut: string; cutter: string }>): void {
+    this.badCuts = new Set(
+      (pairs || []).map((p) => this._badCutKey(p.toCut, p.cutter)),
+    );
+  }
+
+  /** True if cutting `toCut` by `cutter` previously hung the worker. */
+  isBadCut(toCut: string, cutter: string): boolean {
+    return this.badCuts.has(this._badCutKey(toCut, cutter));
   }
 
   private updateLRU(projectId: string) {
@@ -836,9 +862,12 @@ class GeometryProvider {
         const args = [toCutGeom, cutterGeom];
         if (this.areAllDrawings(args)) {
           phase("2D cut()");
+          reportBooleanInflight(toCut, cutter, true);
+          const drawingResult = args[0].cut(args[1]);
+          reportBooleanInflight(toCut, cutter, false);
           return {
             outcome: BooleanOutcome.NewShape,
-            result: args[0].cut(args[1]),
+            result: drawingResult,
           };
         } else if (this.areAll3DShapes(args)) {
           phase("measureVolume(initial)");
@@ -852,8 +881,14 @@ class GeometryProvider {
           }
 
           phase("3D cut()");
+          // Announce the exact cut about to run. If `.cut()` hangs, the worker
+          // thread freezes and the matching `false` beacon below never sends, so
+          // the main thread still sees this cut as in-flight and can record it as
+          // a known-hanging cut when the watchdog fires.
+          reportBooleanInflight(toCut, cutter, true);
           const cutStart = performance.now();
           const result = args[0].cut(args[1]);
+          reportBooleanInflight(toCut, cutter, false);
           const cutMs = Math.round(performance.now() - cutStart);
           if (cutMs > 1000) {
             console.warn(`[boolean] cut .cut() took ${cutMs}ms`);

--- a/src/worker/interaction.ts
+++ b/src/worker/interaction.ts
@@ -4,6 +4,38 @@ import { AbundanceLeaf, AbundanceObject } from "./util";
 import { RequestContext } from "./geometryProvider";
 import { extractKeepOut } from "./tags";
 import { reportCadProgress } from "./progress";
+
+/** Color used to flag the two parts of a boolean cut that could not be computed. */
+const FAILED_CUT_COLOR = "#ff0000";
+
+/**
+ * Thrown by `recursiveCut` when it reaches a boolean cut that previously hung
+ * the worker (recorded as a known-hanging cut). Rather than re-run the cut and
+ * hang again — or silently omit it and produce subtly-wrong geometry — the
+ * assembly catches this and returns just the two offending leaves in red, making
+ * the failure impossible to miss and pointing exactly at the parts involved.
+ */
+class FailedCutError extends Error {
+  toCutId: string;
+  cutterId: string;
+  toCutLeaf: AbundanceLeaf;
+  cutterLeaf: AbundanceLeaf;
+  constructor(
+    toCutId: string,
+    cutterId: string,
+    toCutLeaf: AbundanceLeaf,
+    cutterLeaf: AbundanceLeaf,
+  ) {
+    super(
+      `Boolean cut is marked as hanging and was skipped: ${toCutId} cut by ${cutterId}`,
+    );
+    this.name = "FailedCutError";
+    this.toCutId = toCutId;
+    this.cutterId = cutterId;
+    this.toCutLeaf = toCutLeaf;
+    this.cutterLeaf = cutterLeaf;
+  }
+}
 /**
  * All methods in this file take multiple geometries and combine them in some way.
  *
@@ -445,6 +477,40 @@ async function assembly(
     }
     return result;
   } catch (error) {
+    if (error instanceof FailedCutError) {
+      // A previously-hanging boolean cut was reached. Replace the entire assembly
+      // result with just the two leaves that could not be cut, in red, so the
+      // problem is obvious and points exactly at the offending parts. The two
+      // input geometries are still live in the warm cache at this point, so the
+      // batch cleanup must happen AFTER computing their bounds.
+      const redToCut: AbundanceLeaf = {
+        ...error.toCutLeaf,
+        geometry: error.toCutId,
+        color: FAILED_CUT_COLOR,
+      };
+      const redCutter: AbundanceLeaf = {
+        ...error.cutterLeaf,
+        geometry: error.cutterId,
+        color: FAILED_CUT_COLOR,
+      };
+      const failedAssembly = util.assemblyOf([redToCut, redCutter]);
+      const withBounds = await util.withAssemblyBoundingBoxes(
+        failedAssembly,
+        context,
+      );
+      if (startedOwnBatch) {
+        try {
+          // Do NOT cache the (never-computed) full assembly under the batch id.
+          util.geometryProvider!.cleanupBatchWithoutCaching(context);
+        } catch (cleanupError) {
+          console.warn(
+            "Failed to cleanup assembly batch after a failed cut",
+            cleanupError,
+          );
+        }
+      }
+      return withBounds;
+    }
     if (startedOwnBatch) {
       try {
         util.geometryProvider!.cleanupBatchWithoutCaching(context);
@@ -605,6 +671,17 @@ async function recursiveCut(
     // single leaf is cut by many parts.
     cutsPerformed++;
     reportCadProgress(`boolean cut ${cutsPerformed}`);
+    // If this exact cut hung the worker before, do not run it again. Signal the
+    // assembly to surface both parts in red instead of hanging or silently
+    // dropping the cut.
+    if (util.geometryProvider!.isBadCut(resultGeomId, cuttingPart.geometry)) {
+      throw new FailedCutError(
+        resultGeomId,
+        cuttingPart.geometry,
+        partToCut,
+        cuttingPart,
+      );
+    }
     resultGeomId = await util.geometryProvider!.cut(
       resultGeomId,
       cuttingPart.geometry,

--- a/src/worker/progress.ts
+++ b/src/worker/progress.ts
@@ -36,3 +36,44 @@ export function reportCadProgress(label: string): void {
     }
   }
 }
+
+/**
+ * Message type posted by the worker immediately before and after each OCCT
+ * boolean `.cut()` call, carrying the two input geometry ids.
+ *
+ * A synchronous `.cut()` can hang indefinitely and freeze the worker thread; it
+ * can only be stopped by terminating the worker. This beacon lets the main
+ * thread know *which* cut is executing at any instant, so when the inactivity
+ * watchdog fires it can record that exact `(toCut, cutter)` pair as a
+ * known-hanging cut (see CadWorkerManager).
+ */
+export const CAD_BOOLEAN_INFLIGHT_TYPE = "cad-boolean-inflight";
+
+/**
+ * Announce that a boolean `.cut(toCut, cutter)` is about to run (`active=true`)
+ * or has just finished (`active=false`). If the cut hangs, the `active=false`
+ * message never sends (the thread is frozen), so the main thread still sees the
+ * cut as in-flight — exactly what we want for pinpointing the hang.
+ */
+export function reportBooleanInflight(
+  toCut: string,
+  cutter: string,
+  active: boolean,
+): void {
+  if (
+    typeof self !== "undefined" &&
+    typeof (self as any).postMessage === "function" &&
+    typeof (self as any).document === "undefined"
+  ) {
+    try {
+      (self as any).postMessage({
+        type: CAD_BOOLEAN_INFLIGHT_TYPE,
+        toCut,
+        cutter,
+        active,
+      });
+    } catch {
+      // Best-effort; never let it break the operation.
+    }
+  }
+}

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -41,6 +41,15 @@ const started: Promise<boolean> = util.init();
 void started.then(() => util.startHeapMonitor("geometryWorker"));
 
 /**
+ * Replace this worker's set of known-hanging boolean cuts. Called from the main
+ * thread on every (re)start so a fresh worker skips cuts that previously hung
+ * (surfacing the two offending parts in red) instead of hanging again.
+ */
+function setBadCuts(pairs: Array<{ toCut: string; cutter: string }>): void {
+  util.geometryProvider!.setBadCuts(pairs);
+}
+
+/**
  * Returns the z-values of flat faces in the geometry, which can be used for area operations in gcode generation.
  * @param {AbundanceObject} input - The geometry to export
  * @returns {Promise<number[]>} A promise that resolves to an array of z-values corresponding to flat faces in the geometry
@@ -870,6 +879,7 @@ if (
     extractParts,
     sweepCache,
     getAsPoint3D,
+    setBadCuts,
   };
 
   // Gate EVERY exposed worker method on `started` (OCCT WASM init). Until


### PR DESCRIPTION
A synchronous OCCT `.cut()` can hang indefinitely and can only be stopped by terminating the worker.

The worker now posts a `{toCut, cutter}` beacon around each `.cut()`; if it hangs, the watchdog records that pair as known-hanging (persisted to localStorage), restarts, injects the set into the fresh worker, and re-dispatches the same call. On the re-run `recursiveCut` throws `FailedCutError` for the known pair and `assembly()` returns just the two offending leaves in red — the atom resolves loudly instead of hanging, with no wrong geometry and nothing silently skipped. Future loads skip straight to the red result.

**Files:** `progress.ts`, `interaction.ts`, `worker.ts`, plus feature hunks in `geometryProvider.ts` / `cadWorkerManager.js`.

**Stacked on** `pr/cad-worker-diagnostics`. Part 3 of 4.