### PR TITLE
Fix issue that caused cache misses for code atoms on reload.

### DIFF
--- a/src/worker/code.ts
+++ b/src/worker/code.ts
@@ -347,12 +347,7 @@ function composeCacheKey(code: string, args: { [key: string]: any }) {
   const argString = Object.entries(args)
     .map(([k, v]) => `${k}:${JSON.stringify(v)}`)
     .join("-");
-  const result = util.hashString(code + "-" + argString);
-  console.log("composing cache key for code atom. code, args, result");
-  console.log("hashtest - ", code);
-  console.log("hashtest - ", argString);
-  console.log("hashtest - ", result);
-  return result;
+  return util.hashString(code + "-" + argString);
 }
 
 async function executeTsCode(

--- a/src/worker/code.ts
+++ b/src/worker/code.ts
@@ -347,7 +347,12 @@ function composeCacheKey(code: string, args: { [key: string]: any }) {
   const argString = Object.entries(args)
     .map(([k, v]) => `${k}:${JSON.stringify(v)}`)
     .join("-");
-  return util.hashString(code + "-" + argString);
+  const result = util.hashString(code + "-" + argString);
+  console.log("composing cache key for code atom. code, args, result");
+  console.log("hashtest - ", code);
+  console.log("hashtest - ", argString);
+  console.log("hashtest - ", result);
+  return result;
 }
 
 async function executeTsCode(
@@ -405,6 +410,47 @@ async function executeTsCode(
           };
         })()
       : console;
+
+    const passThroughKeys = [
+      "geometry",
+      "plane",
+      "tags",
+      "bom",
+      "color",
+      "selection",
+      "metadata",
+    ];
+    const helper = (obj: AbundanceObject): AbundanceObject => {
+      if (util.isLeaf(obj)) {
+        return Object.fromEntries(
+          Object.entries(obj).filter(([key]) => passThroughKeys.includes(key)),
+        ) as util.AbundanceLeaf;
+      } else {
+        // is branch
+        const children = obj.geometry.map(helper);
+        const filtered = Object.fromEntries(
+          Object.entries(obj).filter(([key]) => passThroughKeys.includes(key)),
+        );
+        return {
+          ...filtered,
+          geometry: children,
+        } as AbundanceObject;
+      }
+    };
+
+    // filter AbundanceObject arguments down to just the properties which are passed
+    // through to code atoms and exclude the rest since differences there are
+    // by definition nonimpactful to the result. In particular this is important
+    // for bounding boxes which can be in an initialized or uninitialized state.
+    argumentsArray = Object.fromEntries(
+      Object.entries(argumentsArray).map(([key, val]) => {
+        if (util.isAbundanceObject(val)) {
+          return [key, helper(val)];
+        } else {
+          return [key, val];
+        }
+      }),
+    );
 
     // Check cache for result of this code atom before doing any heavy work like
     // materializing arguments or launching the sandbox.


### PR DESCRIPTION
Bounding box values seemingly can be initialized to different states (all zeroes or all null) which was causing issues on code atoms because we hash the args as part of the cache key. So on a reload the bounding box may have landed in a different state causing the hash to change even though there is no logical difference for the code atom.

This fix strips out all contents of the input args which are not passed through to the code atom before composing the cache key. Bounding boxes weren't passed into the code context so this prevents them from disrupting the hash without any behavior change for code atoms.