### PR TITLE
Incremental Fuse

### DIFF
--- a/src/worker/booleanOpCache.ts
+++ b/src/worker/booleanOpCache.ts
@@ -1,0 +1,267 @@
+import { getPairCache, putPairCache } from "./indexeddbUtils";
+
+/**
+ * Persistent cache of shape-id pairs with known special
+ * boolean outcomes, so a `cut`/`intersect` that previously produced a no-op
+ * or empty-shape result doesn't need to be recomputed after a reload.
+ *
+ * `disjoint` pairs are commutative, ie, `a` disjoint with `b` implies
+ * `b` disjoint with `a`
+ *
+ * `occlusion` pairs are not commutative.
+ *
+ * Each project's pairs live in memory and are periodically flushed to
+ * IndexedDB as a single serialized blob per list (see `_flushPairCache`),
+ * rather than one row per pair — see design discussion for the tradeoffs.
+ *
+ * Calles should be primarily concerned with `isDisjoint`/`recordDisjoint`
+ * and `isOccluded`/`recordOccluded`.
+ *
+ * Some additional cache management utilities are also provided. Namely,
+ * `loadProject` which returns fast but starts the async task of loading a
+ * new project's cache from long term indexeddb storage. And sweep(idsToRetain)
+ * which cleans the in-memory and serialized copies of this cache of any
+ * entries which don't concern the specified shape ids.
+ */
+class BooleanOpCache {
+  private pairCaches: Map<
+    string,
+    { disjoint: Set<string>; occlusion: Set<string>; dirty: boolean }
+  > = new Map();
+  // Dedupes concurrent lazy-loads of a project's pair cache.
+  private pairCacheLoading: Map<string, Promise<void>> = new Map();
+  // Tracks the pending throttled flush timer per project (see
+  // `_scheduleFlush`), so only one flush is scheduled at a time.
+  private pairCacheFlushTimers: Map<string, ReturnType<typeof setTimeout>> =
+    new Map();
+  private static PAIR_CACHE_FLUSH_THROTTLE_MS = 2000;
+  private static DISJOINT_PAIRS_KEY = "__disjointPairs__";
+  private static OCCLUSION_PAIRS_KEY = "__occlusionPairs__";
+
+  private _disjointKey(a: string, b: string): string {
+    return [a, b].sort().join("\u0000");
+  }
+
+  private _occlusionKey(occludedId: string, containerId: string): string {
+    return occludedId + "\u0000" + containerId;
+  }
+
+  /**
+   * Lazily loads a project's persisted disjoint/occlusion pair blobs into
+   * memory, at most once per project (concurrent callers share the same
+   * load). Safe to call repeatedly; a no-op once loaded.
+   */
+  private async _ensureLoaded(projectId: string): Promise<void> {
+    if (this.pairCaches.has(projectId)) {
+      return;
+    }
+    const existingLoad = this.pairCacheLoading.get(projectId);
+    if (existingLoad) {
+      return existingLoad;
+    }
+    const load = (async () => {
+      const [disjointRecord, occlusionRecord] = await Promise.all([
+        getPairCache(projectId, BooleanOpCache.DISJOINT_PAIRS_KEY),
+        getPairCache(projectId, BooleanOpCache.OCCLUSION_PAIRS_KEY),
+      ]);
+      this.pairCaches.set(projectId, {
+        disjoint: new Set(
+          disjointRecord ? JSON.parse(disjointRecord.serialized) : [],
+        ),
+        occlusion: new Set(
+          occlusionRecord ? JSON.parse(occlusionRecord.serialized) : [],
+        ),
+        dirty: false,
+      });
+    })();
+    this.pairCacheLoading.set(projectId, load);
+    try {
+      await load;
+    } finally {
+      this.pairCacheLoading.delete(projectId);
+    }
+  }
+
+  /**
+   * Kicks off (without awaiting) a load of the project's persisted pairs if
+   * one isn't already loaded or in flight. Used by the read methods so they
+   * can stay synchronous: the first call(s) for a project may miss (fail
+   * open to `false`) while the load is in flight, but subsequent calls will
+   * see the loaded data.
+   */
+  private _kickOffLoad(projectId: string): void {
+    if (
+      this.pairCaches.has(projectId) ||
+      this.pairCacheLoading.has(projectId)
+    ) {
+      return;
+    }
+    void this._ensureLoaded(projectId);
+  }
+
+  /**
+   * Schedules a throttled (not debounced) flush of a project's pair cache:
+   * if a flush isn't already pending for this project, one is scheduled
+   * `PAIR_CACHE_FLUSH_THROTTLE_MS` out. Subsequent calls before it fires are
+   * no-ops, so continuous pair discovery can't defer persistence forever.
+   */
+  private _scheduleFlush(projectId: string): void {
+    if (this.pairCacheFlushTimers.has(projectId)) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      this.pairCacheFlushTimers.delete(projectId);
+      void this._flush(projectId);
+    }, BooleanOpCache.PAIR_CACHE_FLUSH_THROTTLE_MS);
+    this.pairCacheFlushTimers.set(projectId, timer);
+  }
+
+  /** Persists a project's pair cache to IndexedDB if it has unsaved changes. */
+  private async _flush(projectId: string): Promise<void> {
+    const cache = this.pairCaches.get(projectId);
+    if (!cache || !cache.dirty) {
+      return;
+    }
+    cache.dirty = false;
+    await Promise.all([
+      putPairCache(
+        projectId,
+        BooleanOpCache.DISJOINT_PAIRS_KEY,
+        JSON.stringify([...cache.disjoint]),
+      ),
+      putPairCache(
+        projectId,
+        BooleanOpCache.OCCLUSION_PAIRS_KEY,
+        JSON.stringify([...cache.occlusion]),
+      ),
+    ]);
+  }
+
+  loadProject(projectId: string): void {
+    this._kickOffLoad(projectId);
+  }
+
+  /**
+   * Dumps a project's in memory cache.
+  */
+  forgetProject(projectId: string): void {
+    this.pairCaches.delete(projectId);
+    this.pairCacheLoading.delete(projectId);
+    const timer = this.pairCacheFlushTimers.get(projectId);
+    if (timer) {
+      clearTimeout(timer);
+      this.pairCacheFlushTimers.delete(projectId);
+    }
+  }
+
+  /**
+   * True if `a` and `b` are known to be disjoint (a boolean op between them
+   * produces an empty intersection / a true no-op cut). Commutative.
+   *
+   * Returns `false` (a safe cache-miss) if this project's persisted pairs
+   * haven't finished loading yet; a load is kicked off in the background if
+   * one isn't already underway.
+   */
+  isDisjoint(a: string, b: string, projectId: string): boolean {
+    this._kickOffLoad(projectId);
+    return (
+      this.pairCaches.get(projectId)?.disjoint.has(this._disjointKey(a, b)) ??
+      false
+    );
+  }
+
+  /** Records that `a` and `b` are disjoint and schedules a persist. */
+  recordDisjoint(a: string, b: string, projectId: string): void {
+    this._kickOffLoad(projectId);
+    const cache = this.pairCaches.get(projectId);
+    if (!cache) {
+      // Load hasn't landed yet; drop this discovery rather than blocking the
+      // caller. It will simply be rediscovered (and recorded) the next time
+      // this pair is computed.
+      return;
+    }
+    cache.disjoint.add(this._disjointKey(a, b));
+    cache.dirty = true;
+    this._scheduleFlush(projectId);
+  }
+
+  /**
+   * True if `containerId` is known to fully enclose `occludedId` (ie:
+   * `cut(occludedId, containerId)` produces an empty shape). Directional.
+   *
+   * Returns `false` (a safe cache-miss) if this project's persisted pairs
+   * haven't finished loading yet; a load is kicked off in the background if
+   * one isn't already underway.
+   */
+  isOccluded(
+    occludedId: string,
+    containerId: string,
+    projectId: string,
+  ): boolean {
+    this._kickOffLoad(projectId);
+    return (
+      this.pairCaches
+        .get(projectId)
+        ?.occlusion.has(this._occlusionKey(occludedId, containerId)) ?? false
+    );
+  }
+
+  /** Records that `containerId` fully encloses `occludedId` and schedules a persist. */
+  recordOcclusion(
+    occludedId: string,
+    containerId: string,
+    projectId: string,
+  ): void {
+    this._kickOffLoad(projectId);
+    const cache = this.pairCaches.get(projectId);
+    if (!cache) {
+      // Load hasn't landed yet; drop this discovery rather than blocking the
+      // caller. It will simply be rediscovered (and recorded) the next time
+      // this pair is computed.
+      return;
+    }
+    cache.occlusion.add(this._occlusionKey(occludedId, containerId));
+    cache.dirty = true;
+    this._scheduleFlush(projectId);
+  }
+
+  /**
+   * Removes any disjoint/occlusion pairs referencing an id not present in
+   * `idsToRetain`, then immediately (not throttled) persists the result if
+   * anything changed. Returns the number of pairs pruned.
+   */
+  async sweep(idsToRetain: Set<string>, projectId: string): Promise<number> {
+    await this._ensureLoaded(projectId);
+    const cache = this.pairCaches.get(projectId);
+    if (!cache) {
+      return 0;
+    }
+    let prunedCount = 0;
+    for (const key of cache.disjoint) {
+      const [a, b] = key.split("\u0000");
+      if (!idsToRetain.has(a) || !idsToRetain.has(b)) {
+        cache.disjoint.delete(key);
+        prunedCount++;
+      }
+    }
+    for (const key of cache.occlusion) {
+      const [occludedId, containerId] = key.split("\u0000");
+      if (!idsToRetain.has(occludedId) || !idsToRetain.has(containerId)) {
+        cache.occlusion.delete(key);
+        prunedCount++;
+      }
+    }
+    if (prunedCount > 0) {
+      cache.dirty = true;
+      const timer = this.pairCacheFlushTimers.get(projectId);
+      if (timer) {
+        clearTimeout(timer);
+        this.pairCacheFlushTimers.delete(projectId);
+      }
+      await this._flush(projectId);
+    }
+    return prunedCount;
+  }
+}
+
+export { BooleanOpCache };

