### PR TITLE
Fix SVG import failing on fresh upload

### DIFF
--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -396,17 +396,20 @@ async function importingSTL(
 
 /**
  * Imports an SVG file and creates 2D geometry, then stores it in the library.
- * @param {string} svg - The SVG content as a string
+ * @param {string|Blob} svg - The SVG content, either as a string or as the
+ * uploaded File/Blob (fresh uploads hand us the File directly)
  * @param {number} width - The width to scale the SVG to
  * @throws {Error} Throws an error if the SVG import fails
  */
 async function importingSVG(
-  svg: string,
+  svg: string | Blob,
   context: RequestContext,
   width: number,
 ): Promise<AbundanceObject> {
   await started;
-  const svgString = svg;
+  // The SVG parser only accepts a string, but callers coming from a fresh
+  // upload pass the File through untouched, so read it here.
+  const svgString = typeof svg === "string" ? svg : await svg.text();
 
   try {
     const drawnSVG = await drawSVG(svgString, { width: width });
@@ -417,7 +420,7 @@ async function importingSVG(
         drawnSVG.clone().translate(-center[0], -center[1]),
         context,
         "import-svg",
-        [await util.hashString(svg), width],
+        [await util.hashString(svgString), width],
       ),
       tags: [],
       plane: util.XYPlane,

--- a/tests/svg-import-file-object.test.js
+++ b/tests/svg-import-file-object.test.js
@@ -1,0 +1,31 @@
+import { importingSVG } from "../src/worker/worker.ts";
+import { init } from "../src/worker/util.ts";
+
+// A single-path SVG of the kind exported by cutline tools
+const SVG_CONTENT = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50" width="100" height="50"><path d="M 10 10 L 90 10 L 90 40 L 10 40 Z" fill="#1a7a3a"/></svg>`;
+
+describe("importingSVG", () => {
+  beforeAll(async () => {
+    await init();
+  });
+
+  it("imports an SVG passed as a string", async () => {
+    const result = await importingSVG(SVG_CONTENT, { project: "test" }, 100);
+
+    expect(result.dimension).toEqual("2D");
+    expect(result.geometry).toBeTruthy();
+  });
+
+  // A fresh upload hands the File straight to the worker rather than reading
+  // it into a string first, which used to blow up inside the SVG parser.
+  it("imports an SVG passed as a File", async () => {
+    const file = new File([SVG_CONTENT], "cutline.svg", {
+      type: "image/svg+xml",
+    });
+
+    const result = await importingSVG(file, { project: "test" }, 100);
+
+    expect(result.dimension).toEqual("2D");
+    expect(result.geometry).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## What changed

`importingSVG` in the worker now accepts either a string or a `Blob`/`File`, reading the blob to text before handing it to the SVG parser. The geometry cache key hashes the resolved string rather than the raw argument.

## Why

Importing an SVG failed immediately after uploading it, with this in the console:

```
[xmldom error]	invalid doc source
Error importing SVG: TypeError: can't access property "getElementsByTagName", s is undefined
```

`importingSVG` expects the SVG **as a string**. Every path that loads a file from GitHub decodes it to text first — `import.js` returns the decoded text for SVG, and `input.js` uses the stored `localFileContent`. But the two "fresh upload" fast paths added to avoid CDN propagation 404s pass the raw `File` object straight through:

- `updateFile` in `src/molecules/import.js`
- `processFileFromBlob` in `src/molecules/input.js`

xmldom's `DOMParser` got a `File` instead of markup, logged `invalid doc source`, returned `undefined`, and the next line threw. This is why the failure only showed up on the initial upload — reloading the project afterwards worked, since that path goes through GitHub and gets text.

The fix is applied once at the worker boundary rather than at each call site, so any future caller is covered too.

## Notes for reviewers

- Hashing `svgString` instead of `svg` is a deliberate part of the fix: hashing a `File` object would not have produced a content-stable key, so an upload and a later reload of the same file now agree on the cache entry.
- `tests/svg-import-file-object.test.js` covers both the string and `File` paths. With the fix reverted, the `File` case reproduces the reported error exactly; with the fix, both pass.

```bash
npx vitest --config=vitest.headless.config.ts run tests/svg-import-file-object.test.js
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)