### PR TITLE
intersection filters assembly 2 based on bounding box before fusing its elements

### DIFF
--- a/src/worker/interaction.ts
+++ b/src/worker/interaction.ts
@@ -266,8 +266,31 @@ async function intersect(
     );
   }
 
+  shape2 = await util.withAssemblyBoundingBoxes(shape2, context);
+  shape1 = await util.withAssemblyBoundingBoxes(shape1, context);
+
+  const shape1Targets = util.flattenAssembly(shape1);
+
+  const filteredShape2Leafs = await util
+    .flattenAssembly(shape2)
+    .filter((intersector) => {
+      return shape1Targets.some((target) =>
+        util.boundsOverlap(target.boundingBox, intersector.boundingBox),
+      );
+    });
+
+  if (filteredShape2Leafs.length === 0) {
+    return util.EMPTY_ASSEMBLY;
+  }
+  const shapeToIntersectWith =
+    filteredShape2Leafs.length == 1
+      ? filteredShape2Leafs[0]
+      : await fuseAssembly(
+          { ...shape2, geometry: filteredShape2Leafs },
+          context,
+        );
+
   return util.actOnLeafs(shape1, async (leaf: AbundanceLeaf) => {
-    const shapeToIntersectWith = await fuseAssembly(shape2, context);
     const resultGeom = await util.geometryProvider!.intersect(
       leaf.geometry,
       shapeToIntersectWith.geometry,
@@ -364,7 +387,7 @@ async function fusion(
  */
 async function assembly(
   geometries: AbundanceObject[],
-  context: RequestContext
+  context: RequestContext,
 ): Promise<AbundanceObject> {
   if (!Array.isArray(geometries) || geometries.length === 0) {
     throw new Error("inputIDs must be a non-empty array");

--- a/src/worker/util.ts
+++ b/src/worker/util.ts
@@ -108,6 +108,22 @@ interface AbundanceLeaf {
   metadata?: Record<string, any>;
 }
 
+const EMPTY_ASSEMBLY: AbundanceObject = {
+  geometry: [],
+  plane: {
+    origin: [0, 0, 0],
+    xDir: [1, 0, 0],
+    normal: [0, 0, 1],
+  },
+  color: defaultColor,
+  tags: [],
+  bom: [],
+  dimension: "3D",
+  nonReplicadSerialized: undefined,
+  boundingBox: EMPTY_BOUNDS,
+  metadata: {},
+};
+
 function dimensionLabel(geom: any): Dimension {
   if (geom instanceof replicad.Drawing) {
     return "2D";
@@ -419,9 +435,9 @@ function actOnLeafsSync(
   if (isLeaf(assembly)) {
     return action(assembly);
   } else {
-    const newChildren = (assembly.geometry as AbundanceObject[]).map((child) =>
-      actOnLeafsSync(child, action),
-    );
+    const newChildren = (assembly.geometry as AbundanceObject[])
+      .map((child) => actOnLeafsSync(child, action))
+      .filter((child) => child !== undefined);
     // Preserve nonReplicadGeom if present
     return {
       ...assembly,
@@ -493,7 +509,6 @@ async function actOnLeafs(
 function flattenAssembly(assembly: AbundanceObject): AbundanceLeaf[] {
   const flattened: AbundanceLeaf[] = [];
   if (assembly == undefined || assembly.geometry == undefined) {
-    console.trace("attempted to flatten empty assembly");
     return flattened;
   }
 
@@ -691,4 +706,5 @@ export {
   withAssemblyBoundingBoxes,
   XYPlane,
   startHeapMonitor,
+  EMPTY_ASSEMBLY,
 };


### PR DESCRIPTION
Optimizes for the case where assembly2 has many parts which are distant from the area of intersection.

There are other optimizations that a can likely be made here. In practice the fuse operation on assembly2 can take a majority of the time of the whole intersect process. Further optimizations may involve constructing different subsets of assembly2 for each component in assembly 1 which is being intersected. But this will require some more extensive measurement, so is left to a later date.