--- a/src/worker/code.ts
+++ b/src/worker/code.ts
@@ -347,7 +347,12 @@ function composeCacheKey(code: string, args: { [key: string]: any }) {
   const argString = Object.entries(args)
     .map(([k, v]) => `${k}:${JSON.stringify(v)}`)
     .join("-");
-  return util.hashString(code + "-" + argString);
+  const result = util.hashString(code + "-" + argString);
+  console.log("composing cache key for code atom. code, args, result");
+  console.log("hashtest - ", code);
+  console.log("hashtest - ", argString);
+  console.log("hashtest - ", result);
+  return result;
 }
 
 async function executeTsCode(
@@ -405,6 +410,47 @@ async function executeTsCode(
           };
         })()
       : console;
+
+    const passThroughKeys = [
+      "geometry",
+      "plane",
+      "tags",
+      "bom",
+      "color",
+      "selection",
+      "metadata",
+    ];
+    const helper = (obj: AbundanceObject): AbundanceObject => {
+      if (util.isLeaf(obj)) {
+        return Object.fromEntries(
+          Object.entries(obj).filter(([key]) => passThroughKeys.includes(key)),
+        ) as util.AbundanceLeaf;
+      } else {
+        // is branch
+        const children = obj.geometry.map(helper);
+        const filtered = Object.fromEntries(
+          Object.entries(obj).filter(([key]) => passThroughKeys.includes(key)),
+        );
+        return {
+          ...filtered,
+          geometry: children,
+        } as AbundanceObject;
+      }
+    };
+
+    // filter AbundanceObject arguments down to just the properties which are passed
+    // through to code atoms and exclude the rest since differences there are
+    // by definition nonimpactful to the result. In particular this is important
+    // for bounding boxes which can be in an initialized or uninitialized state.
+    argumentsArray = Object.fromEntries(
+      Object.entries(argumentsArray).map(([key, val]) => {
+        if (util.isAbundanceObject(val)) {
+          return [key, helper(val)];
+        } else {
+          return [key, val];
+        }
+      }),
+    );
 
     // Check cache for result of this code atom before doing any heavy work like
     // materializing arguments or launching the sandbox.

