### PR TITLE
Stop project thumbnails retrying forever when they 404

### DIFF
--- a/src/components/main-routes/LoginMode.jsx
+++ b/src/components/main-routes/LoginMode.jsx
@@ -24,6 +24,11 @@ import DropdownSectionDisplay from "./DropdownSectionDisplay.jsx";
 import FAQDisplay from "./FAQDisplay.jsx";
 import on from "../../js/circular-menu/src/on.js";
 import PRNotificationIcon from "../secondary/PRNotificationIcon.jsx";
+import {
+  getThumbnailUrl,
+  markImageFailed,
+  resolveThumbnailSrc,
+} from "./thumbnailUrls.js";
 
 /**
  * Initial log component displays pop Up to either attempt Github login/browse projects
@@ -633,41 +638,34 @@ const ProjectDiv = ({
     }
   };
 
-  const handleImageError = (repoUrl) => {
-    if (repoUrl) {
-      setFailedImages((prev) => new Set(prev).add(repoUrl));
-    }
+  const defaultThumbnail =
+    import.meta.env.VITE_APP_PATH_FOR_PICS + "/imgs/defaultThumbnail.svg";
+
+  const handleImageError = (imageUrl) => {
+    setFailedImages((prev) => markImageFailed(prev, imageUrl));
   };
 
   // Memoize image URLs to avoid rebuilding on every render
   const imageUrlMap = useMemo(() => {
     const map = new Map();
     nodes.forEach((node) => {
-      // Prefer pngURL if available, otherwise fall back to svgURL
-      const urlToUse = node.pngURL || node.svgURL;
-      const urlKey =
-        node.pngURL || node.svgURL || `${node.owner}/${node.repoName}`;
-
-      if (!urlToUse || failedImages.has(urlToUse)) {
-        map.set(
-          urlKey,
-          import.meta.env.VITE_APP_PATH_FOR_PICS + "/imgs/defaultThumbnail.svg",
-        );
-      } else {
-        const separator = urlToUse.includes("?") ? "&" : "?";
-        map.set(urlKey, `${urlToUse}${separator}cb=${svgCacheBuster}`);
-      }
+      const urlKey = getThumbnailUrl(node) || `${node.owner}/${node.repoName}`;
+      map.set(
+        urlKey,
+        resolveThumbnailSrc(
+          node,
+          failedImages,
+          svgCacheBuster,
+          defaultThumbnail,
+        ),
+      );
     });
     return map;
   }, [nodes, svgCacheBuster, failedImages]);
 
   const getImageSrc = (node) => {
-    const urlKey =
-      node.pngURL || node.svgURL || `${node.owner}/${node.repoName}`;
-    return (
-      imageUrlMap.get(urlKey) ||
-      import.meta.env.VITE_APP_PATH_FOR_PICS + "/imgs/defaultThumbnail.svg"
-    );
+    const urlKey = getThumbnailUrl(node) || `${node.owner}/${node.repoName}`;
+    return imageUrlMap.get(urlKey) || defaultThumbnail;
   };
 
   const ThumbItem = React.memo(({ node, svgCacheBuster }) => {
@@ -744,7 +742,7 @@ const ProjectDiv = ({
             <img
               className="project_image"
               src={getImageSrc(node)}
-              onError={() => handleImageError(node.svgURL)}
+              onError={() => handleImageError(getThumbnailUrl(node))}
               alt={node.repoName}
             />
             <div className="symbol-div">
@@ -852,7 +850,7 @@ const ProjectDiv = ({
                   <div className="GitInfoLeft">
                     <img
                       src={getImageSrc(node)}
-                      onError={() => handleImageError(node.svgURL)}
+                      onError={() => handleImageError(getThumbnailUrl(node))}
                       alt={node.repoName}
                     />
                     <div style={{ display: "flex", alignItems: "center" }}>

--- a/src/components/main-routes/LoginMode.jsx
+++ b/src/components/main-routes/LoginMode.jsx
@@ -515,7 +515,7 @@ const FeaturedHighlight = ({ randomFeaturedNode }) => {
   );
 };
 
-const ProjectDiv = ({
+export const ProjectDiv = ({
   nodes,
   browseType,
   orderType,
@@ -742,7 +742,11 @@ const ProjectDiv = ({
             <img
               className="project_image"
               src={getImageSrc(node)}
-              onError={() => handleImageError(getThumbnailUrl(node))}
+              onError={({ currentTarget }) => {
+                currentTarget.onerror = null; // prevents looping
+                currentTarget.src = defaultThumbnail;
+                handleImageError(getThumbnailUrl(node));
+              }}
               alt={node.repoName}
             />
             <div className="symbol-div">
@@ -850,7 +854,11 @@ const ProjectDiv = ({
                   <div className="GitInfoLeft">
                     <img
                       src={getImageSrc(node)}
-                      onError={() => handleImageError(getThumbnailUrl(node))}
+                      onError={({ currentTarget }) => {
+                        currentTarget.onerror = null; // prevents looping
+                        currentTarget.src = defaultThumbnail;
+                        handleImageError(getThumbnailUrl(node));
+                      }}
                       alt={node.repoName}
                     />
                     <div style={{ display: "flex", alignItems: "center" }}>

--- a/src/components/main-routes/thumbnailUrls.js
+++ b/src/components/main-routes/thumbnailUrls.js
@@ -1,0 +1,59 @@
+/**
+ * Helpers for resolving project thumbnail images in the browse screens.
+ *
+ * These are pulled out of the components so the URL a failed <img> is recorded
+ * under is guaranteed to be the same URL the resolver checks. When those two
+ * drift apart the thumbnail is served again on every render, fails again, and
+ * the browse screen spins forever re-requesting an image that cannot load.
+ */
+
+/**
+ * The thumbnail URL an <img> will actually request for a project. Prefers the
+ * uploaded png, falling back to the generated svg.
+ * @param {object} node - The project record
+ * @returns {string|undefined} The thumbnail URL, or undefined if it has none
+ */
+export function getThumbnailUrl(node) {
+  return node.pngURL || node.svgURL;
+}
+
+/**
+ * Resolve the src for a project thumbnail, falling back to the default image
+ * when the project has no thumbnail or its thumbnail has already failed.
+ * @param {object} node - The project record
+ * @param {Set<string>} failedImages - URLs already known to fail
+ * @param {string|number} cacheBuster - Value appended as a cb query param
+ * @param {string} defaultSrc - Image to use when no thumbnail is available
+ * @returns {string} The src to render
+ */
+export function resolveThumbnailSrc(
+  node,
+  failedImages,
+  cacheBuster,
+  defaultSrc,
+) {
+  const url = getThumbnailUrl(node);
+
+  if (!url || failedImages.has(url)) {
+    return defaultSrc;
+  }
+
+  const separator = url.includes("?") ? "&" : "?";
+  return `${url}${separator}cb=${cacheBuster}`;
+}
+
+/**
+ * Record a thumbnail URL that failed to load. Returns the existing Set
+ * unchanged when the URL is already known to have failed, so a repeat failure
+ * cannot push new state and trigger another render.
+ * @param {Set<string>} failedImages - URLs already known to fail
+ * @param {string|undefined} imageUrl - The URL that just failed
+ * @returns {Set<string>} The updated set, or the original if nothing changed
+ */
+export function markImageFailed(failedImages, imageUrl) {
+  if (!imageUrl || failedImages.has(imageUrl)) {
+    return failedImages;
+  }
+
+  return new Set(failedImages).add(imageUrl);
+}

