### PR TITLE
Various small fixits

### DIFF
--- a/src/molecules/input.js
+++ b/src/molecules/input.js
@@ -3,6 +3,7 @@ import GlobalVariables from "../js/globalvariables.js";
 import { Status } from "../prototypes/observableEntity.js";
 import { ValueChangeCommand } from "../js/undoCommands.js";
 import { Octokit } from "octokit";
+import { hashAssembly } from "../worker/util.ts";
 
 // Default values for range type inputs
 const DEFAULT_RANGE_MIN = 0;
@@ -95,10 +96,6 @@ export default class Input extends Atom {
      * @type {Object.<number, number[]>}
      */
     this.selectedFaceData = {};
-
-    // True when a new upstream connection is awaiting its first READY value
-    // so its existing selection flags can be inherited.
-    this._pendingSelectionInheritance = false;
 
     /**
      * Flag indicating if the name text is currently truncated
@@ -361,10 +358,7 @@ export default class Input extends Atom {
       // For partselect type, transform the incoming geometry with selection flags
       if (this.type === "partselect") {
         if (parentState.status === Status.READY && parentState.value != null) {
-          if (this._pendingSelectionInheritance) {
-            this.inheritSelectionFromAssembly(parentState.value);
-            this._pendingSelectionInheritance = false;
-          }
+          this.inheritSelectionFromAssembly(parentState.value);
           const transformed = this.applyPartSelection(
             parentState.value,
             this.selectedLeafIndexes,
@@ -380,10 +374,7 @@ export default class Input extends Atom {
       // For edgeselect type
       if (this.type === "edgeselect") {
         if (parentState.status === Status.READY && parentState.value != null) {
-          if (this._pendingSelectionInheritance) {
-            this.inheritSelectionFromAssembly(parentState.value);
-            this._pendingSelectionInheritance = false;
-          }
+          this.inheritSelectionFromAssembly(parentState.value);
           const transformed = this.applyEdgeSelection(
             parentState.value,
             this.selectedEdgeData,
@@ -399,10 +390,7 @@ export default class Input extends Atom {
       // For faceselect type
       if (this.type === "faceselect") {
         if (parentState.status === Status.READY && parentState.value != null) {
-          if (this._pendingSelectionInheritance) {
-            this.inheritSelectionFromAssembly(parentState.value);
-            this._pendingSelectionInheritance = false;
-          }
+          this.inheritSelectionFromAssembly(parentState.value);
           const transformed = this.applyFaceSelection(
             parentState.value,
             this.selectedFaceData,
@@ -530,7 +518,6 @@ export default class Input extends Atom {
     this.selectedLeafIndexes = [];
     this.selectedEdgeData = {};
     this.selectedFaceData = {};
-    this._pendingSelectionInheritance = false;
     GlobalVariables.bumpSelectionVersion();
     if (typeof this._panelSetInputChanged === "function") {
       this._panelSetInputChanged(String(Date.now()));
@@ -547,7 +534,6 @@ export default class Input extends Atom {
     this.selectedLeafIndexes = [];
     this.selectedEdgeData = {};
     this.selectedFaceData = {};
-    this._pendingSelectionInheritance = true;
     GlobalVariables.bumpSelectionVersion();
     if (typeof this._panelSetInputChanged === "function") {
       this._panelSetInputChanged(String(Date.now()));
@@ -561,6 +547,10 @@ export default class Input extends Atom {
    * (e.g. produced by a code atom) starts populated instead of empty.
    */
   inheritSelectionFromAssembly(assembly) {
+    if (hashAssembly(this.value) == hashAssembly(assembly)) {
+      // no-op if the upstream is identical to prior.
+      return;
+    }
     const leafIndexes = [];
     const edgeData = {};
     const faceData = {};
@@ -579,9 +569,20 @@ export default class Input extends Atom {
       }
     };
     walk(assembly);
-    this.selectedLeafIndexes = leafIndexes;
-    this.selectedEdgeData = edgeData;
-    this.selectedFaceData = faceData;
+    // if upstream doesn't have a selection defer to our existing selection
+    // state
+    if (leafIndexes.length > 0) {
+      this.selectedLeafIndexes = leafIndexes;
+    }
+    if (Object.keys(edgeData).length > 0) {
+      console.log(
+        "updating edge selection with data:  " + JSON.stringify(edgeData),
+      );
+      this.selectedEdgeData = edgeData;
+    }
+    if (Object.keys(faceData).length > 0) {
+      this.selectedFaceData = faceData;
+    }
   }
 
   /**

--- a/src/molecules/input.js
+++ b/src/molecules/input.js
@@ -570,8 +570,10 @@ export default class Input extends Atom {
       if (!Array.isArray(node.geometry)) {
         const idx = leafCounter++;
         if (node.selection?.part) leafIndexes.push(idx);
-        if (node.selection?.edges?.length) edgeData[idx] = [...node.selection.edges];
-        if (node.selection?.faces?.length) faceData[idx] = [...node.selection.faces];
+        if (node.selection?.edges?.length)
+          edgeData[idx] = [...node.selection.edges];
+        if (node.selection?.faces?.length)
+          faceData[idx] = [...node.selection.faces];
       } else {
         node.geometry.forEach(walk);
       }

--- a/src/molecules/input.js
+++ b/src/molecules/input.js
@@ -96,6 +96,10 @@ export default class Input extends Atom {
      */
     this.selectedFaceData = {};
 
