### PR TITLE
Fix tags dropdown collapse and first-click expand in Render Controls

### DIFF
--- a/src/components/secondary/RenderMenu.jsx
+++ b/src/components/secondary/RenderMenu.jsx
@@ -105,13 +105,15 @@ export default function RenderMenu({
         label: tag,
         value: activeTags.has(tag),
         onChange: (isActive) => {
-          const newActiveTags = new Set(activeTags);
-          if (isActive) {
-            newActiveTags.add(tag);
-          } else {
-            newActiveTags.delete(tag);
-          }
-          setActiveTags(newActiveTags);
+          setActiveTags((prevActiveTags) => {
+            const newActiveTags = new Set(prevActiveTags);
+            if (isActive) {
+              newActiveTags.add(tag);
+            } else {
+              newActiveTags.delete(tag);
+            }
+            return newActiveTags;
+          });
         },
       };
     });
@@ -194,7 +196,6 @@ export default function RenderMenu({
     showBackgroundModel,
     showTopLevelWireframe,
     availableTags,
-    activeTags,
     activeAtom,
   ]);
 

--- a/src/components/secondary/SimpleControlPanel.jsx
+++ b/src/components/secondary/SimpleControlPanel.jsx
@@ -2240,7 +2240,7 @@ export const SimpleControlPanel = forwardRef(function SimpleControlPanel(
                     const toggleGroup = () => {
                       setGroupStates((prev) => ({
                         ...prev,
-                        [key]: !prev[key],
+                        [key]: !(prev?.[key] ?? config.defaultCollapsed ?? false),
                       }));
                     };
                     return (


### PR DESCRIPTION
## Summary\n- keep Tags group open when toggling tags in Render Controls\n- fix group toggle so default-collapsed groups expand on first click\n- avoid control regeneration on every activeTags toggle\n\n## Details\n- update tag onChange to functional state update in RenderMenu\n- remove activeTags from RenderMenu useControls dependency list\n- toggle groups from effective collapsed state in SimpleControlPanel\n\n## Validation\n- build passes with npm run build\n- unit tests mostly pass; existing Vitest browser connection flake still appears near run end