### PR TITLE
Fix duplicate loading

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -847,11 +847,16 @@ function AppContent() {
         // progress log intervals don't keep running after the switch.
         cad.cancelAll();
 
-        if (rawFile.filetypeVersion == 1) {
-          targetMolecule.deserialize(rawFile);
-        } else {
-          // For older file versions, try to deserialize directly for now
-          targetMolecule.deserialize(rawFile);
+        try {
+          if (rawFile.filetypeVersion == 1) {
+            await targetMolecule.deserialize(rawFile);
+          } else {
+            // For older file versions, try to deserialize directly for now
+            await targetMolecule.deserialize(rawFile);
+          }
+        } catch (deserializeError) {
+          targetMolecule.loadedProjectKey = undefined;
+          throw deserializeError;
         }
         GlobalVariables.currentMolecule = targetMolecule;
         GlobalVariables.currentMolecule.selected = true;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -818,17 +818,35 @@ function AppContent() {
         // Reset ID counter to avoid collisions with existing IDs
         GlobalVariables.resetIdCounter(rawFile);
 
+        const targetMolecule = GlobalVariables.topLevelMolecule;
+        const projectKey = `${project.owner}/${project.repoName}`;
+
+        // Guard against duplicate deserialization: multiple components (e.g.
+        // CreateMode and FlowCanvas) can independently call loadProject for
+        // the same project during mount/navigation. Since deserialize() only
+        // appends atoms, calling it twice on the same molecule instance would
+        // place every atom twice, stacked on top of each other. Tagging the
+        // molecule instance with the project it has already loaded (or
+        // started loading) makes repeat calls a no-op.
+        if (targetMolecule.loadedProjectKey === projectKey) {
+          GlobalVariables.currentMolecule = targetMolecule;
+          targetMolecule.selected = true;
+          setActiveAtom(targetMolecule);
+          return;
+        }
+        targetMolecule.loadedProjectKey = projectKey;
+
         // Cancel any in-flight CAD calls from the previous project so their
         // progress log intervals don't keep running after the switch.
         cad.cancelAll();
 
         if (rawFile.filetypeVersion == 1) {
-          GlobalVariables.topLevelMolecule.deserialize(rawFile);
+          targetMolecule.deserialize(rawFile);
         } else {
           // For older file versions, try to deserialize directly for now
-          GlobalVariables.topLevelMolecule.deserialize(rawFile);
+          targetMolecule.deserialize(rawFile);
         }
-        GlobalVariables.currentMolecule = GlobalVariables.topLevelMolecule;
+        GlobalVariables.currentMolecule = targetMolecule;
         GlobalVariables.currentMolecule.selected = true;
         setActiveAtom(GlobalVariables.currentMolecule);
       })

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -820,7 +820,14 @@ function AppContent() {
 
         const targetMolecule = GlobalVariables.topLevelMolecule;
         const projectKey = `${project.owner}/${project.repoName}`;
+        const currentProjectKey =
+          GlobalVariables.currentAWSnode?.owner && GlobalVariables.currentAWSnode?.repoName
+            ? `${GlobalVariables.currentAWSnode.owner}/${GlobalVariables.currentAWSnode.repoName}`
+            : null;
 
+        if (currentProjectKey && currentProjectKey !== projectKey) {
+          return;
+        }
         // Guard against duplicate deserialization: multiple components (e.g.
         // CreateMode and FlowCanvas) can independently call loadProject for
         // the same project during mount/navigation. Since deserialize() only


### PR DESCRIPTION
The previous fix to loading private projects resulted in projects loading twice resulting in all of the atoms being doubled