### PR TITLE
Allow Assemblies to contain bare Face entities

### DIFF
--- a/src/worker/actions.ts
+++ b/src/worker/actions.ts
@@ -24,21 +24,40 @@ async function extrude(
     throw new Error("Cannot extrude a Point3D.");
   }
   await util.init();
-  return util.actOnLeafs(toExtrude, async (leaf: AbundanceLeaf) => {
-    const transformed = {
-      ...leaf,
-      geometry: await util.geometryProvider!.extrude(
-        leaf.geometry,
-        leaf.plane,
-        height,
-        context,
-      ),
-      dimension: "3D",
-    };
-    // Delete boundingBox - extrude creates entirely new geometry with different bounds
-    delete transformed.boundingBox;
-    return transformed;
-  });
+  if (util.is2D(toExtrude)) {
+    return util.actOnLeafs(toExtrude, async (leaf: AbundanceLeaf) => {
+      const transformed = {
+        ...leaf,
+        geometry: await util.geometryProvider!.extrude(
+          leaf.geometry,
+          leaf.plane,
+          height,
+          context,
+        ),
+        dimension: "3D",
+      };
+      // Delete boundingBox - extrude creates entirely new geometry with different bounds
+      delete transformed.boundingBox;
+      return transformed;
+    });
+  } else if (util.isFace(toExtrude)) {
+    return util.actOnLeafs(toExtrude, async (leaf: AbundanceLeaf) => {
+      const transformed = {
+        ...leaf,
+        geometry: await util.geometryProvider!.extrudeFace(
+          leaf.geometry,
+          height,
+          context,
+        ),
+        dimension: "3D",
+      };
+      // Delete boundingBox - extrude creates entirely new geometry with different bounds
+      delete transformed.boundingBox;
+      return transformed;
+    });
+  } else {
+    throw new Error("Unknown Geometry Type: " + toExtrude.dimension);
+  }
 }
 
 function handleNonReplicadMove(

--- a/src/worker/geometryProvider.ts
+++ b/src/worker/geometryProvider.ts
@@ -21,7 +21,8 @@ type ReplicadObject =
   | replicad.Shape3D
   | replicad.Drawing
   | replicad.Wire
-  | replicad.Vertex;
+  | replicad.Vertex
+  | replicad.Face;
 
 type RequestContext = {
   project: string;
@@ -464,6 +465,35 @@ class GeometryProvider {
     return extrudedId;
   }
 
+  /**
+   * Extrudes a 2D shape into a 3D volume.
+   * @param inputId - The ID of the 2D geometry to extrude
+   * @param plane - The plane to sketch the shape on
+   * @param height - The height of the extrusion
+   * @returns The ID of the created extruded geometry
+   */
+  async extrudeFace(
+    inputId: string,
+    height: number,
+    context: RequestContext,
+  ): Promise<string> {
+    const extrudedId = this._makeId("extrudeFace", inputId, height);
+    await this.createIfAbsent(extrudedId, context, async () => {
+      const geometry = (await this.get(inputId, context)) as replicad.Face;
+      const midpoint = [
+        geometry.UVBounds.uMin + geometry.UVBounds.uMax,
+        geometry.UVBounds.vMin + geometry.UVBounds.vMax,
+      ].map((v) => v / 2) as [number, number];
+      const extVec = geometry.normalAt(midpoint).normalize().multiply(height);
+      const result = replicad.basicFaceExtrusion(geometry, extVec);
+      if (!replicad.isShape3D(result)) {
+        throw new Error("Face Extrude did not produce a Shape3D");
+      }
+      return result;
+    });
+    return extrudedId;
+  }
+
   async move(
     id: string,
     dx: number,
@@ -811,7 +841,9 @@ class GeometryProvider {
     if (existing) {
       // Prevent self-deadlock if a batch tries to start itself again before settling.
       if (context.operationId === batchId) {
-        throw new Error("Batch operation with id " + batchId + " is already in flight");
+        throw new Error(
+          "Batch operation with id " + batchId + " is already in flight",
+        );
       }
       await existing.promise;
       const afterWait = await this.getAssembly(batchId, context);
@@ -1003,7 +1035,8 @@ class GeometryProvider {
           ? (await this._getAsPoint(endPoint, context)).asTuple()
           : undefined,
       };
-      return replicad.loft(wires, config);
+      const result = replicad.loft(wires, config);
+      return result;
     });
     return loftId;
   }

--- a/src/worker/interaction.ts
+++ b/src/worker/interaction.ts
@@ -292,8 +292,8 @@ async function fusion(
   if (filteredShapes.length === 0) {
     throw new Error("No shapes provided for fusion");
   }
-  const fuseAssemblyd = await fuseAssembly(filteredShapes[0], context);
-  let fusedGeometry = fuseAssemblyd.geometry;
+  const fusedAssembly = await fuseAssembly(filteredShapes[0], context);
+  let fusedGeometry = fusedAssembly.geometry;
   const bomAssembly = filteredShapes[0].bom
     ? filteredShapes[0].bom.slice()
     : [];
@@ -321,7 +321,7 @@ async function fusion(
     bom: bomAssembly,
     plane: util.XYPlane,
     color: util.defaultColor,
-    dimension: fuseAssemblyd.dimension,
+    dimension: fusedAssembly.dimension,
   };
 }
 
@@ -332,7 +332,7 @@ async function fusion(
  */
 async function assembly(
   geometries: AbundanceObject[],
-  context: RequestContext,
+  context: RequestContext
 ): Promise<AbundanceObject> {
   if (!Array.isArray(geometries) || geometries.length === 0) {
     throw new Error("inputIDs must be a non-empty array");
@@ -347,7 +347,7 @@ async function assembly(
   // Allowed inputs -> all 2d, all 3d, or just wires/points
   const geomType = util.validateMixOfTypes(geometries);
   // Fast return if all points or wires.
-  if (geomType === "Mixable") {
+  if (geomType === "Mixable" || geomType === "Face") {
     return util.assemblyOf(geometries);
   }
 

--- a/src/worker/interaction.ts
+++ b/src/worker/interaction.ts
@@ -345,24 +345,10 @@ async function assembly(
 
   // Dimension assertions:
   // Allowed inputs -> all 2d, all 3d, or just wires/points
-  const all3D = geometries.every((geom) => util.is3D(geom));
-  const all2D = geometries.every((geom) => util.is2D(geom));
-  const allWireOrPoint = geometries.every(
-    (geom) => util.isWireGeometry(geom) || util.isPoint3D(geom),
-  );
-  if (!(all2D || all3D || allWireOrPoint)) {
-    throw new Error(
-      "Input geometries must be all 2D, all 3D, or just wires/points.",
-    );
-  }
+  const geomType = util.validateMixOfTypes(geometries);
   // Fast return if all points or wires.
-  if (allWireOrPoint) {
+  if (geomType === "Mixable") {
     return util.assemblyOf(geometries);
-  }
-  if (!(all2D || all3D)) {
-    throw new Error(
-      "Input geometries must be all 2D or all 3D (unless they are wires/points).",
-    );
   }
 
   await util.init();

--- a/src/worker/util.ts
+++ b/src/worker/util.ts
@@ -164,17 +164,19 @@ function isWireGeometry(part: AbundanceObject): boolean {
 
 function validateMixOfTypes(
   geometries: AbundanceObject[],
-): "2D" | "3D" | "Mixable" | undefined {
-  const dimensions = geometries.map((geom) => {
-    const dims: Dimension[] = []
-    actOnLeafsSync(geom, (leaf: AbundanceLeaf) => {
-      dims.push(leaf.dimension);
-      return leaf
-    });
-    return dims;
-  }).flat();
+): "2D" | "3D" | "Face" | "Mixable" | undefined {
+  const dimensions = geometries
+    .map((geom) => {
+      const dims: Dimension[] = [];
+      actOnLeafsSync(geom, (leaf: AbundanceLeaf) => {
+        dims.push(leaf.dimension);
+        return leaf;
+      });
+      return dims;
+    })
+    .flat();
   const constraints = dimensions.map((dim) => {
-    if (dim === "Wire" || dim === "Point3D" || dim === "Face") {
+    if (dim === "Wire" || dim === "Point3D") {
       return "Mixable";
     }
     return dim;
@@ -182,7 +184,7 @@ function validateMixOfTypes(
   const uniqConst = new Set(constraints);
   if (!(uniqConst.size === 1)) {
     throw new Error(
-      "Input geometries must be all 2D, all 3D, or mix of faces/wires/points. Found: " +
+      "Input geometries must be all 2D, all 3D, all Faces, or mix of wires/points. Found: " +
         dimensions.join(", "),
     );
   }

--- a/src/worker/util.ts
+++ b/src/worker/util.ts
@@ -82,13 +82,15 @@ const EMPTY_BOUNDS: AbundanceBounds = {
 
 type AbundanceObject = AbundanceLeaf | AbundanceBranch;
 
+type Dimension = "2D" | "3D" | "Wire" | "Point3D" | "Face";
+
 interface AbundanceBranch {
   geometry: AbundanceObject[];
   plane: SimplePlane;
   color: string;
   tags: string[];
   bom: string[];
-  dimension?: "2D" | "3D" | "Wire" | "Point3D";
+  dimension?: Dimension;
   nonReplicadSerialized?: any;
   boundingBox?: AbundanceBounds;
   metadata?: Record<string, any>;
@@ -96,7 +98,7 @@ interface AbundanceBranch {
 
 interface AbundanceLeaf {
   geometry: string;
-  dimension: "2D" | "3D" | "Wire" | "Point3D";
+  dimension: Dimension;
   plane: SimplePlane;
   color: string;
   tags: string[];
@@ -106,15 +108,19 @@ interface AbundanceLeaf {
   metadata?: Record<string, any>;
 }
 
-function dimensionLabel(geom: any): "2D" | "3D" | "Wire" | "Point3D" {
+function dimensionLabel(geom: any): Dimension {
   if (geom instanceof replicad.Drawing) {
     return "2D";
   } else if (geom instanceof replicad.Wire) {
     return "Wire";
   } else if (geom instanceof replicad.Vertex) {
     return "Point3D";
-  } else if (replicad.isShape3D(geom) || geom instanceof replicad.Face) {
+  } else if (geom instanceof replicad.Face) {
+    return "Face";
+  } else if (replicad.isShape3D(geom)) {
     return "3D";
+  } else if (Array.isArray(geom)) {
+    return dimensionLabel(geom[0]); // recurse down the first child of assembly.
   } else {
     throw new Error(
       "Unsupported geometry type: " +
@@ -125,7 +131,7 @@ function dimensionLabel(geom: any): "2D" | "3D" | "Wire" | "Point3D" {
 
 function _checkFirstDimIs(
   part: AbundanceObject,
-  dimension: "2D" | "3D" | "Wire" | "Point3D",
+  dimension: Dimension,
 ): boolean {
   if (isAssembly(part)) {
     return part.geometry.some((input: AbundanceObject) =>
@@ -144,12 +150,43 @@ function is3D(part: AbundanceObject): boolean {
   return _checkFirstDimIs(part, "3D");
 }
 
+function isFace(part: AbundanceObject): boolean {
+  return _checkFirstDimIs(part, "Face");
+}
+
 function isPoint3D(part: AbundanceObject): boolean {
   return _checkFirstDimIs(part, "Point3D");
 }
 
 function isWireGeometry(part: AbundanceObject): boolean {
   return _checkFirstDimIs(part, "Wire");
+}
+
+function validateMixOfTypes(
+  geometries: AbundanceObject[],
+): "2D" | "3D" | "Mixable" | undefined {
+  const dimensions = geometries.map((geom) => {
+    const dims: Dimension[] = []
+    actOnLeafsSync(geom, (leaf: AbundanceLeaf) => {
+      dims.push(leaf.dimension);
+      return leaf
+    });
+    return dims;
+  }).flat();
+  const constraints = dimensions.map((dim) => {
+    if (dim === "Wire" || dim === "Point3D" || dim === "Face") {
+      return "Mixable";
+    }
+    return dim;
+  });
+  const uniqConst = new Set(constraints);
+  if (!(uniqConst.size === 1)) {
+    throw new Error(
+      "Input geometries must be all 2D, all 3D, or mix of faces/wires/points. Found: " +
+        dimensions.join(", "),
+    );
+  }
+  return uniqConst.values().next().value;
 }
 
 async function getBounds(
@@ -601,6 +638,8 @@ export {
   init,
   is2D,
   is3D,
+  isFace,
+  validateMixOfTypes,
   isAbundanceObject,
   isAssembly,
   isLeaf,


### PR DESCRIPTION
Assemblies can now be made of bare Face entities. This is our one-sided surface representation. Notable limitations come with this type, including: Surfaces cannot cut one another nor can they cut solids (though eventually we may support this via Opencascades half-space api: https://dev.opencascade.org/doc/refman/html/class_b_rep_prim_a_p_i___make_half_space.html which is not currently included in replicad).

Face assemblies are treated similarly to point and wire assemblies in that they can be constructed but don't enforce any disjointness.

None of our default atoms allow users to get a solitary face. But there are some github code atoms which do allow this. In general working with bare faces is expected to be a somewhat infrequent mode. 

The reason we support this at all is that working with solitary faces is more natural and efficient for certain workflows that involve weird shapes like boats, and some high-curvature lofts.

This PR also adds functionality to Extrude so that it can now take a bare face as input and will extrude it into a solid. Extrusions of this kind are in the direction of the normal vector at the face's midpoint. height is set by parameter same as extrude from a face. Notably sometimes the result of a face can be a self-intersecting shape. This is allowed at the moment but might be something we want to change later.