### PR TITLE
PNG capture for thumnail

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -832,7 +832,8 @@ function AppContent() {
         const targetMolecule = GlobalVariables.topLevelMolecule;
         const projectKey = `${project.owner}/${project.repoName}`;
         const currentProjectKey =
-          GlobalVariables.currentAWSnode?.owner && GlobalVariables.currentAWSnode?.repoName
+          GlobalVariables.currentAWSnode?.owner &&
+          GlobalVariables.currentAWSnode?.repoName
             ? `${GlobalVariables.currentAWSnode.owner}/${GlobalVariables.currentAWSnode.repoName}`
             : null;
 
@@ -1025,8 +1026,8 @@ export default function ReplicadApp() {
   return (
     <QueryClientProvider client={queryClient}>
       <DevSettingsProvider>
-        <ThumbnailDialogProvider>
-          <AuthProvider>
+        <AuthProvider>
+          <ThumbnailDialogProvider>
             <AppStateProvider>
               <BrowseSettingsProvider>
                 <FileImportProvider>
@@ -1040,8 +1041,8 @@ export default function ReplicadApp() {
                 </FileImportProvider>
               </BrowseSettingsProvider>
             </AppStateProvider>
-          </AuthProvider>
-        </ThumbnailDialogProvider>
+          </ThumbnailDialogProvider>
+        </AuthProvider>
       </DevSettingsProvider>
     </QueryClientProvider>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,6 +34,7 @@ import {
   ProjectProvider,
   BrowseSettingsProvider,
   FileImportProvider,
+  ThumbnailDialogProvider,
   useRendering,
   useAuth,
   useAppState,
@@ -1014,21 +1015,23 @@ export default function ReplicadApp() {
   return (
     <QueryClientProvider client={queryClient}>
       <DevSettingsProvider>
-        <AuthProvider>
-          <AppStateProvider>
-            <BrowseSettingsProvider>
-              <FileImportProvider>
-                <TutorialProvider>
-                  <RenderingProvider>
-                    <ProgressBarProvider>
-                      <AppContent />
-                    </ProgressBarProvider>
-                  </RenderingProvider>
-                </TutorialProvider>
-              </FileImportProvider>
-            </BrowseSettingsProvider>
-          </AppStateProvider>
-        </AuthProvider>
+        <ThumbnailDialogProvider>
+          <AuthProvider>
+            <AppStateProvider>
+              <BrowseSettingsProvider>
+                <FileImportProvider>
+                  <TutorialProvider>
+                    <RenderingProvider>
+                      <ProgressBarProvider>
+                        <AppContent />
+                      </ProgressBarProvider>
+                    </RenderingProvider>
+                  </TutorialProvider>
+                </FileImportProvider>
+              </BrowseSettingsProvider>
+            </AppStateProvider>
+          </AuthProvider>
+        </ThumbnailDialogProvider>
       </DevSettingsProvider>
     </QueryClientProvider>
   );

--- a/src/components/dialogs/ThumbnailDialog.css
+++ b/src/components/dialogs/ThumbnailDialog.css
@@ -1,0 +1,143 @@
+.thumbnail-dialog-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
+.thumbnail-dialog {
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+  max-width: 600px;
+  width: 90%;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.thumbnail-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.thumbnail-dialog-header h2 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #333;
+}
+
+.thumbnail-dialog-close {
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  color: #666;
+  padding: 0;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+}
+
+.thumbnail-dialog-close:hover {
+  background-color: #f0f0f0;
+  color: #333;
+}
+
+.thumbnail-dialog-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.thumbnail-preview-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f5f5f5;
+  border-radius: 4px;
+  padding: 16px;
+  min-height: 300px;
+}
+
+.thumbnail-preview-image {
+  max-width: 100%;
+  max-height: 400px;
+  object-fit: contain;
+  border-radius: 4px;
+}
+
+.thumbnail-dialog-message {
+  text-align: center;
+  color: #666;
+}
+
+.thumbnail-dialog-message p {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.thumbnail-dialog-message strong {
+  color: #333;
+  font-weight: 600;
+}
+
+.thumbnail-dialog-footer {
+  display: flex;
+  gap: 12px;
+  padding: 16px 20px;
+  border-top: 1px solid #e0e0e0;
+  justify-content: flex-end;
+}
+
+.thumbnail-dialog-btn {
+  padding: 8px 16px;
+  border: none;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.thumbnail-dialog-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.thumbnail-dialog-btn-cancel {
+  background-color: #f0f0f0;
+  color: #333;
+}
+
+.thumbnail-dialog-btn-cancel:hover:not(:disabled) {
+  background-color: #e0e0e0;
+}
+
+.thumbnail-dialog-btn-confirm {
+  background-color: #4a90e2;
+  color: white;
+}
+
+.thumbnail-dialog-btn-confirm:hover:not(:disabled) {
+  background-color: #357abd;
+}

--- a/src/components/dialogs/ThumbnailDialog.jsx
+++ b/src/components/dialogs/ThumbnailDialog.jsx
@@ -56,6 +56,13 @@ export default function ThumbnailDialog({
               Use this screenshot as the default thumbnail for{" "}
               <strong>{projectName || "this project"}</strong>?
             </p>
+            <p
+              className="thumbnail-dialog-warning"
+              style={{ fontSize: "0.8rem", color: "#888888ce" }}
+            >
+              (Doesn't look like you expected? Try changing the camera angle and
+              taking another screenshot.)
+            </p>
           </div>
         </div>
 

--- a/src/components/dialogs/ThumbnailDialog.jsx
+++ b/src/components/dialogs/ThumbnailDialog.jsx
@@ -1,0 +1,81 @@
+import React, { useState } from "react";
+import "./ThumbnailDialog.css";
+
+/**
+ * ThumbnailDialog Component
+ * Displays a screenshot preview and allows user to set it as the default project thumbnail
+ */
+export default function ThumbnailDialog({
+  isOpen,
+  imageDataUrl,
+  onClose,
+  onSetAsThumbnail,
+  projectName,
+}) {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSetAsThumbnail = async () => {
+    setIsLoading(true);
+    try {
+      if (onSetAsThumbnail) {
+        await onSetAsThumbnail(imageDataUrl);
+      }
+    } finally {
+      setIsLoading(false);
+      onClose();
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="thumbnail-dialog-overlay">
+      <div className="thumbnail-dialog">
+        <div className="thumbnail-dialog-header">
+          <h2>Set Project Thumbnail</h2>
+          <button
+            className="thumbnail-dialog-close"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="thumbnail-dialog-content">
+          <div className="thumbnail-preview-container">
+            <img
+              src={imageDataUrl}
+              alt="Screenshot preview"
+              className="thumbnail-preview-image"
+            />
+          </div>
+
+          <div className="thumbnail-dialog-message">
+            <p>
+              Use this screenshot as the default thumbnail for{" "}
+              <strong>{projectName || "this project"}</strong>?
+            </p>
+          </div>
+        </div>
+
+        <div className="thumbnail-dialog-footer">
+          <button
+            className="thumbnail-dialog-btn thumbnail-dialog-btn-cancel"
+            onClick={onClose}
+            disabled={isLoading}
+          >
+            Cancel
+          </button>
+          <button
+            className="thumbnail-dialog-btn thumbnail-dialog-btn-confirm"
+            onClick={handleSetAsThumbnail}
+            disabled={isLoading}
+          >
+            {isLoading ? "Setting..." : "Set as Thumbnail"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/main-routes/LoginMode.jsx
+++ b/src/components/main-routes/LoginMode.jsx
@@ -343,7 +343,7 @@ const FeaturedHighlight = ({ randomFeaturedNode }) => {
         <img
           className="project_image"
           style={{ left: "80%", top: "30%" }}
-          src={randomFeaturedNode.svgURL}
+          src={randomFeaturedNode.pngURL || randomFeaturedNode.svgURL}
           onError={({ currentTarget }) => {
             currentTarget.onerror = null; // prevents looping
             currentTarget.src =
@@ -440,7 +440,7 @@ const FeaturedHighlight = ({ randomFeaturedNode }) => {
             >
               <div className="GitInfoLeft">
                 <img
-                  src={randomFeaturedNode.svgURL}
+                  src={randomFeaturedNode.pngURL || randomFeaturedNode.svgURL}
                   onError={({ currentTarget }) => {
                     currentTarget.onerror = null;
                     currentTarget.src =
@@ -643,22 +643,29 @@ const ProjectDiv = ({
   const imageUrlMap = useMemo(() => {
     const map = new Map();
     nodes.forEach((node) => {
-      if (!node?.svgURL || failedImages.has(node.svgURL)) {
+      // Prefer pngURL if available, otherwise fall back to svgURL
+      const urlToUse = node.pngURL || node.svgURL;
+      const urlKey =
+        node.pngURL || node.svgURL || `${node.owner}/${node.repoName}`;
+
+      if (!urlToUse || failedImages.has(urlToUse)) {
         map.set(
-          node.svgURL || `${node.owner}/${node.repoName}`,
+          urlKey,
           import.meta.env.VITE_APP_PATH_FOR_PICS + "/imgs/defaultThumbnail.svg",
         );
       } else {
-        const separator = node.svgURL.includes("?") ? "&" : "?";
-        map.set(node.svgURL, `${node.svgURL}${separator}cb=${svgCacheBuster}`);
+        const separator = urlToUse.includes("?") ? "&" : "?";
+        map.set(urlKey, `${urlToUse}${separator}cb=${svgCacheBuster}`);
       }
     });
     return map;
   }, [nodes, svgCacheBuster, failedImages]);
 
   const getImageSrc = (node) => {
+    const urlKey =
+      node.pngURL || node.svgURL || `${node.owner}/${node.repoName}`;
     return (
-      imageUrlMap.get(node.svgURL || `${node.owner}/${node.repoName}`) ||
+      imageUrlMap.get(urlKey) ||
       import.meta.env.VITE_APP_PATH_FOR_PICS + "/imgs/defaultThumbnail.svg"
     );
   };

--- a/src/components/main-routes/LoginMode.jsx
+++ b/src/components/main-routes/LoginMode.jsx
@@ -747,17 +747,7 @@ const ProjectDiv = ({
               onError={() => handleImageError(node.svgURL)}
               alt={node.repoName}
             />
-            <div
-              className="symbol-div"
-              style={{
-                display: "flex",
-                height: "100%",
-                position: "absolute",
-                top: "-10px",
-                right: "2px",
-                flexDirection: "column",
-              }}
-            >
+            <div className="symbol-div">
               {/* Ranking */}
               <div
                 className="ranking-icon"

--- a/src/components/main-routes/RunMode.jsx
+++ b/src/components/main-routes/RunMode.jsx
@@ -78,7 +78,8 @@ function updateProjectMetaTags(project) {
   const description =
     project.description ||
     `View ${project.repoName} in Abundance, a web-based CAD platform.`;
-  const imageUrl = project.svgURL || "/public/imgs/abundance_logo.png";
+  const imageUrl =
+    project.pngURL || project.svgURL || "/public/imgs/abundance_logo.png";
   const pageUrl = window.location.href;
 
   document.title = title;

--- a/src/components/render/ScreenshotCaptureComponent.jsx
+++ b/src/components/render/ScreenshotCaptureComponent.jsx
@@ -1,12 +1,25 @@
 import GlobalVariables from "../../js/globalvariables.js";
 import { useScreenshotCapture } from "../../hooks/useScreenshotCapture";
+import { useThumbnailDialog } from "../../contexts/ThumbnailDialogContext";
 
 /**
  * ScreenshotCaptureComponent
  * Mounts inside Canvas and exposes screenshot capture via GlobalVariables
  */
 export default function ScreenshotCaptureComponent() {
-  const { captureHighResScreenshot } = useScreenshotCapture();
+  const { openDialog } = useThumbnailDialog();
+  
+  const handleScreenshotCaptured = (dataUrl) => {
+    const projectName = GlobalVariables.currentAWSnode?.name || "this project";
+    openDialog(dataUrl, projectName, async (imageDataUrl) => {
+      // TODO: Implement thumbnail upload logic here
+      console.log("Setting thumbnail:", imageDataUrl);
+    });
+  };
+
+  const { captureHighResScreenshot } = useScreenshotCapture(
+    handleScreenshotCaptured,
+  );
 
   // Expose the function globally for use in menus and other components
   GlobalVariables.captureHighResScreenshot = captureHighResScreenshot;

--- a/src/components/render/ScreenshotCaptureComponent.jsx
+++ b/src/components/render/ScreenshotCaptureComponent.jsx
@@ -1,0 +1,15 @@
+import GlobalVariables from "../../js/globalvariables.js";
+import { useScreenshotCapture } from "../../hooks/useScreenshotCapture";
+
+/**
+ * ScreenshotCaptureComponent
+ * Mounts inside Canvas and exposes screenshot capture via GlobalVariables
+ */
+export default function ScreenshotCaptureComponent() {
+  const { captureHighResScreenshot } = useScreenshotCapture();
+
+  // Expose the function globally for use in menus and other components
+  GlobalVariables.captureHighResScreenshot = captureHighResScreenshot;
+
+  return null; // This component doesn't render anything
+}

--- a/src/components/render/ThreeContext.jsx
+++ b/src/components/render/ThreeContext.jsx
@@ -6,6 +6,7 @@ import Controls from "./ThreeControls.jsx";
 import BackgroundModel from "./BackgroundModel.jsx";
 import GlobalVariables from "../../js/globalvariables.js";
 import { useRendering, useAuth } from "../../contexts/index.js";
+import ScreenshotCaptureComponent from "./ScreenshotCaptureComponent.jsx";
 
 // We change the default orientation - threejs tends to use Y are the height,
 // while replicad uses Z. This is mostly a representation default.
@@ -83,6 +84,7 @@ export default function ext({ children, cameraZoom, ...otherProps }) {
         />
         {gridParam ? (
           <Grid
+            name="grid"
             position={[0, 0, 0]}
             cellSize={cellSection}
             args={[10000, 10000]}
@@ -97,7 +99,11 @@ export default function ext({ children, cameraZoom, ...otherProps }) {
           />
         ) : null}
 
-        <Controls axesParam={axesParam} enableDamping={false}></Controls>
+        <Controls
+          name="controls"
+          axesParam={axesParam}
+          enableDamping={false}
+        ></Controls>
 
         {!outdatedMesh ? (
           <ambientLight intensity={0.9} />
@@ -114,6 +120,8 @@ export default function ext({ children, cameraZoom, ...otherProps }) {
             unitsKey={unitsKey}
           />
         ) : null}
+
+        <ScreenshotCaptureComponent />
 
         {children}
       </Canvas>

--- a/src/components/render/ThreeControls.jsx
+++ b/src/components/render/ThreeControls.jsx
@@ -7,7 +7,7 @@ import { useRef, useEffect, useState } from "react";
 const Controls = React.memo(
   React.forwardRef(function Controls(
     { axesParam, enableDamping },
-    controlsRef
+    controlsRef,
   ) {
     const { plane, geometryType } = useRendering();
     const [extraPlane, setExtraPlane] = useState(false);
@@ -89,7 +89,11 @@ const Controls = React.memo(
 
         {axesParam && (
           <>
-            <GizmoHelper alignment="bottom-right" margin={[70, 100]}>
+            <GizmoHelper
+              name="gizmo"
+              alignment="bottom-right"
+              margin={[70, 100]}
+            >
               <GizmoViewport
                 axisColors={["#9d4b4b", "#2f7f4f", "#3b5b9d"]}
                 labelColor="white"
@@ -101,7 +105,7 @@ const Controls = React.memo(
         )}
       </>
     );
-  })
+  }),
 );
 
 export default Controls;

--- a/src/components/secondary/GitSearchMenu.jsx
+++ b/src/components/secondary/GitSearchMenu.jsx
@@ -475,7 +475,11 @@ export default function GitSearchMenu({
         >
           <div className="GitInfoLeft">
             <img
-              src={panelItem.isLocal ? panelItem.iconPath : panelItem.svgURL}
+              src={
+                panelItem.isLocal
+                  ? panelItem.iconPath
+                  : panelItem.pngURL || panelItem.svgURL
+              }
               onError={({ currentTarget }) => {
                 currentTarget.onerror = null; // prevents looping
                 currentTarget.src = "/imgs/defaultThumbnail.svg";

--- a/src/components/secondary/RenderMenu.jsx
+++ b/src/components/secondary/RenderMenu.jsx
@@ -189,7 +189,7 @@ export default function RenderMenu({
       label: "📸 Capture Screenshot (4K)",
       onClick: () => {
         if (GlobalVariables.captureHighResScreenshot) {
-          GlobalVariables.captureHighResScreenshot(3840, 2160);
+          GlobalVariables.captureHighResScreenshot(1000, 1000); // Capture a 4K screenshot
         }
       },
     },

--- a/src/components/secondary/RenderMenu.jsx
+++ b/src/components/secondary/RenderMenu.jsx
@@ -184,6 +184,15 @@ export default function RenderMenu({
         setShowTopLevelWireframe(value);
       },
     },
+    screenshot: {
+      type: "button",
+      label: "📸 Capture Screenshot (4K)",
+      onClick: () => {
+        if (GlobalVariables.captureHighResScreenshot) {
+          GlobalVariables.captureHighResScreenshot(3840, 2160);
+        }
+      },
+    },
   };
 
   const [

--- a/src/components/secondary/RenderMenu.jsx
+++ b/src/components/secondary/RenderMenu.jsx
@@ -186,7 +186,7 @@ export default function RenderMenu({
     },
     screenshot: {
       type: "button",
-      label: "📸",
+      label: "📸 Set New Project Thumbnail",
       onClick: () => {
         if (GlobalVariables.captureHighResScreenshot) {
           GlobalVariables.captureHighResScreenshot(1000, 1000); // Capture a 4K screenshot

--- a/src/components/secondary/RenderMenu.jsx
+++ b/src/components/secondary/RenderMenu.jsx
@@ -186,7 +186,7 @@ export default function RenderMenu({
     },
     screenshot: {
       type: "button",
-      label: "📸 Capture Screenshot (4K)",
+      label: "📸",
       onClick: () => {
         if (GlobalVariables.captureHighResScreenshot) {
           GlobalVariables.captureHighResScreenshot(1000, 1000); // Capture a 4K screenshot

--- a/src/contexts/ThumbnailDialogContext.jsx
+++ b/src/contexts/ThumbnailDialogContext.jsx
@@ -1,11 +1,13 @@
 import React, { createContext, useContext, useState } from "react";
 import ThumbnailDialog from "../components/dialogs/ThumbnailDialog.jsx";
+import GlobalVariables from "../js/globalvariables.js";
+import { useAuth } from "./AuthContext.jsx";
 
 const ThumbnailDialogContext = createContext();
 
 /**
  * ThumbnailDialogProvider
- * Manages the state and display of the thumbnail dialog
+ * Manages the state and display of the thumbnail dialog and thumbnail upload
  */
 export function ThumbnailDialogProvider({ children }) {
   const [isOpen, setIsOpen] = useState(false);
@@ -13,6 +15,7 @@ export function ThumbnailDialogProvider({ children }) {
   const [projectName, setProjectName] = useState(null);
   const [onSetAsThumbnailCallback, setOnSetAsThumbnailCallback] =
     useState(null);
+  const { authorizedUserOcto } = useAuth();
 
   const openDialog = (dataUrl, projectTitle = null, callback = null) => {
     setImageDataUrl(dataUrl);
@@ -28,6 +31,93 @@ export function ThumbnailDialogProvider({ children }) {
     setOnSetAsThumbnailCallback(null);
   };
 
+  const handleSetAsThumbnail = async (imageDataUrl) => {
+    try {
+      // Convert data URL to base64
+      const base64Data = imageDataUrl.split(",")[1];
+
+      const owner = GlobalVariables.currentAWSnode.owner;
+      const repo = GlobalVariables.currentAWSnode.repoName;
+
+      // Try to get existing file SHA (needed for updates)
+      let sha = null;
+      try {
+        const existingFile = await authorizedUserOcto.rest.repos.getContent({
+          owner,
+          repo,
+          path: "project.png",
+        });
+        sha = existingFile.data.sha;
+      } catch (err) {
+        // File doesn't exist yet, that's fine - we'll create it
+        if (err.status !== 404) {
+          throw err;
+        }
+      }
+
+      // Upload project.png to GitHub repo
+      const uploadParams = {
+        owner,
+        repo,
+        path: "project.png",
+        message: "Update project thumbnail",
+        content: base64Data,
+      };
+
+      // Include SHA if file exists (for updates)
+      if (sha) {
+        uploadParams.sha = sha;
+      }
+
+      const result =
+        await authorizedUserOcto.rest.repos.createOrUpdateFileContents(
+          uploadParams,
+        );
+
+      // Construct the download URL for the uploaded file
+      const downloadUrl = `https://raw.githubusercontent.com/${owner}/${repo}/main/project.png`;
+      console.log("Thumbnail uploaded successfully:", downloadUrl);
+
+      // Update AWS item with pngURL
+      try {
+        const apiUpdateUrl =
+          "https://hg5gsgv9te.execute-api.us-east-2.amazonaws.com/abundance-stage/update-item";
+
+        // Call the update API or method
+        const response = await fetch(apiUpdateUrl, {
+          method: "POST",
+          body: JSON.stringify({
+            owner: owner,
+            repoName: repo,
+            attributeUpdates: {
+              pngURL: downloadUrl,
+            },
+          }),
+          headers: {
+            "Content-type": "application/json; charset=UTF-8",
+          },
+        });
+
+        if (!response.ok) {
+          throw new Error(`Failed to update AWS item: ${response.statusText}`);
+        }
+
+        console.log("AWS item updated with pngURL:", downloadUrl);
+      } catch (err) {
+        console.error("Error updating AWS item:", err);
+        // Don't throw here - file was uploaded successfully even if AWS update fails
+      }
+
+      // Call the original callback if provided
+      if (onSetAsThumbnailCallback) {
+        await onSetAsThumbnailCallback(imageDataUrl);
+      }
+    } catch (error) {
+      console.error("Error uploading thumbnail:", error);
+      throw error;
+    }
+  };
+
   const value = {
     openDialog,
     closeDialog,
@@ -41,7 +131,7 @@ export function ThumbnailDialogProvider({ children }) {
         imageDataUrl={imageDataUrl}
         projectName={projectName}
         onClose={closeDialog}
-        onSetAsThumbnail={onSetAsThumbnailCallback}
+        onSetAsThumbnail={handleSetAsThumbnail}
       />
     </ThumbnailDialogContext.Provider>
   );

--- a/src/contexts/ThumbnailDialogContext.jsx
+++ b/src/contexts/ThumbnailDialogContext.jsx
@@ -1,0 +1,61 @@
+import React, { createContext, useContext, useState } from "react";
+import ThumbnailDialog from "../components/dialogs/ThumbnailDialog.jsx";
+
+const ThumbnailDialogContext = createContext();
+
+/**
+ * ThumbnailDialogProvider
+ * Manages the state and display of the thumbnail dialog
+ */
+export function ThumbnailDialogProvider({ children }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [imageDataUrl, setImageDataUrl] = useState(null);
+  const [projectName, setProjectName] = useState(null);
+  const [onSetAsThumbnailCallback, setOnSetAsThumbnailCallback] =
+    useState(null);
+
+  const openDialog = (dataUrl, projectTitle = null, callback = null) => {
+    setImageDataUrl(dataUrl);
+    setProjectName(projectTitle);
+    setOnSetAsThumbnailCallback(() => callback);
+    setIsOpen(true);
+  };
+
+  const closeDialog = () => {
+    setIsOpen(false);
+    setImageDataUrl(null);
+    setProjectName(null);
+    setOnSetAsThumbnailCallback(null);
+  };
+
+  const value = {
+    openDialog,
+    closeDialog,
+  };
+
+  return (
+    <ThumbnailDialogContext.Provider value={value}>
+      {children}
+      <ThumbnailDialog
+        isOpen={isOpen}
+        imageDataUrl={imageDataUrl}
+        projectName={projectName}
+        onClose={closeDialog}
+        onSetAsThumbnail={onSetAsThumbnailCallback}
+      />
+    </ThumbnailDialogContext.Provider>
+  );
+}
+
+/**
+ * Hook to use the ThumbnailDialogContext
+ */
+export function useThumbnailDialog() {
+  const context = useContext(ThumbnailDialogContext);
+  if (!context) {
+    throw new Error(
+      "useThumbnailDialog must be used within a ThumbnailDialogProvider",
+    );
+  }
+  return context;
+}

--- a/src/contexts/index.js
+++ b/src/contexts/index.js
@@ -5,3 +5,4 @@ export { AppStateProvider, useAppState } from './AppStateContext.jsx';
 export { ProjectProvider, useProject } from './ProjectContext.jsx';
 export { BrowseSettingsProvider, useBrowseSettings } from './BrowseSettingsContext.jsx';
 export { FileImportProvider, useFileImport } from './FileImportContext.jsx';
+export { ThumbnailDialogProvider, useThumbnailDialog } from './ThumbnailDialogContext.jsx';

--- a/src/hooks/useScreenshotCapture.js
+++ b/src/hooks/useScreenshotCapture.js
@@ -71,12 +71,12 @@ export function useScreenshotCapture(onCaptureCallback) {
       const dataURL = canvas.toDataURL("image/png", 0.7); // Use 0.5 quality for PNG to reduce file size
 
       //download the image automatically
-      const link = document.createElement("a");
-      link.href = dataURL;
-      link.download = "screenshot.png";
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
+      // const link = document.createElement("a");
+      // link.href = dataURL;
+      // link.download = "screenshot.png";
+      // document.body.appendChild(link);
+      // link.click();
+      // document.body.removeChild(link);
 
       // Step 7: Cleanup and trigger dialog via callback
       tempRenderer.dispose();

--- a/src/hooks/useScreenshotCapture.js
+++ b/src/hooks/useScreenshotCapture.js
@@ -6,13 +6,14 @@ import * as THREE from "three";
  * Excludes grid, axes, background models, and other helper objects.
  * Must be used inside a Canvas component from @react-three/fiber.
  *
+ * @param {function} onCaptureCallback - Callback function called when screenshot is captured. Receives { dataUrl, projectName }
  * @returns {object} Object containing captureHighResScreenshot function
  *
  * Usage:
- *   const { captureHighResScreenshot } = useScreenshotCapture();
+ *   const { captureHighResScreenshot } = useScreenshotCapture(onScreenshotCallback);
  *   captureHighResScreenshot(3840, 2160); // captures at 4K resolution
  */
-export function useScreenshotCapture() {
+export function useScreenshotCapture(onCaptureCallback) {
   const { scene, camera } = useThree();
 
   const captureHighResScreenshot = (width = 3840, height = 2160) => {
@@ -56,28 +57,16 @@ export function useScreenshotCapture() {
       const canvas = tempRenderer.domElement;
       const dataURL = canvas.toDataURL("image/png", 0.95); // High quality
 
-      // Step 6: Download the screenshot
-      fetch(dataURL)
-        .then((res) => res.blob())
-        .then((blob) => {
-          const url = URL.createObjectURL(blob);
-          const a = document.createElement("a");
-          a.href = url;
-          a.download = `abundance-screenshot-${width}x${height}-${Date.now()}.jpg`;
-          document.body.appendChild(a);
-          a.click();
-          URL.revokeObjectURL(url);
-          document.body.removeChild(a);
-        })
-        .catch((err) =>
-          console.error("Error capturing high-res screenshot:", err),
-        )
-        .finally(() => {
-          // Cleanup: Dispose of the temporary renderer to free GPU memory
-          tempRenderer.dispose();
-        });
+      // Step 6: Cleanup and trigger dialog via callback
+      tempRenderer.dispose();
+      
+      // Call the callback with the screenshot data
+      if (onCaptureCallback) {
+        onCaptureCallback(dataURL);
+      }
     } catch (error) {
       console.error("Error in captureHighResScreenshot:", error);
+      return null;
     }
   };
 

--- a/src/hooks/useScreenshotCapture.js
+++ b/src/hooks/useScreenshotCapture.js
@@ -22,7 +22,7 @@ export function useScreenshotCapture(onCaptureCallback) {
       const visibilityState = new Map();
       const objectsToHide = ["grid"]; // Named objects to exclude from screenshot
       const typesToHide = ["AxesHelper", "GizmoHelper", "BackgroundModel"]; // Types of objects to exclude
-
+      scene.background = null; // Set background to transparent for screenshot
       scene.traverse((obj) => {
         visibilityState.set(obj, obj.visible);
         // Hide objects by name
@@ -40,10 +40,11 @@ export function useScreenshotCapture(onCaptureCallback) {
       const tempRenderer = new THREE.WebGLRenderer({
         preserveDrawingBuffer: true,
         antialias: true,
+        alpha: true,
       });
       tempRenderer.setSize(width, height);
       tempRenderer.setPixelRatio(1); // Disable automatic scaling for consistent resolution
-      tempRenderer.setClearColor(0xf5f5f5); // Match ThreeContext background
+      //tempRenderer.setClearColor(0xf5f5f5); // Match ThreeContext background
 
       // Step 3: Create a perspective camera with the same position and rotation as the existing camera
       const perspectiveCamera = new THREE.PerspectiveCamera(
@@ -55,7 +56,7 @@ export function useScreenshotCapture(onCaptureCallback) {
       perspectiveCamera.position.copy(camera.position);
       perspectiveCamera.rotation.copy(camera.rotation);
       perspectiveCamera.quaternion.copy(camera.quaternion);
-      perspectiveCamera.zoom = camera.zoom * 15; // Match zoom level
+      perspectiveCamera.zoom = camera.zoom * 20; // Match zoom level
       perspectiveCamera.updateProjectionMatrix();
 
       // Step 4: Render the scene with the temporary renderer and perspective camera

--- a/src/hooks/useScreenshotCapture.js
+++ b/src/hooks/useScreenshotCapture.js
@@ -45,21 +45,42 @@ export function useScreenshotCapture(onCaptureCallback) {
       tempRenderer.setPixelRatio(1); // Disable automatic scaling for consistent resolution
       tempRenderer.setClearColor(0xf5f5f5); // Match ThreeContext background
 
-      // Step 3: Render the scene with the temporary renderer
-      tempRenderer.render(scene, camera);
+      // Step 3: Create a perspective camera with the same position and rotation as the existing camera
+      const perspectiveCamera = new THREE.PerspectiveCamera(
+        75, // fov
+        width / height, // aspect ratio
+        0.1, // near
+        90000, // far - match the existing camera's far plane
+      );
+      perspectiveCamera.position.copy(camera.position);
+      perspectiveCamera.rotation.copy(camera.rotation);
+      perspectiveCamera.quaternion.copy(camera.quaternion);
+      perspectiveCamera.zoom = camera.zoom * 15; // Match zoom level
+      perspectiveCamera.updateProjectionMatrix();
 
-      // Step 4: Restore visibility state of all objects
+      // Step 4: Render the scene with the temporary renderer and perspective camera
+      tempRenderer.render(scene, perspectiveCamera);
+
+      // Step 5: Restore visibility state of all objects
       visibilityState.forEach((visible, obj) => {
         obj.visible = visible;
       });
 
-      // Step 5: Capture the temporary canvas
+      // Step 6: Capture the temporary canvas
       const canvas = tempRenderer.domElement;
-      const dataURL = canvas.toDataURL("image/png", 0.95); // High quality
+      const dataURL = canvas.toDataURL("image/png", 0.5); // Use 0.5 quality for PNG to reduce file size
 
-      // Step 6: Cleanup and trigger dialog via callback
+      //download the image automatically
+      const link = document.createElement("a");
+      link.href = dataURL;
+      link.download = "screenshot.png";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+
+      // Step 7: Cleanup and trigger dialog via callback
       tempRenderer.dispose();
-      
+
       // Call the callback with the screenshot data
       if (onCaptureCallback) {
         onCaptureCallback(dataURL);

--- a/src/hooks/useScreenshotCapture.js
+++ b/src/hooks/useScreenshotCapture.js
@@ -68,7 +68,7 @@ export function useScreenshotCapture(onCaptureCallback) {
 
       // Step 6: Capture the temporary canvas
       const canvas = tempRenderer.domElement;
-      const dataURL = canvas.toDataURL("image/png", 0.5); // Use 0.5 quality for PNG to reduce file size
+      const dataURL = canvas.toDataURL("image/png", 0.7); // Use 0.5 quality for PNG to reduce file size
 
       //download the image automatically
       const link = document.createElement("a");

--- a/src/hooks/useScreenshotCapture.js
+++ b/src/hooks/useScreenshotCapture.js
@@ -1,0 +1,85 @@
+import { useThree } from "@react-three/fiber";
+import * as THREE from "three";
+
+/**
+ * Custom hook to capture high-resolution screenshots of only the mesh geometry.
+ * Excludes grid, axes, background models, and other helper objects.
+ * Must be used inside a Canvas component from @react-three/fiber.
+ *
+ * @returns {object} Object containing captureHighResScreenshot function
+ *
+ * Usage:
+ *   const { captureHighResScreenshot } = useScreenshotCapture();
+ *   captureHighResScreenshot(3840, 2160); // captures at 4K resolution
+ */
+export function useScreenshotCapture() {
+  const { scene, camera } = useThree();
+
+  const captureHighResScreenshot = (width = 3840, height = 2160) => {
+    try {
+      // Step 1: Save visibility state and hide UI helper objects by name
+      const visibilityState = new Map();
+      const objectsToHide = ["grid"]; // Named objects to exclude from screenshot
+      const typesToHide = ["AxesHelper", "GizmoHelper", "BackgroundModel"]; // Types of objects to exclude
+
+      scene.traverse((obj) => {
+        visibilityState.set(obj, obj.visible);
+        // Hide objects by name
+        if (objectsToHide.includes(obj.name)) {
+          obj.visible = false;
+        }
+
+        // Hide objects by type
+        if (typesToHide.includes(obj.type)) {
+          obj.visible = false;
+        }
+      });
+
+      // Step 2: Create a temporary renderer with high resolution
+      const tempRenderer = new THREE.WebGLRenderer({
+        preserveDrawingBuffer: true,
+        antialias: true,
+      });
+      tempRenderer.setSize(width, height);
+      tempRenderer.setPixelRatio(1); // Disable automatic scaling for consistent resolution
+      tempRenderer.setClearColor(0xf5f5f5); // Match ThreeContext background
+
+      // Step 3: Render the scene with the temporary renderer
+      tempRenderer.render(scene, camera);
+
+      // Step 4: Restore visibility state of all objects
+      visibilityState.forEach((visible, obj) => {
+        obj.visible = visible;
+      });
+
+      // Step 5: Capture the temporary canvas
+      const canvas = tempRenderer.domElement;
+      const dataURL = canvas.toDataURL("image/png", 0.95); // High quality
+
+      // Step 6: Download the screenshot
+      fetch(dataURL)
+        .then((res) => res.blob())
+        .then((blob) => {
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement("a");
+          a.href = url;
+          a.download = `abundance-screenshot-${width}x${height}-${Date.now()}.jpg`;
+          document.body.appendChild(a);
+          a.click();
+          URL.revokeObjectURL(url);
+          document.body.removeChild(a);
+        })
+        .catch((err) =>
+          console.error("Error capturing high-res screenshot:", err),
+        )
+        .finally(() => {
+          // Cleanup: Dispose of the temporary renderer to free GPU memory
+          tempRenderer.dispose();
+        });
+    } catch (error) {
+      console.error("Error in captureHighResScreenshot:", error);
+    }
+  };
+
+  return { captureHighResScreenshot };
+}

--- a/src/styles/login.css
+++ b/src/styles/login.css
@@ -856,6 +856,15 @@
   width: 100%;
 }
 
+.symbol-div {
+  display: flex;
+  height: 100%;
+  position: absolute;
+  top: -0.5em;
+  right: 0rem;
+  flex-direction: column;
+}
+
 .project {
   text-wrap: nowrap;
   background-color: var(--loginPopup-projectColor);
@@ -893,10 +902,10 @@
   display: block;
   position: absolute;
   padding: 0;
-  width: 70px;
-  height: 50px;
-  left: 20px;
-  top: 10px;
+  width: 80px;
+  height: 80px;
+  left: 10px;
+  top: 0px;
 }
 
 .browseDiv {


### PR DESCRIPTION
Allows for PNG thumnails to be set by the project owner. If a png is saved to github and aws, the project will use it as a default thumnail instead of the svg which we still save. Might switch to automatically saving pngs but because it depends on camera position this seems like a good start.

- [x] Set up png capture from a temporary threejs render (use perspective camera, hide grid and helpers)
- [x] Button to capture + dialog to confirm thumnail default
- [x] Update github by commiting png as new file, "project.png"
- [x] Update aws image path to check for png before checking for svg and use png if available. 
- [x] Set project path thumnail to default to png for sharing purposes.
- [x] update login screen & gitsearch to look for png before looking for svg