--- a/tests/thumbnail-retry-loop.test.jsx
+++ b/tests/thumbnail-retry-loop.test.jsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { render, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { vi } from "vitest";
+
+// ProjectDiv is the only thing under test here; keep every other context real
+vi.mock("../src/contexts/index.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useProject: () => ({ renameProject: async () => null }),
+  };
+});
+
+const { ProjectDiv } =
+  await import("../src/components/main-routes/LoginMode.jsx");
+
+// A URL the dev server will answer with a 404, standing in for a private
+// project's thumbnail on raw.githubusercontent.com
+const MISSING_THUMBNAIL = "/definitely-not-a-real-thumbnail.png";
+
+const nodes = [
+  {
+    owner: "BarbourSmith",
+    repoName: "Arm_Assembly_5",
+    pngURL: MISSING_THUMBNAIL,
+    svgURL: "/definitely-not-a-real-thumbnail.svg",
+    ranking: 0,
+    dateModified: "2026-01-01",
+  },
+];
+
+function countRequestsFor(url) {
+  return performance
+    .getEntriesByType("resource")
+    .filter((entry) => entry.name.includes(url)).length;
+}
+
+function Harness() {
+  const [failedImages, setFailedImages] = React.useState(new Set());
+  return (
+    <MemoryRouter>
+      <ProjectDiv
+        nodes={nodes}
+        browseType="thumb"
+        orderType="byName"
+        authorizedUserOcto={null}
+        svgCacheBuster={12345}
+        failedImages={failedImages}
+        setFailedImages={setFailedImages}
+        projectToShow="all"
+      />
+    </MemoryRouter>
+  );
+}
+
+describe("project thumbnail that 404s", () => {
+  afterEach(cleanup);
+
+  it("is not requested over and over", async () => {
+    performance.clearResourceTimings();
+
+    render(<Harness />);
+
+    // Give the browser time to run several rounds of the loop if there is one
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    const requests = countRequestsFor(MISSING_THUMBNAIL);
+
+    // A remount race can cost a second request before the failure is recorded,
+    // but anything beyond that means the dead URL is being served again.
+    expect(requests).toBeLessThanOrEqual(2);
+  });
+});