--- a/src/worker/geometryProvider.ts
+++ b/src/worker/geometryProvider.ts
@@ -19,6 +19,7 @@ import {
   filter,
 } from "./indexeddbUtils";
 import { reportBooleanInflight } from "./progress";
+import { BooleanOpCache } from "./booleanOpCache";
 
 type ReplicadObject =
   | replicad.Shape3D
@@ -50,7 +51,7 @@ enum BooleanOutcome {
 type BooleanResult = {
   outcome: BooleanOutcome;
   inputIndexAsResult?: number; // if outcome is InputShape, which input shape is it.
-  result?: replicad.Shape3D | replicad.Drawing; // it outcome is NewShape, include that here.
+  resultId: string; // id string of the result
 };
 
 /**
@@ -68,6 +69,10 @@ class GeometryProvider {
   // Keeps typical ids human-readable while bounding pathological nested-boolean
   // recipes (observed at 65-78KB) that otherwise dominate large assemblies.
   private static MAX_ID_LENGTH = 512;
+  // tolerance under which a boolean result is considered to be equivalent to
+  // an input. Ie, indicator of a boolean no-op.
+  private static BOOLEAN_TOLERANCE = 1e-5;
+
   // Set of `toCut\u0000cutter` keys for boolean cuts that previously hung the
   // worker (>watchdog). `recursiveCut` consults `isBadCut` and, rather than
   // re-running a cut that will hang again, surfaces the two failing parts in red.
@@ -77,7 +82,12 @@ class GeometryProvider {
   private projectLRU: string[] = [];
   private cacheHitMetrics: Record<string, [number, number, number]>; // hits, misses, total-miss-duration-ms
   private warmCache: Map<string, Map<string, ReplicadObject>> = new Map();
-  private noOpCache: Map<string, string> = new Map();
+
+  // Persistent (per-project) cache of shape-id pairs with known special
+  // boolean outcomes (disjoint / occlusion). Since such outcomes don't create
+  // a new shape in the cache they get special handling here to avoid eternally
+  // recomputing booleans with no-op outcomes.
+  private booleanOpCache: BooleanOpCache = new BooleanOpCache();
 
   // Tracks batch operations that are currently running so that concurrent
   // requests for an identical batch (same content-hashed id) share the first
@@ -146,6 +156,7 @@ class GeometryProvider {
     }
     this.projectLRU.push(projectId);
     if (newProject) {
+      this.booleanOpCache.loadProject(projectId);
       if (this.projectLRU.length > this.MAX_PROJECTS) {
         this.projectLRU.shift();
       }
@@ -157,124 +168,127 @@ class GeometryProvider {
   }
 
   private evictProjectsBesides(projectIds: Set<string>) {
-    return getAllProjectIds().then(async (allIds) => {
-      if (allIds.size <= this.MAX_PROJECTS) {
-        return;
-      }
-      const evictIds = Array.from(allIds).filter((id) => !projectIds.has(id));
-      for (const evictId of evictIds) {
-        await deleteProjectCache(evictId);
-      }
-    });
+    return getAllProjectIds()
+      .then(async (allIds) => {
+        if (allIds.size <= this.MAX_PROJECTS) {
+          return;
+        }
+        const evictIds = Array.from(allIds).filter((id) => !projectIds.has(id));
+        for (const evictId of evictIds) {
+          await deleteProjectCache(evictId);
+          this.booleanOpCache.forgetProject(evictId);
+        }
+      })
+      .catch((error) => {
+        console.error("Evict projects failed.");
+        console.error(error);
+      });
   }
 
-  private async booleanOperation(
+  /**
+   * An alternative to createIfAbsent which allows for the case where
+   * this operation is a no-op and in fact doesn't need to put a
+   * new entry into the cache. Generally should be used for boolean
+   * operations.
+   *
+   * @param resultId
+   * @param args
+   * @param context
+   * @param operation
+   * @returns
+   */
+  private async maybeOp(
     resultId: string,
-    inputs: string[],
+    args: string[],
     context: RequestContext,
     operation: (
-      inputs: string[],
-      phase: (name: string) => void,
-    ) => Promise<BooleanResult>,
-  ): Promise<string> {
-    // Always use cache result if it's available
+      inputs: replicad.Shape3D[] | replicad.Drawing[],
+    ) => replicad.Shape3D | replicad.Drawing,
+  ): Promise<BooleanResult> {
+    // check shape cache
     if (
       this.getFromWarmCache(resultId, context) ||
       (await shapeExists(context.project, resultId))
     ) {
       this.cacheHit(resultId);
-      return resultId;
+      return { outcome: BooleanOutcome.NewShape, resultId: resultId };
     }
 
-    if (this.noOpCache.has(resultId)) {
-      const result = this.noOpCache.get(resultId)!;
-      if (this.EMPTY_SHAPE_SENTINEL == result) {
-        this.cacheHit("boolempty");
-      } else {
-        this.cacheHit("boolnoop");
-      }
-      return result;
-    }
-
-    // Cache miss. Compute the operation then either:
-    //  add result to the cache
-    //  if a no-op return the appropriate input id
-    //  if a empty shape return the sentinel
-    // DIAGNOSTIC: `resultId` encodes the op + input ids (e.g. `cut-<toCut>-<cutter>`).
-    // The "starting" line is always logged so a hanging boolean is identifiable as
-    // the last entry in getRecentWorkerLogs with no matching "done" line. The
-    // "done" line is gated to slow ops to bound the worker-log ring buffer.
-    console.warn(`[boolean] ${resultId} starting`);
+    // Start actual computation of the op. No cache had the result ready for us.
     const start = performance.now();
-    // Begin-marker for a sub-step. A single synchronous OCCT step (deserialize,
-    // .cut(), measureVolume, serialize) can block the worker for >90s, at which
-    // point the inactivity watchdog kills it before any "done" line is logged.
-    // The LAST phase marker before the log gap therefore pinpoints exactly which
-    // sub-step hung.
-    const phase = (name: string): void => {
+    console.warn(`[boolean] ${resultId.split("-")[0]} starting at ${start}`);
+    // deserialize args
+    const geoms = await Promise.all(
+      args.map((shapeid) => this.get(shapeid, context)),
+    );
+    console.warn(
+      `[boolean] ${resultId.split("-")[0]} deserialize finished at ${performance.now() - start}`,
+    );
+
+    // case 2D
+    if (this.areAllDrawings(geoms)) {
+      const result = operation(geoms);
+      await putShape(context.project, resultId, result.serialize());
+      this.cacheMiss(resultId, start - performance.now());
       console.warn(
-        `[boolean] ${resultId} phase:${name} @${Math.round(
-          performance.now() - start,
-        )}ms`,
+        `[boolean] ${resultId.split("-")[0]} drawings. done at ${performance.now() - start}`,
       );
-    };
-    let opResult: BooleanResult;
-    try {
-      opResult = await operation(inputs, phase);
-    } catch (err) {
-      // Surface the real error — comlink otherwise collapses a worker-thread
-      // throw to an opaque "{}" on the main thread.
-      const e = err as any;
-      const stackHead = e?.stack
-        ? " | " + String(e.stack).split("\n").slice(0, 3).join(" ")
-        : "";
-      console.warn(
-        `[boolean] ${resultId} threw: ${e?.name || "Error"}: ${
-          e?.message ?? String(e)
-        }${stackHead}`,
-      );
-      throw err;
+      return { outcome: BooleanOutcome.NewShape, resultId: resultId };
     }
-    const durationMs = Math.round(performance.now() - start);
-    if (durationMs > 2000) {
+
+    // case 3D
+    if (this.areAll3DShapes(geoms)) {
+      const volumes = geoms.map(replicad.measureVolume);
       console.warn(
-        `[boolean] ${resultId} done in ${durationMs}ms outcome=${BooleanOutcome[opResult.outcome]}`,
+        `[boolean] ${resultId.split("-")[0]} arg volumes measured at: ${performance.now() - start}`,
       );
-    }
-    switch (opResult.outcome) {
-      case BooleanOutcome.EmptyShape:
-        this.cacheMiss("boolempty" + resultId, performance.now() - start);
-        this.noOpCache.set(resultId, this.EMPTY_SHAPE_SENTINEL);
-        return this.EMPTY_SHAPE_SENTINEL;
-      case BooleanOutcome.InputShape:
-        if (opResult.inputIndexAsResult === undefined) {
-          throw new Error(
-            "Boolean operation returned InputShape without index: " +
-              JSON.stringify(opResult),
+      const result = this.as3dShapeOrThrow(
+        operation(geoms) as replicad.AnyShape,
+      );
+      console.warn(
+        `[boolean] ${resultId.split("-")[0]} operation finished at: ${performance.now() - start}`,
+      );
+
+      // use volume measurements to identify possible no-op conditions.
+      const resVol = replicad.measureVolume(result);
+      let toReturn = undefined;
+      if (resVol < GeometryProvider.BOOLEAN_TOLERANCE) {
+        toReturn = {
+          outcome: BooleanOutcome.EmptyShape,
+          resultId: this.EMPTY_SHAPE_SENTINEL,
+        };
+      } else {
+        const volumeMatchIndex = volumes.findIndex(
+          (inputVol) =>
+            Math.abs(resVol - inputVol) < GeometryProvider.BOOLEAN_TOLERANCE,
+        );
+        if (volumeMatchIndex >= 0) {
+          toReturn = {
+            outcome: BooleanOutcome.InputShape,
+            inputIndexAsResult: volumeMatchIndex,
+            resultId: args[volumeMatchIndex],
+          };
+        } else {
+          await putShape(context.project, resultId, result.serialize());
+          console.warn(
+            `[boolean] ${resultId.split("-")[0]} new shape serialized at: ${performance.now() - start}`,
           );
+          toReturn = {
+            outcome: BooleanOutcome.NewShape,
+            resultId: resultId,
+          };
         }
-        this.cacheMiss("boolnoop" + resultId, performance.now() - start);
-        this.noOpCache.set(resultId, inputs[opResult.inputIndexAsResult]);
-        return inputs[opResult.inputIndexAsResult];
-      case BooleanOutcome.NewShape:
-        this.cacheMiss(resultId, performance.now() - start);
-        if (opResult.result) {
-          phase("serialize+persist");
-          const serializeStart = performance.now();
-          await putShape(
-            context.project,
-            resultId,
-            opResult.result.serialize(),
-          );
-          const serializeMs = Math.round(performance.now() - serializeStart);
-          if (serializeMs > 1000) {
-            console.warn(
-              `[boolean] ${resultId} serialize+persist took ${serializeMs}ms`,
-            );
-          }
-        }
-        return resultId;
+      }
+      this.cacheMiss(resultId, performance.now() - start);
+      console.warn(
+        `[boolean] ${resultId.split("-")[0]} outcome: ${BooleanOutcome[toReturn.outcome]}. done at: ${performance.now() - start}`,
+      );
+
+      return toReturn;
     }
+
+    // no mix matching for boolean operations
+    throw new Error("Boolean args were not all 2D nor all 3D");
   }
 
   // Returns the id of the geometry once it's been added to the cache.
@@ -424,6 +438,7 @@ class GeometryProvider {
   async clearCache(context: RequestContext): Promise<boolean> {
     this.projectLRU = this.projectLRU.filter((id) => id !== context.project);
     await deleteProjectCache(context.project);
+    this.booleanOpCache.forgetProject(context.project);
     return true;
   }
 
@@ -473,6 +488,16 @@ class GeometryProvider {
       },
       true,
     );
+
+    const prunedPairs = await this.booleanOpCache.sweep(
+      idsToRetain,
+      context.project,
+    );
+    if (prunedPairs > 0) {
+      console.warn(
+        `[GeometryProvider] sweepCache pruned ${prunedPairs} stale disjoint/occlusion pairs for project ${context.project}`,
+      );
+    }
 
     return deletedGeoms + deletedAssemblies;
   }
@@ -749,79 +774,109 @@ class GeometryProvider {
   }
 
   async intersect(
-    input1ID: string,
-    inputID2: string,
+    inputId1: string,
+    inputId2: string,
     context: RequestContext,
   ): Promise<string | undefined> {
     if (
-      input1ID === this.EMPTY_SHAPE_SENTINEL ||
-      inputID2 === this.EMPTY_SHAPE_SENTINEL
+      inputId1 === this.EMPTY_SHAPE_SENTINEL ||
+      inputId2 === this.EMPTY_SHAPE_SENTINEL
     ) {
       return this.EMPTY_SHAPE_SENTINEL;
     }
-    const id = this._makeId("intersect", input1ID, inputID2);
-    return await this.createIfAbsent(id, context, async () => {
-      const args = [
-        await this.get(input1ID, context),
-        await this.get(inputID2, context),
-      ];
-      // Intersect only allowed between matching types. 2 drawings or 2 3d shapes.
 
-      if (this.areAllDrawings(args)) {
-        const result = args[0].intersect(args[1]);
-        //@ts-ignore - no other way to check if the generated shape is nonexistent
-        if (!result.innerShape) {
-          return undefined;
-        }
-        return result;
-      } else if (this.areAll3DShapes(args)) {
-        return this.as3dShapeOrThrow(args[0].intersect(args[1]));
-      } else {
-        throw new Error(
-          "Invalid types for intersection: " +
-            typeof args[0] +
-            " and " +
-            typeof args[1],
+    const id = this._makeId("intersect", inputId1, inputId2);
+    if (this.booleanOpCache.isDisjoint(inputId1, inputId2, context.project)) {
+      this.cacheHit("disjoint" + id);
+      return this.EMPTY_SHAPE_SENTINEL;
+    }
+    if (this.booleanOpCache.isOccluded(inputId1, inputId2, context.project)) {
+      this.cacheHit("occluded" + id);
+      return inputId1;
+    }
+    if (this.booleanOpCache.isOccluded(inputId2, inputId1, context.project)) {
+      this.cacheHit("occluded" + id);
+      return inputId2;
+    }
+
+    const boolResult = await this.maybeOp(
+      id,
+      [inputId1, inputId2],
+      context,
+      (args) => {
+        // @ts-expect-error Type coercion happens inside of maybeOp.
+        return args[0].intersect(args[1]);
+      },
+    );
+    if (boolResult.outcome == BooleanOutcome.EmptyShape) {
+      this.booleanOpCache.recordDisjoint(inputId1, inputId2, context.project);
+    }
+    if (boolResult.outcome == BooleanOutcome.InputShape) {
+      if (boolResult.inputIndexAsResult == 0) {
+        this.booleanOpCache.recordOcclusion(
+          inputId1,
+          inputId2,
+          context.project,
+        );
+      } else if (boolResult.inputIndexAsResult == 1) {
+        // Flip args since inputId2 was identical to result.
+        this.booleanOpCache.recordOcclusion(
+          inputId2,
+          inputId1,
+          context.project,
         );
       }
-    });
+    }
+    return boolResult.resultId;
   }
 
   // Fuse 1 or more geometries together.
   async fuse(
-    input1ID: string,
-    inputID2: string,
+    inputId1: string,
+    inputId2: string,
     context: RequestContext,
   ): Promise<string> {
-    if (input1ID === this.EMPTY_SHAPE_SENTINEL) {
-      return inputID2;
+    if (inputId1 === this.EMPTY_SHAPE_SENTINEL) {
+      return inputId2;
     }
-    if (inputID2 === this.EMPTY_SHAPE_SENTINEL) {
-      return input1ID;
+    if (inputId2 === this.EMPTY_SHAPE_SENTINEL) {
+      return inputId1;
     }
-    const sortedArgs = [input1ID, inputID2].sort();
+    const sortedArgs = [inputId1, inputId2].sort();
     const resultId = this._makeId("fuse", sortedArgs[0], sortedArgs[1]);
 
-    await this.createIfAbsent(resultId, context, async () => {
-      const args = [
-        await this.get(input1ID, context),
-        await this.get(inputID2, context),
-      ];
-      // Fuse only allowed between matching types. 2 drawings or 2 3d shapes.
-      if (this.areAllDrawings(args)) {
-        return args[0].fuse(args[1]);
-      } else if (this.areAll3DShapes(args)) {
-        return this.as3dShapeOrThrow(args[0].fuse(args[1]));
-      } else {
-        throw new Error(
-          "Invalid types for fusion: " +
-            typeof args[0] +
-            " and " +
-            typeof args[1],
+    if (this.booleanOpCache.isOccluded(inputId1, inputId2, context.project)) {
+      this.cacheHit("occluded" + resultId);
+      return inputId2;
+    }
+    if (this.booleanOpCache.isOccluded(inputId2, inputId1, context.project)) {
+      this.cacheHit("occluded" + resultId);
+      return inputId1;
+    }
+
+    const boolResult = await this.maybeOp(
+      resultId,
+      sortedArgs,
+      context,
+      //@ts-expect-error type coercion done in maybeop.
+      (args) => args[0].fuse(args[1]),
+    );
+    if (boolResult.outcome == BooleanOutcome.InputShape) {
+      if (boolResult.inputIndexAsResult == 0) {
+        this.booleanOpCache.recordOcclusion(
+          sortedArgs[1],
+          sortedArgs[0],
+          context.project,
+        );
+      } else if (boolResult.inputIndexAsResult == 1) {
+        this.booleanOpCache.recordOcclusion(
+          sortedArgs[0],
+          sortedArgs[1],
+          context.project,
         );
       }
-    });
-    return resultId;
+    }
+    return boolResult.resultId;
   }
 
   async assemblyFuse(
@@ -871,152 +926,48 @@ class GeometryProvider {
     cutter: string,
     context: RequestContext,
   ): Promise<string | undefined> {
-    console.warn(
-      `cut toCut is: ${hashString(toCut)} being cut with: ${hashString(cutter)}`,
-    );
+    if (
+      toCut === this.EMPTY_SHAPE_SENTINEL ||
+      cutter === this.EMPTY_SHAPE_SENTINEL
+    ) {
+      return toCut;
+    }
+    const resultId = this._makeId("cut", toCut, cutter);
 
-    // Don't deserialize if it's a cache hit. Move checks inside the
-    // cache check operation.
-    return await this.booleanOperation(
-      this._makeId("cut", toCut, cutter),
+    // Fast no op checks
+    if (this.booleanOpCache.isDisjoint(toCut, cutter, context.project)) {
+      this.cacheHit("disjoint" + resultId);
+      return toCut;
+    }
+    if (this.booleanOpCache.isOccluded(toCut, cutter, context.project)) {
+      this.cacheHit("occluded" + resultId);
+      return this.EMPTY_SHAPE_SENTINEL;
+    }
+
+    const boolResult = await this.maybeOp(
+      resultId,
       [toCut, cutter],
       context,
-      async (_inputs, phase) => {
-        // Empty shape special cases
-        if (toCut === this.EMPTY_SHAPE_SENTINEL) {
-          return { outcome: BooleanOutcome.EmptyShape };
-        } else if (cutter === this.EMPTY_SHAPE_SENTINEL) {
-          return {
-            outcome: BooleanOutcome.InputShape,
-            inputIndexAsResult: 0,
-          };
-        }
-        console.warn(
-          `cut no cache hits. computing cut: ${hashString(toCut)} with: ${hashString(cutter)}`,
-        );
-
-        phase("deserialize toCut");
-        const getToCutStart = performance.now();
-        const toCutGeom = await this.get(toCut, context);
-        const toCutMs = Math.round(performance.now() - getToCutStart);
-        if (toCutMs > 1000) {
-          console.warn(
-            `[boolean] cut deserialize toCut took ${toCutMs}ms (${toCut.length}-char id)`,
-          );
-        }
-
-        phase("deserialize cutter");
-        const getCutterStart = performance.now();
-        const cutterGeom = await this.get(cutter, context);
-        const cutterMs = Math.round(performance.now() - getCutterStart);
-        if (cutterMs > 1000) {
-          console.warn(
-            `[boolean] cut deserialize cutter took ${cutterMs}ms (${cutter.length}-char id)`,
-          );
-        }
-
-        const args = [toCutGeom, cutterGeom];
-        if (this.areAllDrawings(args)) {
-          phase("2D cut()");
-          reportBooleanInflight(toCut, cutter, true);
-          const drawingResult = args[0].cut(args[1]);
-          reportBooleanInflight(toCut, cutter, false);
-          return {
-            outcome: BooleanOutcome.NewShape,
-            result: drawingResult,
-          };
-        } else if (this.areAll3DShapes(args)) {
-          phase("measureVolume(initial)");
-          const mv1Start = performance.now();
-          const initialVolume = replicad.measureVolume(args[0]);
-          const mv1Ms = Math.round(performance.now() - mv1Start);
-          if (mv1Ms > 1000) {
-            console.warn(
-              `[boolean] cut measureVolume(initial) took ${mv1Ms}ms`,
-            );
-          }
-
-          /*          phase("manifold preview");
-          const manifoldPreviewStart = performance.now();
-          const manifoldToCut = (toCutGeom as replicad.Shape3D).meshShape({
-            tolerance: 0.01,
-          });
-          const manifoldCutter = (cutterGeom as replicad.Shape3D).meshShape();
-          const prepDone = performance.now();
-          /*          // manifold generation took a long time to compute try it with some different tolerances
-          // to see if performance scales with tolerance
-          const timings = [0.1, 0.01].map((tolerance) => {
-            const s = performance.now();
-            const c1 = (toCutGeom as replicad.Shape3D).meshShape({
-              tolerance,
-            });
-            return [tolerance, performance.now() - s];
-          });
-          timings.push([1e-6, prepDone - manifoldPreviewStart]);
-          console.log(`meshshape generation against tolerance: ${timings}`);
-          console.warn(
-            `[boolean] cut manifold generation took ${Math.round(prepDone - manifoldPreviewStart)}ms`,
-          );
-          const intersection = manifoldToCut.intersect(manifoldCutter);
-          console.warn(
-            `[boolean] manifold intersect took ${Math.round(performance.now() - prepDone)}ms. Vol: ${intersection.volume()}`,
-          );*/
-
-          phase("3D cut()");
-          // Announce the exact cut about to run. If `.cut()` hangs, the worker
-          // thread freezes and the matching `false` beacon below never sends, so
-          // the main thread still sees this cut as in-flight and can record it as
-          // a known-hanging cut when the watchdog fires.
-          reportBooleanInflight(toCut, cutter, true);
-          const cutStart = performance.now();
-          const result = args[0].cut(args[1]);
-          reportBooleanInflight(toCut, cutter, false);
-          const cutMs = Math.round(performance.now() - cutStart);
-          if (cutMs > 1000) {
-            console.warn(`[boolean] cut .cut() took ${cutMs}ms`);
-          }
-
-          phase("measureVolume(result)");
-          const mv2Start = performance.now();
-          const resultVolume = replicad.measureVolume(result);
-          const mv2Ms = Math.round(performance.now() - mv2Start);
-          if (mv2Ms > 1000) {
-            console.warn(
-              `[boolean] cut measureVolume(result) took ${mv2Ms}ms`,
-            );
-          }
-
-          const volumeDiff = Math.abs(initialVolume - resultVolume);
-          const tolerance = 1e-5;
-          if (volumeDiff < tolerance) {
-            // DIAGNOSTIC: a boolean that removed ~no volume yet ran (bounding
-            // boxes overlapped) is a degenerate/wasted-cut candidate. Paired
-            // with the [boolean] timing line this flags expensive no-op cuts.
-            console.warn(
-              `[boolean] cut near-noop toCut=${toCut} cutter=${cutter} initialVolume=${initialVolume} volumeDiff=${volumeDiff}`,
-            );
-            return {
-              outcome: BooleanOutcome.InputShape,
-              inputIndexAsResult: 0,
-            };
-          } else if (resultVolume < tolerance) {
-            return { outcome: BooleanOutcome.EmptyShape };
-          } else {
-            return {
-              outcome: BooleanOutcome.NewShape,
-              result: this.as3dShapeOrThrow(result),
-            };
-          }
-        } else {
-          throw new Error(
-            "Invalid types for cut: " +
-              typeof args[0] +
-              " and " +
-              typeof args[1],
-          );
-        }
-      },
+      //@ts-expect-error type checking happens in maybeop
+      (args) => args[0].cut(args[1]),
     );
+
+    if (boolResult.outcome == BooleanOutcome.EmptyShape) {
+      this.booleanOpCache.recordOcclusion(toCut, cutter, context.project);
+    }
+    if (boolResult.outcome == BooleanOutcome.InputShape) {
+      if (boolResult.inputIndexAsResult == 0) {
+        this.booleanOpCache.recordDisjoint(toCut, cutter, context.project);
+      } else if (boolResult.inputIndexAsResult == 1) {
+        // Special case. This volume-match is erronious since the cutter
+        // cannot be the result. Return resultId instead.
+        return resultId;
+      }
+    }
+    if (boolResult.outcome == BooleanOutcome.NewShape) {
+      this.booleanOpCache.recordDisjoint(resultId, cutter, context.project);
+    }
+    return boolResult.resultId;
   }
 
   /**

--- a/src/worker/geometryProvider.ts
+++ b/src/worker/geometryProvider.ts
@@ -216,7 +216,9 @@ class GeometryProvider {
 
     // Start actual computation of the op. No cache had the result ready for us.
     const start = performance.now();
-    console.warn(`[boolean] ${resultId.split("-")[0]} starting at ${start}`);
+    console.warn(
+      `[boolean] ${resultId.split("-")[0]} starting for ${resultId}`,
+    );
     // deserialize args
     const geoms = await Promise.all(
       args.map((shapeid) => this.get(shapeid, context)),
@@ -227,6 +229,9 @@ class GeometryProvider {
 
     // case 2D
     if (this.areAllDrawings(geoms)) {
+      // Skip all no-op style optimizations here. Boolean operations on drawings are faster and
+      // drawings are smaller in the cache so the more complicated logic we use for 3d operations
+      // isn't worthwhile.
       const result = operation(geoms);
       await putShape(context.project, resultId, result.serialize());
       this.cacheMiss(resultId, start - performance.now());

--- a/src/worker/geometryProvider.ts
+++ b/src/worker/geometryProvider.ts
@@ -6,6 +6,7 @@ import {
   asReplicadPlane,
   flattenAssembly,
   hashStringWide,
+  hashString,
   SimplePlane,
 } from "./util";
 import {
@@ -17,7 +18,6 @@ import {
   StoredGeometryRecord,
   filter,
 } from "./indexeddbUtils";
-import { GCWithScope } from "replicad";
 import { reportBooleanInflight } from "./progress";
 
 type ReplicadObject =
@@ -77,6 +77,8 @@ class GeometryProvider {
   private projectLRU: string[] = [];
   private cacheHitMetrics: Record<string, [number, number, number]>; // hits, misses, total-miss-duration-ms
   private warmCache: Map<string, Map<string, ReplicadObject>> = new Map();
+  private noOpCache: Map<string, string> = new Map();
+
   // Tracks batch operations that are currently running so that concurrent
   // requests for an identical batch (same content-hashed id) share the first
   // one's result instead of racing and throwing "already exists".
@@ -92,7 +94,10 @@ class GeometryProvider {
     if (logMetrics) {
       setInterval(() => {
         console.warn("[GeometryProvider] cache metrics:", this.cacheHitMetrics);
-        console.warn("[GeometryProvider] replicad live shapes:", getReplicadLiveCounts());
+        console.warn(
+          "[GeometryProvider] replicad live shapes:",
+          getReplicadLiveCounts(),
+        );
       }, 10000);
     }
   }
@@ -181,6 +186,16 @@ class GeometryProvider {
       return resultId;
     }
 
+    if (this.noOpCache.has(resultId)) {
+      const result = this.noOpCache.get(resultId)!;
+      if (this.EMPTY_SHAPE_SENTINEL == result) {
+        this.cacheHit("boolempty");
+      } else {
+        this.cacheHit("boolnoop");
+      }
+      return result;
+    }
+
     // Cache miss. Compute the operation then either:
     //  add result to the cache
     //  if a no-op return the appropriate input id
@@ -228,7 +243,8 @@ class GeometryProvider {
     }
     switch (opResult.outcome) {
       case BooleanOutcome.EmptyShape:
-        this.cacheHit("boolempty" + resultId);
+        this.cacheMiss("boolempty" + resultId, performance.now() - start);
+        this.noOpCache.set(resultId, this.EMPTY_SHAPE_SENTINEL);
         return this.EMPTY_SHAPE_SENTINEL;
       case BooleanOutcome.InputShape:
         if (opResult.inputIndexAsResult === undefined) {
@@ -237,7 +253,8 @@ class GeometryProvider {
               JSON.stringify(opResult),
           );
         }
-        this.cacheHit("boolnoop" + resultId);
+        this.cacheMiss("boolnoop" + resultId, performance.now() - start);
+        this.noOpCache.set(resultId, inputs[opResult.inputIndexAsResult]);
         return inputs[opResult.inputIndexAsResult];
       case BooleanOutcome.NewShape:
         this.cacheMiss(resultId, performance.now() - start);
@@ -854,6 +871,10 @@ class GeometryProvider {
     cutter: string,
     context: RequestContext,
   ): Promise<string | undefined> {
+    console.warn(
+      `cut toCut is: ${hashString(toCut)} being cut with: ${hashString(cutter)}`,
+    );
+
     // Don't deserialize if it's a cache hit. Move checks inside the
     // cache check operation.
     return await this.booleanOperation(
@@ -870,6 +891,9 @@ class GeometryProvider {
             inputIndexAsResult: 0,
           };
         }
+        console.warn(
+          `cut no cache hits. computing cut: ${hashString(toCut)} with: ${hashString(cutter)}`,
+        );
 
         phase("deserialize toCut");
         const getToCutStart = performance.now();
@@ -911,6 +935,32 @@ class GeometryProvider {
               `[boolean] cut measureVolume(initial) took ${mv1Ms}ms`,
             );
           }
+
+          /*          phase("manifold preview");
+          const manifoldPreviewStart = performance.now();
+          const manifoldToCut = (toCutGeom as replicad.Shape3D).meshShape({
+            tolerance: 0.01,
+          });
+          const manifoldCutter = (cutterGeom as replicad.Shape3D).meshShape();
+          const prepDone = performance.now();
+          /*          // manifold generation took a long time to compute try it with some different tolerances
+          // to see if performance scales with tolerance
+          const timings = [0.1, 0.01].map((tolerance) => {
+            const s = performance.now();
+            const c1 = (toCutGeom as replicad.Shape3D).meshShape({
+              tolerance,
+            });
+            return [tolerance, performance.now() - s];
+          });
+          timings.push([1e-6, prepDone - manifoldPreviewStart]);
+          console.log(`meshshape generation against tolerance: ${timings}`);
+          console.warn(
+            `[boolean] cut manifold generation took ${Math.round(prepDone - manifoldPreviewStart)}ms`,
+          );
+          const intersection = manifoldToCut.intersect(manifoldCutter);
+          console.warn(
+            `[boolean] manifold intersect took ${Math.round(performance.now() - prepDone)}ms. Vol: ${intersection.volume()}`,
+          );*/
 
           phase("3D cut()");
           // Announce the exact cut about to run. If `.cut()` hangs, the worker
@@ -1293,7 +1343,7 @@ class GeometryProvider {
     // collapsed id can never collide with a non-collapsed one, and identical
     // recipes always collapse identically — preserving cache correctness.
     if (key.length > GeometryProvider.MAX_ID_LENGTH) {
-      return type + "#" + hashStringWide(key);
+      return type + "-#" + hashStringWide(key);
     }
     return key;
   }

--- a/src/worker/indexeddbUtils.ts
+++ b/src/worker/indexeddbUtils.ts
@@ -1,4 +1,4 @@
-export type DataType = "ReplicadObject" | "AbundanceObject";
+export type DataType = "ReplicadObject" | "AbundanceObject" | "PairCache";
 export type StoredGeometryRecord = {
   projectId: string;
   shapeKey: string;
@@ -136,6 +136,60 @@ export async function deleteShape(
   });
 }
 
+/**
+ * Stores a serialized blob (eg: a JSON-encoded array of known disjoint/occlusion
+ * pairs) under the "PairCache" type. Blob stored as a single record keyed by
+ * project and blobkey.
+ */
+export async function putPairCache(
+  projectId: string,
+  blobKey: string,
+  serialized: string,
+): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readwrite");
+    const store = tx.objectStore(STORE_NAME);
+    store.put({
+      projectId: projectId,
+      shapeKey: blobKey,
+      type: "PairCache",
+      serialized: serialized,
+    });
+    tx.oncomplete = () => {
+      db.close();
+      resolve();
+    };
+    tx.onerror = () => {
+      db.close();
+      reject(tx.error);
+    };
+  });
+}
+
+/**
+ * Retrieves a previously-stored "PairCache" blob, or undefined if absent.
+ */
+export async function getPairCache(
+  projectId: string,
+  blobKey: string,
+): Promise<StoredGeometryRecord | undefined> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readonly");
+    const store = tx.objectStore(STORE_NAME);
+    const req = store.get([projectId, blobKey]);
+    req.onsuccess = () => {
+      db.close();
+      resolve(req.result);
+    };
+    req.onerror = () => {
+      db.close();
+      reject(req.error);
+    };
+  });
+}
+
 export async function shapeExists(
   projectId: string,
   shapeKey: string,
@@ -232,5 +286,6 @@ export async function filter(
 export async function deleteProjectCache(projectId: string): Promise<void> {
   await filter(projectId, "ReplicadObject", () => false, false);
   await filter(projectId, "AbundanceObject", () => false, false);
+  await filter(projectId, "PairCache", () => false, false);
   return;
 }

--- a/src/worker/interaction.ts
+++ b/src/worker/interaction.ts
@@ -551,15 +551,41 @@ async function fuseAssembly(
   context: RequestContext,
 ): Promise<AbundanceLeaf> {
   await util.init();
-  const flattened = util.flattenAssembly(assembly);
-  if (flattened.length === 0) {
-    throw new Error("No geometries found in assembly");
+  if (util.isFace(assembly)) {
+    throw new Error("Faces cannot be fused.");
   }
-  // TODO: should be union of tags and bom?
+
+  // Exclude wires, points
+  const flat = util.flattenAssembly(assembly).filter((shape) => {
+    return util.is2D(shape) || util.is3D(shape);
+  });
+  if (flat.length == 0) {
+    throw new Error(
+      "No fusable elements in this assembly. Wires and Points cannot be fused",
+    );
+  }
+  let result: string | undefined = flat[0].geometry;
+  for (let i = 1; i < flat.length; i++) {
+    if (result == undefined) {
+      throw Error("got undefined shape from fuse.");
+    }
+    reportCadProgress(`fuseAssembly ${i}/${flat.length}`);
+    result = await util.geometryProvider?.fuse(
+      result,
+      flat[i].geometry,
+      context,
+    );
+  }
+  if (result == undefined) {
+    throw Error("got undefined shape from fuse.");
+  }
   return {
-    ...assembly,
-    geometry: await util.geometryProvider!.assemblyFuse(assembly, context),
-    dimension: flattened[0].dimension,
+    geometry: result,
+    tags: [...new Set(flat.map((s) => s.tags).flat())],
+    bom: [...new Set(flat.map((s) => s.bom).flat())],
+    dimension: flat[0].dimension,
+    plane: flat[0].plane,
+    color: flat[0].color, // TODO consider most common color?
   };
 }
 

--- a/src/worker/interaction.ts
+++ b/src/worker/interaction.ts
@@ -569,7 +569,7 @@ async function fuseAssembly(
     if (result == undefined) {
       throw Error("got undefined shape from fuse.");
     }
-    reportCadProgress(`fuseAssembly ${i}/${flat.length}`);
+    reportCadProgress(`fuseAssembly ${i}/${flat.length - 1}`);
     result = await util.geometryProvider?.fuse(
       result,
       flat[i].geometry,


### PR DESCRIPTION
Remove assemblyFuse and instead perform fuse one step at a time. This helps avoid hitting the operation timeout when doing a complex fuse since now each step resets the timer once it's complete. This also allows better progress reporting in the UI.

TODO: 

- [ ] consider if assemblyFuse should be a batch operation. Pros: batching this avoids paying the overhead of serialize/deserialize between each step. However, it means that if a timeout does occur no progress has been saved.