### PR TITLE
Auto generate PNG + depth order fix 

### DIFF
--- a/src/contexts/ProjectContext.jsx
+++ b/src/contexts/ProjectContext.jsx
@@ -8,6 +8,10 @@ import { re } from "mathjs";
 import { useAuth } from "./AuthContext.jsx";
 import { useAppState } from "./AppStateContext.jsx";
 import { useNavigate } from "react-router-dom";
+import {
+  generateMeshPNG,
+  extractBase64FromDataURL,
+} from "../js/meshPNGGenerator.js";
 
 const ProjectContext = createContext();
 
@@ -53,6 +57,46 @@ export function ProjectProvider({ children, cad, loadProject }) {
    * @param {boolean} exporting - If exporting a molecule
    *
    */
+  /**
+   * Generate preview.html content for social media previews
+   * @param {string} projectName - Name of the project
+   * @param {string} projectDescription - Project description
+   * @param {string} owner - GitHub owner
+   * @param {string} repo - GitHub repo name
+   * @returns {string} Base64-encoded HTML string
+   */
+  const generatePreviewHtml = (
+    projectName,
+    projectDescription,
+    owner,
+    repo,
+  ) => {
+    const previewUrl = `https://abundance.maslowcnc.com/run/${owner}/${repo}`;
+    const projectImageUrl = `https://raw.githubusercontent.com/${owner}/${repo}/main/project.png`;
+
+    const previewHtml = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <meta property="og:title" content="${projectName}" />
+  <meta property="og:description" content="${projectDescription.substring(0, 160)}" />
+  <meta property="og:image" content="${projectImageUrl}" />
+  <meta property="og:url" content="${previewUrl}" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="${projectName}" />
+  <meta name="twitter:description" content="${projectDescription.substring(0, 160)}" />
+  <meta name="twitter:image" content="${projectImageUrl}" />
+  <title>${projectName}</title>
+</head>
+<body>
+  <p>Loading project...</p>
+</body>
+</html>`;
+
+    return window.btoa(previewHtml);
+  };
+
   const createProject = async (
     authorizedUserOcto,
     [name, topics, description, license, units],
@@ -270,6 +314,33 @@ export function ProjectProvider({ children, cad, loadProject }) {
       content: window.btoa(GlobalVariables.toBinaryStr(licenses[license])),
     });
     setNewProjectBar(90);
+
+    // Generate and commit preview.html for social media previews
+    try {
+      const projectName = currentRepoName;
+      const projectDescription =
+        description || `Check out ${currentRepoName} in Abundance`;
+      npm;
+      // Generate base64-encoded preview.html
+      const base64PreviewHtml = generatePreviewHtml(
+        projectName,
+        projectDescription,
+        currentUser,
+        currentRepoName,
+      );
+
+      await authorizedUserOcto.rest.repos.createOrUpdateFileContents({
+        owner: currentUser,
+        repo: currentRepoName,
+        path: "preview.html",
+        message: "Initialize project preview metadata",
+        content: base64PreviewHtml,
+      });
+      console.log("preview.html created successfully");
+    } catch (err) {
+      console.error("Error creating preview.html:", err);
+      // Non-critical failure - continue anyway
+    }
 
     // Set topics with error handling
     try {
@@ -983,10 +1054,10 @@ export function ProjectProvider({ children, cad, loadProject }) {
   };
 
   /**
-   * Generate a thumbnail for the project
+   * Generate a PNG thumbnail for the project from the mesh
    */
-  const generateProjectThumbnail = async (meshRef) => {
-    //Generate a thumbnail for the project
+  const generateProjectThumbnail = async () => {
+    // Generate a PNG thumbnail for the project
     if (GlobalVariables.topLevelMolecule.value == null) {
       console.warn(
         "No top level molecule value found for thumbnail generation.",
@@ -994,24 +1065,30 @@ export function ProjectProvider({ children, cad, loadProject }) {
       return null;
     }
 
-    // Check if meshRef and meshRef.current are available
-    if (!meshRef || !meshRef.current) {
-      console.warn("meshRef is not available for thumbnail generation.");
+    try {
+      const mesh = await GlobalVariables.pool
+        .proxy()
+        .then((worker) => {
+          return worker.generateDisplayMesh(
+            GlobalVariables.topLevelMolecule.value,
+            GlobalVariables.topLevelMolecule.getContext(),
+          );
+        })
+        .then((result) => result.mesh);
+
+      if (!mesh) {
+        console.warn("No mesh generated for thumbnail");
+        return null;
+      }
+
+      // Generate PNG from mesh
+      const pngDataUrl = await generateMeshPNG(mesh);
+      console.log("Generated project thumbnail PNG data URL:", pngDataUrl);
+      return pngDataUrl;
+    } catch (error) {
+      console.error("Error generating project thumbnail:", error);
       return null;
     }
-
-    return GlobalVariables.pool
-      .proxy()
-      .then((worker) => {
-        return worker.generateDisplayMesh(
-          GlobalVariables.topLevelMolecule.value,
-          GlobalVariables.topLevelMolecule.getContext(),
-        );
-      })
-      .then(async (m) => {
-        const svg = await meshRef.current.buildThumbnail(m.mesh);
-        return svg;
-      });
   };
 
   /**
@@ -1023,6 +1100,7 @@ export function ProjectProvider({ children, cad, loadProject }) {
     updateSaveProgress,
     saveType = "Auto Save",
     setErrorNotification,
+    finalPNG,
   ) {
     try {
       updateSaveProgress(35);
@@ -1088,9 +1166,16 @@ export function ProjectProvider({ children, cad, loadProject }) {
                     });
                   }
                 } else {
-                  const encodedContent = window.btoa(
-                    GlobalVariables.toBinaryStr(fileContent),
-                  );
+                  // For PNG files, the content is already base64-encoded from the canvas
+                  // For other files, encode the text content
+                  let encodedContent;
+                  if (path === "project.png") {
+                    encodedContent = fileContent; // Already base64
+                  } else {
+                    encodedContent = window.btoa(
+                      GlobalVariables.toBinaryStr(fileContent),
+                    );
+                  }
 
                   await octokit.rest.repos.createOrUpdateFileContents({
                     owner,
@@ -1158,11 +1243,20 @@ export function ProjectProvider({ children, cad, loadProject }) {
                 sha: null,
               });
             } else {
+              // For PNG files, the content is already base64-encoded from the canvas
+              // For other files, encode the text content
+              let contentToBlob;
+              if (path === "project.png") {
+                contentToBlob = fileContent; // Already base64
+              } else {
+                contentToBlob = fileContent; // Text content
+              }
+
               const blobResponse = await octokit.rest.git.createBlob({
                 owner,
                 repo,
-                content: fileContent,
-                encoding: "utf-8",
+                content: contentToBlob,
+                encoding: path === "project.png" ? "base64" : "utf-8",
               });
               treeEntries.push({
                 path,
@@ -1174,8 +1268,7 @@ export function ProjectProvider({ children, cad, loadProject }) {
 
             processed += 1;
             updateSaveProgress(
-              50 +
-                Math.floor((processed / Math.max(files.length, 1)) * 20),
+              50 + Math.floor((processed / Math.max(files.length, 1)) * 20),
             );
           }
 
@@ -1236,20 +1329,29 @@ export function ProjectProvider({ children, cad, loadProject }) {
           topicString
         ).toLowerCase();
 
+        const attributeUpdates = {
+          ranking: 0,
+          privateRepo: privateRepo,
+          html_url: htmlURL,
+          searchField: searchField,
+          githubMoleculesUsed: githubMoleculeUsedList,
+          description: GlobalVariables.currentAWSnode.description,
+          topics: GlobalVariables.currentAWSnode.topics,
+        };
+
+        // Only update pngURL if user hasn't manually set a thumbnail
+        if (finalPNG && !GlobalVariables.currentAWSnode.userSetAsThumbnail) {
+          const pngUrl = `https://raw.githubusercontent.com/${owner}/${repo}/main/project.png`;
+          attributeUpdates.pngURL = pngUrl;
+          attributeUpdates.userSetAsThumbnail = false; // Reset userSetAsThumbnail to false since we're updating the thumbnail
+        }
+
         await fetch(apiUpdateUrl, {
           method: "POST",
           body: JSON.stringify({
             owner: owner,
             repoName: repo,
-            attributeUpdates: {
-              ranking: 0,
-              privateRepo: privateRepo,
-              html_url: htmlURL,
-              searchField: searchField,
-              githubMoleculesUsed: githubMoleculeUsedList,
-              description: GlobalVariables.currentAWSnode.description,
-              topics: GlobalVariables.currentAWSnode.topics,
-            },
+            attributeUpdates: attributeUpdates,
           }),
           headers: {
             "Content-type": "application/json; charset=UTF-8",
@@ -1284,7 +1386,7 @@ export function ProjectProvider({ children, cad, loadProject }) {
    * @param {Function} setSaveProgress - Function to update save progress
    * @param {string} typeSave - Type of save operation
    * @param {boolean} forceSave - If true, bypasses the "no changes" check
-   * @param {object} meshRef - Reference to the mesh for thumbnail generation (optional)
+   * @param {object} meshRef - Reference to the mesh (deprecated, kept for backwards compatibility)
    * @param {Function} setErrorNotification - Function to set error notifications (optional)
    * @param {Function} onSaveStart - Callback invoked only if changes are detected and save will proceed
    */
@@ -1323,7 +1425,8 @@ export function ProjectProvider({ children, cad, loadProject }) {
           return;
         }
 
-        const message = "Save already in progress. Please wait for it to finish.";
+        const message =
+          "Save already in progress. Please wait for it to finish.";
         setNotification(message, "warning");
         setTimeout(() => setNotification(null), 3000);
         return;
@@ -1381,13 +1484,17 @@ export function ProjectProvider({ children, cad, loadProject }) {
 
       updateSaveProgress(5); //Set the state to 5% to show the progress bar
 
-      let finalSVG;
-      // Only generate thumbnail for user-triggered saves, not auto saves
-      if (typeSave !== "Auto Save" && meshRef) {
-        finalSVG = await generateProjectThumbnail(meshRef).catch((error) => {
-          console.error("Error generating final project thumbnail: ", error);
+      let finalPNG = null;
+      // Generate PNG thumbnail for all saves (except auto saves on first time)
+      if (typeSave !== "Auto Save") {
+        finalPNG = await generateProjectThumbnail().catch((error) => {
+          console.error(
+            "Error generating final project thumbnail PNG: ",
+            error,
+          );
         });
       }
+      console.log("Final PNG generated for save:", finalPNG);
 
       updateSaveProgress(10);
       // Reuse the already serialized project data instead of serializing again
@@ -1465,15 +1572,20 @@ export function ProjectProvider({ children, cad, loadProject }) {
         return hasContent;
       };
 
-      // Only update project thumbnail if a valid one has been generated
-      // Prioritize finalSVG from main output, but fall back to readme SVG if main output is empty
+      // Add auto-generated PNG thumbnail if available (unless user has manually set one)
+      if (finalPNG && !GlobalVariables.currentAWSnode.userSetAsThumbnail) {
+        const pngBase64 = extractBase64FromDataURL(finalPNG);
+        filesObject["project.png"] = pngBase64;
+      }
+      // Only update project SVG thumbnail if a valid one has been generated
+      // (keeping existing SVG logic for backwards compatibility)
       const thumbnailToUse =
-        finalSVG && isValidSVG(finalSVG)
-          ? finalSVG
+        finalPNG && !GlobalVariables.currentAWSnode.userSetAsThumbnail
+          ? finalPNG
           : backupProjectSVG && isValidSVG(backupProjectSVG)
             ? backupProjectSVG
             : null;
-      if (thumbnailToUse) {
+      if (thumbnailToUse && isValidSVG(thumbnailToUse)) {
         filesObject["project.svg"] = thumbnailToUse;
       }
       // If no valid thumbnail was generated, don't include project.svg in the commit
@@ -1494,6 +1606,7 @@ export function ProjectProvider({ children, cad, loadProject }) {
         updateSaveProgress,
         typeSave,
         setErrorNotification,
+        finalPNG,
       );
 
       // Save snapshot only after a successful remote commit.

--- a/src/contexts/ThumbnailDialogContext.jsx
+++ b/src/contexts/ThumbnailDialogContext.jsx
@@ -91,6 +91,7 @@ export function ThumbnailDialogProvider({ children }) {
             repoName: repo,
             attributeUpdates: {
               pngURL: downloadUrl,
+              userSetThumbnail: true,
             },
           }),
           headers: {

--- a/src/hooks/useScreenshotCapture.js
+++ b/src/hooks/useScreenshotCapture.js
@@ -46,21 +46,23 @@ export function useScreenshotCapture(onCaptureCallback) {
       tempRenderer.setPixelRatio(1); // Disable automatic scaling for consistent resolution
       //tempRenderer.setClearColor(0xf5f5f5); // Match ThreeContext background
 
-      // Step 3: Create a perspective camera with the same position and rotation as the existing camera
-      const perspectiveCamera = new THREE.PerspectiveCamera(
-        75, // fov
-        width / height, // aspect ratio
-        0.1, // near
-        90000, // far - match the existing camera's far plane
+      // Step 3: Create an orthographic camera matching the normal renderer
+      const orthoCam = new THREE.OrthographicCamera(
+        width / -2,
+        width / 2,
+        height / 2,
+        height / -2,
+        camera.near,
+        camera.far,
       );
-      perspectiveCamera.position.copy(camera.position);
-      perspectiveCamera.rotation.copy(camera.rotation);
-      perspectiveCamera.quaternion.copy(camera.quaternion);
-      perspectiveCamera.zoom = camera.zoom * 20; // Match zoom level
-      perspectiveCamera.updateProjectionMatrix();
+      orthoCam.position.copy(camera.position);
+      orthoCam.rotation.copy(camera.rotation);
+      orthoCam.quaternion.copy(camera.quaternion);
+      orthoCam.zoom = camera.zoom;
+      orthoCam.updateProjectionMatrix();
 
-      // Step 4: Render the scene with the temporary renderer and perspective camera
-      tempRenderer.render(scene, perspectiveCamera);
+      // Step 4: Render the scene with the temporary renderer and orthographic camera
+      tempRenderer.render(scene, orthoCam);
 
       // Step 5: Restore visibility state of all objects
       visibilityState.forEach((visible, obj) => {

--- a/src/hooks/useScreenshotCapture.js
+++ b/src/hooks/useScreenshotCapture.js
@@ -11,12 +11,12 @@ import * as THREE from "three";
  *
  * Usage:
  *   const { captureHighResScreenshot } = useScreenshotCapture(onScreenshotCallback);
- *   captureHighResScreenshot(3840, 2160); // captures at 4K resolution
+ *   captureHighResScreenshot(1000, 1000); // captures at default resolution
  */
 export function useScreenshotCapture(onCaptureCallback) {
   const { scene, camera } = useThree();
 
-  const captureHighResScreenshot = (width = 3840, height = 2160) => {
+  const captureHighResScreenshot = (width = 1000, height = 1000) => {
     try {
       // Step 1: Save visibility state and hide UI helper objects by name
       const visibilityState = new Map();

--- a/src/hooks/useScreenshotCapture.js
+++ b/src/hooks/useScreenshotCapture.js
@@ -41,28 +41,27 @@ export function useScreenshotCapture(onCaptureCallback) {
         preserveDrawingBuffer: true,
         antialias: true,
         alpha: true,
+        logarithmicDepthBuffer: true, // Enables accurate depth precision for perspective camera
       });
       tempRenderer.setSize(width, height);
       tempRenderer.setPixelRatio(1); // Disable automatic scaling for consistent resolution
       //tempRenderer.setClearColor(0xf5f5f5); // Match ThreeContext background
 
-      // Step 3: Create an orthographic camera matching the normal renderer
-      const orthoCam = new THREE.OrthographicCamera(
-        width / -2,
-        width / 2,
-        height / 2,
-        height / -2,
+      // Step 3: Create a perspective camera matching the normal view
+      const perspectiveCamera = new THREE.PerspectiveCamera(
+        camera.fov || 75,
+        width / height,
         camera.near,
         camera.far,
       );
-      orthoCam.position.copy(camera.position);
-      orthoCam.rotation.copy(camera.rotation);
-      orthoCam.quaternion.copy(camera.quaternion);
-      orthoCam.zoom = camera.zoom;
-      orthoCam.updateProjectionMatrix();
+      perspectiveCamera.position.copy(camera.position);
+      perspectiveCamera.rotation.copy(camera.rotation);
+      perspectiveCamera.quaternion.copy(camera.quaternion);
+      perspectiveCamera.zoom = camera.zoom * 10;
+      perspectiveCamera.updateProjectionMatrix();
 
-      // Step 4: Render the scene with the temporary renderer and orthographic camera
-      tempRenderer.render(scene, orthoCam);
+      // Step 4: Render the scene with the temporary renderer and perspective camera
+      tempRenderer.render(scene, perspectiveCamera);
 
       // Step 5: Restore visibility state of all objects
       visibilityState.forEach((visible, obj) => {

--- a/src/js/meshPNGGenerator.js
+++ b/src/js/meshPNGGenerator.js
@@ -1,0 +1,169 @@
+import * as THREE from "three";
+import {
+  syncFaces,
+  syncLines,
+  syncLinesFromFaces,
+} from "replicad-threejs-helper";
+
+/**
+ * Generate a high-resolution PNG from mesh data returned by the worker
+ * @param {Array} meshArray - Array of mesh objects from worker with { faces, edges, color, cameraZoom }
+ * @param {number} width - Output width in pixels (default: 1000)
+ * @param {number} height - Output height in pixels (default: 1000)
+ * @returns {Promise<string>} Base64-encoded PNG data URL
+ */
+export async function generateMeshPNG(meshArray, width = 1000, height = 1000) {
+  if (!meshArray || !Array.isArray(meshArray) || meshArray.length === 0) {
+    console.warn("No mesh data provided for PNG generation");
+    return null;
+  }
+
+  try {
+    // Create a temporary scene
+    const scene = new THREE.Scene();
+    scene.background = null; // Transparent background
+
+    // Convert mesh data to Three.js objects using replicad-threejs-helper
+    let cameraZoom = 1;
+    const meshGroup = new THREE.Group();
+
+    for (const m of meshArray) {
+      // Store camera zoom from first mesh (they should all be the same)
+      if (m.cameraZoom) cameraZoom = m.cameraZoom;
+
+      // Skip point-only geometries for PNG generation
+      if (m.point) continue;
+
+      // Create geometry from mesh data
+      const geometry = new THREE.BufferGeometry();
+
+      // Use replicad-threejs-helper to populate geometry
+      if (m.faces) {
+        syncFaces(geometry, m.faces);
+      }
+
+      // Create material with proper color
+      const material = new THREE.MeshStandardMaterial({
+        color: m.color || "#888888",
+        side: THREE.DoubleSide,
+        metalness: 0.3,
+        roughness: 0.7,
+      });
+
+      // Create mesh and add to group
+      const mesh = new THREE.Mesh(geometry, material);
+      meshGroup.add(mesh);
+
+      // Add wireframe edges if they exist
+      if (m.edges) {
+        const edgeGeometry = new THREE.BufferGeometry();
+        syncLines(edgeGeometry, m.edges);
+        const edgeMaterial = new THREE.LineBasicMaterial({
+          color: "#000000",
+          linewidth: 1,
+          transparent: true,
+          opacity: 0.3,
+        });
+        const wireframe = new THREE.LineSegments(edgeGeometry, edgeMaterial);
+        meshGroup.add(wireframe);
+      }
+    }
+
+    scene.add(meshGroup);
+
+    // Calculate camera position from bounding box
+    const boundingBox = new THREE.Box3().setFromObject(meshGroup);
+    const size = boundingBox.getSize(new THREE.Vector3());
+    const center = boundingBox.getCenter(new THREE.Vector3());
+    const maxDim = Math.max(size.x, size.y, size.z) * 2.2; // Add padding
+
+    // Create perspective camera positioned to view the mesh
+    // Use near/far planes calculated from bounding box to prevent clipping
+    const distance = maxDim * 1.5;
+    const near = Math.max(0.1, distance - maxDim * 2);
+    const far = distance + maxDim * 2;
+
+    const camera = new THREE.PerspectiveCamera(
+      75, // fov
+      width / height,
+      near,
+      far,
+    );
+
+    // Position camera to look at the mesh center
+    // 30-degree elevation from the XY horizon plane
+    // tan(30°) ≈ 0.577, so vertical distance ≈ horizontal distance * 0.577
+    camera.position.set(
+      center.x + maxDim * 0.8,
+      center.y + maxDim * 0.2,
+      center.z + maxDim * 0.26,
+    );
+    camera.lookAt(center);
+
+    // Calculate appropriate zoom to frame the mesh properly
+    // This ensures consistent sizing compared to useScreenshotCapture
+    const vFOV = (camera.fov * Math.PI) / 180; // Convert to radians
+    const requiredDistance = Math.abs(maxDim / 2 / Math.tan(vFOV / 2));
+    const actualDistance = camera.position.distanceTo(center);
+    camera.zoom = actualDistance / requiredDistance;
+
+    camera.updateProjectionMatrix();
+
+    // Add lighting to match ThreeContext
+    const ambientLight = new THREE.AmbientLight(0xffffff, 0.9);
+    scene.add(ambientLight);
+
+    // Directional light comes from the same direction as the camera
+    const directionalLight = new THREE.DirectionalLight(0xffffff, 0.5);
+    directionalLight.position.copy(camera.position);
+    directionalLight.target.position.copy(center);
+    scene.add(directionalLight);
+    scene.add(directionalLight.target);
+
+    // Create renderer with high quality settings
+    const renderer = new THREE.WebGLRenderer({
+      preserveDrawingBuffer: true,
+      antialias: true,
+      alpha: true,
+      logarithmicDepthBuffer: true, // For proper depth precision
+    });
+
+    renderer.setSize(width, height);
+    renderer.setPixelRatio(1);
+    renderer.render(scene, camera);
+
+    // Capture PNG
+    const canvas = renderer.domElement;
+    const dataURL = canvas.toDataURL("image/png", 0.7); // Match quality from useScreenshotCapture
+
+    // Cleanup
+    renderer.dispose();
+    meshGroup.traverse((child) => {
+      if (child.geometry) child.geometry.dispose();
+      if (child.material) {
+        if (Array.isArray(child.material)) {
+          child.material.forEach((mat) => mat.dispose());
+        } else {
+          child.material.dispose();
+        }
+      }
+    });
+
+    return dataURL;
+  } catch (error) {
+    console.error("Error generating mesh PNG:", error);
+    return null;
+  }
+}
+
+/**
+ * Extract base64 PNG data from a data URL (removes "data:image/png;base64," prefix)
+ * @param {string} dataURL - Data URL from canvas.toDataURL()
+ * @returns {string} Base64-encoded PNG data
+ */
+export function extractBase64FromDataURL(dataURL) {
+  if (!dataURL || !dataURL.startsWith("data:")) {
+    return dataURL;
+  }
+  return dataURL.split(",")[1];
+}


### PR DESCRIPTION
This PR takes care of depth order errors which we were seeing when generating png images from the models. These were caused by the temporary perspective camera reordering the meshes in the temporary renderer. This PR also introduces automatically generated PNGs on save but prevents user set thumbnails from being overridden.