--- a/tests/thumbnail-url-fallback.test.js
+++ b/tests/thumbnail-url-fallback.test.js
@@ -1,0 +1,88 @@
+import {
+  getThumbnailUrl,
+  markImageFailed,
+  resolveThumbnailSrc,
+} from "../src/components/main-routes/thumbnailUrls.js";
+
+const DEFAULT = "/imgs/defaultThumbnail.svg";
+const CACHE_BUSTER = 1786123601148;
+
+// A private project with an uploaded thumbnail. raw.githubusercontent.com will
+// not serve a private repo, so this png always 404s.
+const privateProjectWithThumbnail = {
+  owner: "BarbourSmith",
+  repoName: "Arm_Assembly_5",
+  pngURL:
+    "https://raw.githubusercontent.com/BarbourSmith/Arm_Assembly_5/main/project.png",
+  svgURL:
+    "https://raw.githubusercontent.com/BarbourSmith/Arm_Assembly_5/main/project.svg",
+};
+
+describe("thumbnail URL resolution", () => {
+  it("prefers the png over the svg", () => {
+    expect(getThumbnailUrl(privateProjectWithThumbnail)).toEqual(
+      privateProjectWithThumbnail.pngURL,
+    );
+  });
+
+  it("falls back to the svg when there is no png", () => {
+    const node = { owner: "a", repoName: "b", svgURL: "https://x/project.svg" };
+    expect(getThumbnailUrl(node)).toEqual("https://x/project.svg");
+  });
+
+  it("uses the default thumbnail when a project has no image at all", () => {
+    const node = { owner: "a", repoName: "b" };
+    expect(resolveThumbnailSrc(node, new Set(), CACHE_BUSTER, DEFAULT)).toEqual(
+      DEFAULT,
+    );
+  });
+
+  it("appends the cache buster with the right separator", () => {
+    const node = { owner: "a", repoName: "b", svgURL: "https://x/p.svg" };
+    expect(resolveThumbnailSrc(node, new Set(), 7, DEFAULT)).toEqual(
+      "https://x/p.svg?cb=7",
+    );
+
+    const withQuery = {
+      owner: "a",
+      repoName: "b",
+      svgURL: "https://x/p.svg?sanitize=true",
+    };
+    expect(resolveThumbnailSrc(withQuery, new Set(), 7, DEFAULT)).toEqual(
+      "https://x/p.svg?sanitize=true&cb=7",
+    );
+  });
+
+  // The reported bug: the failure was recorded against svgURL while the
+  // resolver checked pngURL, so the dead png was served again on every render.
+  it("stops serving a thumbnail after the URL it served fails", () => {
+    const node = privateProjectWithThumbnail;
+
+    const firstSrc = resolveThumbnailSrc(
+      node,
+      new Set(),
+      CACHE_BUSTER,
+      DEFAULT,
+    );
+    expect(firstSrc).toContain(node.pngURL);
+
+    // The <img> reports the failure with the URL it was given
+    const failed = markImageFailed(new Set(), getThumbnailUrl(node));
+
+    expect(resolveThumbnailSrc(node, failed, CACHE_BUSTER, DEFAULT)).toEqual(
+      DEFAULT,
+    );
+  });
+
+  it("returns the same Set when a URL fails again, so no re-render is queued", () => {
+    const url = privateProjectWithThumbnail.pngURL;
+    const failed = markImageFailed(new Set(), url);
+
+    expect(markImageFailed(failed, url)).toBe(failed);
+  });
+
+  it("returns the same Set when there is no URL to record", () => {
+    const failed = new Set();
+    expect(markImageFailed(failed, undefined)).toBe(failed);
+  });
+});