+    // True when a new upstream connection is awaiting its first READY value
+    // so its existing selection flags can be inherited.
+    this._pendingSelectionInheritance = false;
+
     /**
      * Flag indicating if the name text is currently truncated
      * @type {boolean}
@@ -356,8 +360,11 @@ export default class Input extends Atom {
 
       // For partselect type, transform the incoming geometry with selection flags
       if (this.type === "partselect") {
-        console.log(this.selectedLeafIndexes);
         if (parentState.status === Status.READY && parentState.value != null) {
+          if (this._pendingSelectionInheritance) {
+            this.inheritSelectionFromAssembly(parentState.value);
+            this._pendingSelectionInheritance = false;
+          }
           const transformed = this.applyPartSelection(
             parentState.value,
             this.selectedLeafIndexes,
@@ -373,6 +380,10 @@ export default class Input extends Atom {
       // For edgeselect type
       if (this.type === "edgeselect") {
         if (parentState.status === Status.READY && parentState.value != null) {
+          if (this._pendingSelectionInheritance) {
+            this.inheritSelectionFromAssembly(parentState.value);
+            this._pendingSelectionInheritance = false;
+          }
           const transformed = this.applyEdgeSelection(
             parentState.value,
             this.selectedEdgeData,
@@ -388,6 +399,10 @@ export default class Input extends Atom {
       // For faceselect type
       if (this.type === "faceselect") {
         if (parentState.status === Status.READY && parentState.value != null) {
+          if (this._pendingSelectionInheritance) {
+            this.inheritSelectionFromAssembly(parentState.value);
+            this._pendingSelectionInheritance = false;
+          }
           const transformed = this.applyFaceSelection(
             parentState.value,
             this.selectedFaceData,
@@ -508,19 +523,63 @@ export default class Input extends Atom {
   }
 
   /**
-   * Reset all selection state for this input. Called whenever the upstream
-   * connection is established or removed, since previously selected leaf
-   * indexes / edge indexes / face indexes may no longer correspond to valid
-   * elements on the newly (dis)connected geometry.
+   * Reset all selection state for this input. Used when the upstream
+   * connection is removed entirely (no assembly left to inherit from).
    */
   resetSelectionState() {
     this.selectedLeafIndexes = [];
     this.selectedEdgeData = {};
     this.selectedFaceData = {};
+    this._pendingSelectionInheritance = false;
     GlobalVariables.bumpSelectionVersion();
     if (typeof this._panelSetInputChanged === "function") {
       this._panelSetInputChanged(String(Date.now()));
     }
+  }
+
+  /**
+   * Called when a new upstream connection is made. Clears current selection
+   * and marks it to be re-derived from the newly connected assembly's own
+   * selection.part/.edges/.faces flags (e.g. set upstream by a code atom)
+   * once that assembly's first READY value arrives in onUpstreamChange.
+   */
+  markPendingSelectionInheritance() {
+    this.selectedLeafIndexes = [];
+    this.selectedEdgeData = {};
+    this.selectedFaceData = {};
+    this._pendingSelectionInheritance = true;
+    GlobalVariables.bumpSelectionVersion();
+    if (typeof this._panelSetInputChanged === "function") {
+      this._panelSetInputChanged(String(Date.now()));
+    }
+  }
+
+  /**
+   * Walk an assembly in flattenAssembly order and copy any existing
+   * selection.part/.edges/.faces flags into this input's local selection
+   * state, so a selector input linked to an already-selected assembly
+   * (e.g. produced by a code atom) starts populated instead of empty.
+   */
+  inheritSelectionFromAssembly(assembly) {
+    const leafIndexes = [];
+    const edgeData = {};
+    const faceData = {};
+    let leafCounter = 0;
+    const walk = (node) => {
+      if (!node) return;
+      if (!Array.isArray(node.geometry)) {
+        const idx = leafCounter++;
+        if (node.selection?.part) leafIndexes.push(idx);
+        if (node.selection?.edges?.length) edgeData[idx] = [...node.selection.edges];
+        if (node.selection?.faces?.length) faceData[idx] = [...node.selection.faces];
+      } else {
+        node.geometry.forEach(walk);
+      }
+    };
+    walk(assembly);
+    this.selectedLeafIndexes = leafIndexes;
+    this.selectedEdgeData = edgeData;
+    this.selectedFaceData = faceData;
   }
 
   /**

--- a/src/prototypes/attachmentpoint.js
+++ b/src/prototypes/attachmentpoint.js
@@ -970,16 +970,18 @@ export default class AttachmentPoint extends ObservableEntity {
 
       // A new upstream connection means any previously selected parts/edges/faces
       // may no longer correspond to valid indexes on the newly connected geometry.
-      // Reset selection state so stale indexes can't get stuck as unselectable.
+      // Mark for re-derivation from the new assembly's own selection flags (if
+      // any) once its first READY value arrives, instead of just clearing.
       // Skip this while a project is being loaded/deserialized, or while undoing,
       // since those connections are being restored rather than newly made by
       // the user — the saved selection state should be preserved in that case.
       if (
         !GlobalVariables.projectIsLoading &&
         !GlobalVariables.isUndoing &&
-        typeof this.options?.inputAtom?.resetSelectionState === "function"
+        typeof this.options?.inputAtom?.markPendingSelectionInheritance ===
+          "function"
       ) {
-        this.options.inputAtom.resetSelectionState();
+        this.options.inputAtom.markPendingSelectionInheritance();
       }
     } else {
       this.connectors.push(connector);

--- a/src/worker/generated/ts-framework.generated.js
+++ b/src/worker/generated/ts-framework.generated.js
@@ -199,7 +199,7 @@ export function makeAbundanceFramework(replicad) {
         geomString = this.geometry.constructor.name;
       }
       const planeString = this.plane ? "replicad.plane" : "null";
-      return `{__isRawAbundanceObj: true, color: ${this.color}, tags: ${JSON.stringify(this.tags)}, bom: ${JSON.stringify(this.bom)}, plane: ${planeString}, geometry: ${geomString}}`;
+      return `{__isRawAbundanceObj: true, color: ${this.color}, tags: ${JSON.stringify(this.tags)}, bom: ${JSON.stringify(this.bom)}, plane: ${planeString}, selection: ${JSON.stringify(this.selection)}, geometry: ${geomString}}`;
     }
   }
   Assembly.prototype.__abundance = "Assembly";

--- a/src/worker/geometryProvider.ts
+++ b/src/worker/geometryProvider.ts
@@ -224,7 +224,9 @@ class GeometryProvider {
       args.map((shapeid) => this.get(shapeid, context)),
     );
     console.warn(
-      `[boolean] ${resultId.split("-")[0]} deserialize finished at ${performance.now() - start}`,
+      `[boolean] ${resultId.split("-")[0]} deserialize finished at ${
+        performance.now() - start
+      }`,
     );
 
     // case 2D
@@ -236,7 +238,9 @@ class GeometryProvider {
       await putShape(context.project, resultId, result.serialize());
       this.cacheMiss(resultId, start - performance.now());
       console.warn(
-        `[boolean] ${resultId.split("-")[0]} drawings. done at ${performance.now() - start}`,
+        `[boolean] ${resultId.split("-")[0]} drawings. done at ${
+          performance.now() - start
+        }`,
       );
       return { outcome: BooleanOutcome.NewShape, resultId: resultId };
     }
@@ -245,13 +249,17 @@ class GeometryProvider {
     if (this.areAll3DShapes(geoms)) {
       const volumes = geoms.map(replicad.measureVolume);
       console.warn(
-        `[boolean] ${resultId.split("-")[0]} arg volumes measured at: ${performance.now() - start}`,
+        `[boolean] ${resultId.split("-")[0]} arg volumes measured at: ${
+          performance.now() - start
+        }`,
       );
       const result = this.as3dShapeOrThrow(
         operation(geoms) as replicad.AnyShape,
       );
       console.warn(
-        `[boolean] ${resultId.split("-")[0]} operation finished at: ${performance.now() - start}`,
+        `[boolean] ${resultId.split("-")[0]} operation finished at: ${
+          performance.now() - start
+        }`,
       );
 
       // use volume measurements to identify possible no-op conditions.
@@ -276,7 +284,9 @@ class GeometryProvider {
         } else {
           await putShape(context.project, resultId, result.serialize());
           console.warn(
-            `[boolean] ${resultId.split("-")[0]} new shape serialized at: ${performance.now() - start}`,
+            `[boolean] ${resultId.split("-")[0]} new shape serialized at: ${
+              performance.now() - start
+            }`,
           );
           toReturn = {
             outcome: BooleanOutcome.NewShape,
@@ -286,7 +296,9 @@ class GeometryProvider {
       }
       this.cacheMiss(resultId, performance.now() - start);
       console.warn(
-        `[boolean] ${resultId.split("-")[0]} outcome: ${BooleanOutcome[toReturn.outcome]}. done at: ${performance.now() - start}`,
+        `[boolean] ${resultId.split("-")[0]} outcome: ${
+          BooleanOutcome[toReturn.outcome]
+        }. done at: ${performance.now() - start}`,
       );
 
       return toReturn;
@@ -832,6 +844,18 @@ class GeometryProvider {
         );
       }
     }
+    if (boolResult.outcome == BooleanOutcome.NewShape) {
+      this.booleanOpCache.recordOcclusion(
+        boolResult.resultId,
+        inputId1,
+        context.project,
+      );
+      this.booleanOpCache.recordOcclusion(
+        boolResult.resultId,
+        inputId2,
+        context.project,
+      );
+    }
     return boolResult.resultId;
   }
 
@@ -880,6 +904,18 @@ class GeometryProvider {
           context.project,
         );
       }
+    }
+    if (boolResult.outcome == BooleanOutcome.NewShape) {
+      this.booleanOpCache.recordOcclusion(
+        inputId1,
+        boolResult.resultId,
+        context.project,
+      );
+      this.booleanOpCache.recordOcclusion(
+        inputId2,
+        boolResult.resultId,
+        context.project,
+      );
     }
     return boolResult.resultId;
   }
@@ -971,6 +1007,7 @@ class GeometryProvider {
     }
     if (boolResult.outcome == BooleanOutcome.NewShape) {
       this.booleanOpCache.recordDisjoint(resultId, cutter, context.project);
+      this.booleanOpCache.recordOcclusion(resultId, toCut, context.project);
     }
     return boolResult.resultId;
   }

--- a/src/worker/interaction.ts
+++ b/src/worker/interaction.ts
@@ -177,9 +177,15 @@ async function difference(
     (util.is3D(target) && util.is3D(cutter)) ||
     (!util.is3D(target) && !util.is3D(cutter))
   ) {
+    const totalCuts = util.leafCount(target) * util.leafCount(cutter);
+    let completedCuts = 0;
+    const progressCallback = () => {
+      completedCuts++;
+      reportCadProgress(`boolean cut ${completedCuts} / ${totalCuts}`);
+    };
     // Process each leaf of target independently
     return util.actOnLeafs(target, async (leaf: AbundanceLeaf) => {
-      return await recursiveCut(leaf, cutter, context);
+      return await recursiveCut(leaf, cutter, context, progressCallback);
     });
   } else {
     throw new Error("Both inputs must be either 3D or 2D");
@@ -455,13 +461,32 @@ async function assembly(
     // The general case of a cache miss assembly operation.
     const assembly: AbundanceObject[] = [];
 
+    const leafcounts = geometries
+      .map(util.leafCount)
+    let temp = leafcounts[leafcounts.length - 1];
+    let totalCuts = 0;
+    for (let i = leafcounts.length - 1; i >= 0; i++) {
+      totalCuts += leafcounts[i] * temp;
+      temp += leafcounts[i]
+    }
+    let completedCuts = 0;
+    const progressCallback = () => {
+      completedCuts++;
+      reportCadProgress(`boolean cut ${completedCuts} / ${totalCuts}`);
+    };
+
     // Each geometry is cut by all following geometries.
     // TODO: test if this is faster working back-to-front or front-to-back.
     for (let i = 0; i < geometries.length - 1; i++) {
       const geometry = geometries[i];
       reportCadProgress(`cutting part ${i + 1}/${geometries.length}`);
       assembly.push(
-        await cutAssembly(geometry, geometries.slice(i + 1), context),
+        await cutAssembly(
+          geometry,
+          geometries.slice(i + 1),
+          context,
+          progressCallback,
+        ),
       );
     }
     assembly.push(geometries[geometries.length - 1]); // Final entry is always unmodified.
@@ -583,8 +608,17 @@ async function cutAssembly(
   partToCut: AbundanceObject,
   cuttingParts: AbundanceObject[],
   context: RequestContext,
+  progressCallback: (() => void) | undefined = undefined,
 ): Promise<AbundanceObject> {
   await util.init();
+
+  if (progressCallback == undefined) {
+    let cutscount = 0;
+    progressCallback = () => {
+      cutscount++;
+      reportCadProgress(`boolean cut ${cutscount}`);
+    };
+  }
 
   //If the partToCut is an assembly pass each part back into cutAssembly function to be cut separately
   if (util.isAssembly(partToCut)) {
@@ -597,7 +631,9 @@ async function cutAssembly(
       // deeply-nested assembly is cut part-by-part.
       reportCadProgress(`cutting subpart ${subIndex}/${subParts.length}`);
       // make new assembly from cut parts
-      partsAfterCut.push(await cutAssembly(part, cuttingParts, context));
+      partsAfterCut.push(
+        await cutAssembly(part, cuttingParts, context, progressCallback),
+      );
     }
 
     const newAssembly = util.computeAssemblyBounds({
@@ -613,7 +649,12 @@ async function cutAssembly(
       // If they don't overlap, skip the cut operation entirely
       if (util.boundsOverlap(partToCut.boundingBox, cuttingPart.boundingBox)) {
         // for each cutting part cut the part
-        partCutCopy = await recursiveCut(partCutCopy, cuttingPart, context);
+        partCutCopy = await recursiveCut(
+          partCutCopy,
+          cuttingPart,
+          context,
+          progressCallback,
+        );
       } else {
         // Bounding boxes don't overlap - skipping cut operation
         console.log(
@@ -648,6 +689,7 @@ async function recursiveCut(
   partToCut: AbundanceLeaf,
   cuttingParts: AbundanceObject,
   context: RequestContext,
+  progressCallback: () => void,
 ): Promise<AbundanceLeaf> {
   let resultGeomId: string = partToCut.geometry;
 
@@ -655,7 +697,6 @@ async function recursiveCut(
   // checks since we could find an entire branch of the assembly which doesn't
   // intersect bounding box. This is simpler implemenation but may someday warrant
   // a change.
-  let cutsPerformed = 0;
   for (const cuttingPart of util.flattenAssembly(cuttingParts)) {
     // --- Coplanarity check for 2D shapes ---
     if (
@@ -678,8 +719,7 @@ async function recursiveCut(
     // Heartbeat before each real boolean cut — this is the expensive atomic
     // operation, so reporting here resets the inactivity watchdog even when a
     // single leaf is cut by many parts.
-    cutsPerformed++;
-    reportCadProgress(`boolean cut ${cutsPerformed}`);
+    progressCallback();
     // If this exact cut hung the worker before, do not run it again. Signal the
     // assembly to surface both parts in red instead of hanging or silently
     // dropping the cut.

--- a/src/worker/interaction.ts
+++ b/src/worker/interaction.ts
@@ -461,13 +461,12 @@ async function assembly(
     // The general case of a cache miss assembly operation.
     const assembly: AbundanceObject[] = [];
 
-    const leafcounts = geometries
-      .map(util.leafCount)
+    const leafcounts = geometries.map(util.leafCount);
     let temp = leafcounts[leafcounts.length - 1];
     let totalCuts = 0;
-    for (let i = leafcounts.length - 1; i >= 0; i++) {
+    for (let i = leafcounts.length - 1; i >= 0; i--) {
       totalCuts += leafcounts[i] * temp;
-      temp += leafcounts[i]
+      temp += leafcounts[i];
     }
     let completedCuts = 0;
     const progressCallback = () => {

--- a/src/worker/ts-framework.ts
+++ b/src/worker/ts-framework.ts
@@ -278,7 +278,7 @@ export class Assembly<G = any> {
       geomString = this.geometry.constructor.name;
     }
     const planeString = this.plane ? "replicad.plane" : "null";
-    return `{__isRawAbundanceObj: true, color: ${this.color}, tags: ${JSON.stringify(this.tags)}, bom: ${JSON.stringify(this.bom)}, plane: ${planeString}, geometry: ${geomString}}`;
+    return `{__isRawAbundanceObj: true, color: ${this.color}, tags: ${JSON.stringify(this.tags)}, bom: ${JSON.stringify(this.bom)}, plane: ${planeString}, selection: ${JSON.stringify(this.selection)}, geometry: ${geomString}}`;
   }
 }
 

--- a/src/worker/util.ts
+++ b/src/worker/util.ts
@@ -433,6 +433,14 @@ function isLeaf(obj: AbundanceObject): obj is AbundanceLeaf {
   return obj !== undefined && !Array.isArray(obj.geometry);
 }
 
+function leafCount(assembly: AbundanceObject) {
+  if (isLeaf(assembly)) {
+    return 1;
+  } else {
+    return assembly.geometry.map(leafCount).reduce((acc, i) => acc + i, 0);
+  }
+}
+
 function actOnLeafsSync(
   assembly: AbundanceObject,
   action: (leaf: AbundanceLeaf) => AbundanceObject,
@@ -704,6 +712,7 @@ export {
   isLeaf,
   isPoint3D,
   isWireGeometry,
+  leafCount,
   mergeBounds,
   replicad,
   SimplePlane,


### PR DESCRIPTION
changes:

1. Fix progress reporting denominator for assemblies. Before an assembly starts we compute the total number of cuts which will be performed then report that as the denominator in the progress UI
2. Selection state can be passed through selection type inputs without being erased. This facilitates user-defined selectors like edgesInBoundingBox which can then be linked to selection based operations like selected.Fillet
3. stores some additional known disjoint/occlusion relationships after boolean operations.