### PR TITLE
Update to kirimoto configuration. 

### DIFF
--- a/KirimotoUpdate.js
+++ b/KirimotoUpdate.js
@@ -166,7 +166,7 @@ const generateGcode = (
               step: stepOver,
               tool: 1000,
               type: "area",
-            },*/
+            },
             {
               disabled: false,
               dogbones: false,
@@ -174,7 +174,7 @@ const generateGcode = (
               inside: true,
               omitthru: false,
               omitvoid: false,
-              outside: false,
+              outside: true,
               ov_botz: -CUT_THROUGH,
               ov_conv: true,
               ov_topz: 0,
@@ -187,7 +187,7 @@ const generateGcode = (
               top: false,
               type: "outline",
               wide: false,
-            },
+            },*/
             {
               disabled: false,
               dogbones: false,
@@ -195,7 +195,7 @@ const generateGcode = (
               inside: false,
               omitthru: false,
               omitvoid: true,
-              outside: true,
+              outside: false,
               ov_botz: -CUT_THROUGH,
               ov_conv: true,
               ov_topz: 0,

--- a/KirimotoUpdate.js
+++ b/KirimotoUpdate.js
@@ -166,7 +166,7 @@ const generateGcode = (
               step: stepOver,
               tool: 1000,
               type: "area",
-            },
+            },*/
             {
               disabled: false,
               dogbones: false,
@@ -174,7 +174,7 @@ const generateGcode = (
               inside: true,
               omitthru: false,
               omitvoid: false,
-              outside: true,
+              outside: false,
               ov_botz: -CUT_THROUGH,
               ov_conv: true,
               ov_topz: 0,
@@ -187,7 +187,7 @@ const generateGcode = (
               top: false,
               type: "outline",
               wide: false,
-            },*/
+            },
             {
               disabled: false,
               dogbones: false,


### PR DESCRIPTION
If multiple passes are used, the upper layers now follow any positive bevels along the thickness of the shape.

Here's a simple example project with a shape that showcases this functionality: http://localhost:4444/run/tristan-huber/rolling_bevel_example

Importantly, the gcode doesn't try to follow under-cutting bevels which is good because that's unsupported by the maslow (and all 3 axis machines)

@mo Lemme know what you think of this diff, the key thing that enables/disables this behavior is the "outside" boolean flag. I don't have a strong understanding of why there are multiple entries in the ops list so commenting one out entirely is maybe bad? I have no idea.