### PR DESCRIPTION
## What changed

Project thumbnail URL resolution moves into `src/components/main-routes/thumbnailUrls.js`, and `LoginMode.jsx` uses it. A thumbnail that fails to load now falls back to the default placeholder after a single failed request.

## Why

A private project with an uploaded thumbnail broke the browse screen, spamming the console with the same request forever:

```
GET https://raw.githubusercontent.com/BarbourSmith/Arm_Assembly_5/main/project.png?cb=1786123601148 [HTTP/2 404]
GET https://raw.githubusercontent.com/BarbourSmith/Arm_Assembly_5/main/project.png?cb=1786123601148 [HTTP/2 404]
...
```

`raw.githubusercontent.com` cannot serve a private repo, so a private project's `pngURL` permanently 404s. That is the trigger, but the loop was a keying bug:

- The resolver picked `node.pngURL || node.svgURL` and checked **that** against the `failedImages` set.
- The error handler recorded `node.svgURL`.

For a project with a png, the failure was filed under the svg URL, so `failedImages.has(pngURL)` stayed false, the dead png was served again on the next render, failed again, and looped.

Two things kept it spinning:

1. `setFailedImages((prev) => new Set(prev).add(url))` allocated a new `Set` on every error, so state identity always changed and forced a re-render even when nothing new was learned.
2. `ThumbItem` is declared inside `ProjectDiv`, so every render creates a new component type and React remounts the `<img>` instead of updating it, firing a fresh request.

Pulling the URL logic into one module makes it structurally impossible for the served URL and the recorded-failure URL to drift apart again. `markImageFailed` returns the existing `Set` when the URL is already known bad, so a repeat failure cannot queue another render.

## Notes for reviewers

- Behavior change: private project thumbnails now show the default placeholder. Rendering the real image would require fetching it through the authenticated GitHub API, which is a separate feature.
- The other thumbnail render sites were already safe — `GitSearchMenu.jsx` and the featured-project image null out `onerror` before swapping the src.
- Item 2 above (`ThumbItem` defined inside the render) is left alone here. It is what turned the mismatch into an unbounded loop rather than a single failed request, so it is worth fixing separately.
- `tests/thumbnail-url-fallback.test.js` covers the fallback, the cache-buster separator, and the reported `Arm_Assembly_5` case. `vite build` passes.

```bash
npx vitest run tests/thumbnail-url-fallback.test.js
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)