### PR TITLE
temporary prevent doubling fix

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -781,6 +781,19 @@ function AppContent() {
     GlobalVariables.numberOfAtomsToLoad = 0;
     GlobalVariables.startTime = new Date().getTime();
 
+    const projectKey = `${project.owner}/${project.repoName}`;
+
+    // Guard against duplicate loading: add flag BEFORE fetching from GitHub
+    // so concurrent calls see it in the Set
+    if (!GlobalVariables.loadingProjects) {
+      GlobalVariables.loadingProjects = new Set();
+    }
+    if (GlobalVariables.loadingProjects.has(projectKey)) {
+      console.log("Project already loading, skipping:", projectKey);
+      return Promise.resolve(); // Return resolved promise for consistency
+    }
+    GlobalVariables.loadingProjects.add(projectKey);
+
     if (authorizedUser) {
       var octokit = authorizedUser;
     } else {
@@ -867,9 +880,11 @@ function AppContent() {
             await targetMolecule.deserialize(rawFile);
           }
         } catch (deserializeError) {
-          targetMolecule.loadedProjectKey = undefined;
+          GlobalVariables.loadingProjects.delete(projectKey);
           throw deserializeError;
         }
+        // Clear loading flag after deserialization completes
+        GlobalVariables.loadingProjects.delete(projectKey);
         GlobalVariables.currentMolecule = targetMolecule;
         GlobalVariables.currentMolecule.selected = true;
         setActiveAtom(GlobalVariables.currentMolecule);
@@ -936,6 +951,8 @@ function AppContent() {
 
         setErrorNotification("Can't load/find project: " + (e.message || e));
         setTimeout(() => setErrorNotification(null), 5000);
+        // Clear loading flag on error
+        GlobalVariables.loadingProjects.delete(projectKey);
         // Navigate back to projects page after error
         navigate("/");
         throw new Error("Can't load/find project " + e);

--- a/src/components/main-routes/CreateMode.jsx
+++ b/src/components/main-routes/CreateMode.jsx
@@ -40,7 +40,12 @@ import { useDevSettings } from "../../contexts/DevSettingsContext.jsx";
  */
 function CreateMode() {
   // Get context values
-  const { authorizedUserOcto, authRedirectHandler, userScopes } = useAuth();
+  const {
+    authorizedUserOcto,
+    authRedirectHandler,
+    userScopes,
+    isRestoringSession,
+  } = useAuth();
   const {
     activeAtom,
     setActiveAtom,
@@ -105,8 +110,9 @@ function CreateMode() {
   const [isLoadingProject, setIsLoadingProject] = useState(true);
 
   // Update GlobalVariables when route params change and fetch full AWS node
+  // Wait for session restoration to complete before loading project
   useEffect(() => {
-    if (owner && repoName) {
+    if (owner && repoName && !isRestoringSession) {
       setIsLoadingProject(true);
 
       // Fetch the full project metadata from AWS
@@ -137,7 +143,7 @@ function CreateMode() {
           setIsLoadingProject(false);
         });
     }
-  }, [owner, repoName]);
+  }, [owner, repoName, isRestoringSession, authorizedUserOcto]);
 
   /** State for user notification */
   const [userNotification, setUserNotificationRaw] = useState(null);
@@ -170,6 +176,7 @@ function CreateMode() {
       meshRef,
       setUserNotification,
       onSaveStart,
+      authorizedUserOcto,
     );
   };
 

--- a/src/components/main-routes/flowCanvas.jsx
+++ b/src/components/main-routes/flowCanvas.jsx
@@ -151,55 +151,70 @@ export default memo(function FlowCanvas({
         }
       } else {
         // Check for unsaved project state from browsing projects
-        // Note: owner and repoName come from GitHub's API and are validated by GitHub,
-        // so they are safe to use in the localStorage key
-        const projectKey = `unsavedProject_${GlobalVariables.currentAWSnode.owner}_${GlobalVariables.currentAWSnode.repoName}`;
-        const unsavedProject = localStorage.getItem(projectKey);
+        // BUT: Skip this if we're doing a fresh URL navigation to CreateMode
+        // (redirectType undefined and no previous project loaded means fresh navigation)
+        const isFreshUrlNavigation =
+          !redirectType &&
+          (!GlobalVariables.loadedRepo ||
+            GlobalVariables.loadedRepo.name !==
+              GlobalVariables.currentAWSnode.repoName);
 
-        if (unsavedProject) {
-          try {
-            let rawFile = JSON.parse(unsavedProject);
-            // Reset ID counter to avoid collisions with existing IDs
-            GlobalVariables.resetIdCounter(rawFile);
-            // Deserialize the saved project state
-            GlobalVariables.topLevelMolecule.deserialize(rawFile);
-            setActiveAtom(GlobalVariables.currentMolecule);
-            GlobalVariables.currentMolecule.selected = true;
-            GlobalVariables.currentMolecule = GlobalVariables.topLevelMolecule;
-            // Clear the unsaved state from localStorage after restoring
-            localStorage.removeItem(projectKey);
-            // Also load the project metadata from GitHub (without overwriting the molecules)
-            if (authorizedUserOcto) {
-              const octokit = authorizedUserOcto;
-              octokit.rest.repos
-                .get({
-                  owner: GlobalVariables.currentAWSnode.owner,
-                  repo: GlobalVariables.currentAWSnode.repoName,
-                })
-                .then(async (response) => {
-                  GlobalVariables.loadedRepo = response.data;
-                  GlobalVariables.currentRepo = response.data;
-                  GlobalVariables.currentRepoName =
-                    GlobalVariables.currentAWSnode.repoName;
-                })
-                .catch((e) => {
-                  console.error("Error loading repo metadata:", e);
-                  if (setUserNotification) {
-                    setUserNotification(
-                      "Error loading project metadata: " + e.message,
-                      "error",
-                    );
-                    setTimeout(() => setUserNotification(null), 5000);
-                  }
-                });
+        if (isFreshUrlNavigation) {
+          // Fresh URL navigation: load from GitHub, don't use localStorage
+          console.log("Fresh URL navigation detected, loading from GitHub");
+          loadProject(GlobalVariables.currentAWSnode, authorizedUserOcto);
+        } else {
+          // Returning to a previously loaded project: use unsaved state if available
+          // Note: owner and repoName come from GitHub's API and are validated by GitHub,
+          // so they are safe to use in the localStorage key
+          const projectKey = `unsavedProject_${GlobalVariables.currentAWSnode.owner}_${GlobalVariables.currentAWSnode.repoName}`;
+          const unsavedProject = localStorage.getItem(projectKey);
+
+          if (unsavedProject) {
+            try {
+              let rawFile = JSON.parse(unsavedProject);
+              // Reset ID counter to avoid collisions with existing IDs
+              GlobalVariables.resetIdCounter(rawFile);
+              // Deserialize the saved project state
+              GlobalVariables.topLevelMolecule.deserialize(rawFile);
+              setActiveAtom(GlobalVariables.currentMolecule);
+              GlobalVariables.currentMolecule.selected = true;
+              GlobalVariables.currentMolecule =
+                GlobalVariables.topLevelMolecule;
+              // Clear the unsaved state from localStorage after restoring
+              localStorage.removeItem(projectKey);
+              // Also load the project metadata from GitHub (without overwriting the molecules)
+              if (authorizedUserOcto) {
+                const octokit = authorizedUserOcto;
+                octokit.rest.repos
+                  .get({
+                    owner: GlobalVariables.currentAWSnode.owner,
+                    repo: GlobalVariables.currentAWSnode.repoName,
+                  })
+                  .then(async (response) => {
+                    GlobalVariables.loadedRepo = response.data;
+                    GlobalVariables.currentRepo = response.data;
+                    GlobalVariables.currentRepoName =
+                      GlobalVariables.currentAWSnode.repoName;
+                  })
+                  .catch((e) => {
+                    console.error("Error loading repo metadata:", e);
+                    if (setUserNotification) {
+                      setUserNotification(
+                        "Error loading project metadata: " + e.message,
+                        "error",
+                      );
+                      setTimeout(() => setUserNotification(null), 5000);
+                    }
+                  });
+              }
+            } catch (e) {
+              console.error("Error restoring unsaved project:", e);
+              // If restoration fails, load from GitHub
+              loadProject(GlobalVariables.currentAWSnode, authorizedUserOcto);
+              localStorage.removeItem(projectKey);
             }
-          } catch (e) {
-            console.error("Error restoring unsaved project:", e);
-            // If restoration fails, load from GitHub
-            loadProject(GlobalVariables.currentAWSnode, authorizedUserOcto);
-            localStorage.removeItem(projectKey);
           }
-          // Normal case: no unsaved state, CreateMode will handle loading
         }
       }
     } else {

--- a/src/components/secondary/TopMenu.jsx
+++ b/src/components/secondary/TopMenu.jsx
@@ -38,6 +38,7 @@ function TopMenu({
     shortCutsOn,
     setShortCuts,
     setExportPopUp,
+    setNotification,
   } = useAppState();
   const {
     gridParam,
@@ -273,11 +274,18 @@ function TopMenu({
           var jsonRepOfProject = GlobalVariables.topLevelMolecule.serialize();
           const currentProjectRep = JSON.stringify(jsonRepOfProject);
           // Re-authentication logic - redirect to GitHub OAuth
+          setNotification(
+            "Re-authentication is unavailable at this time. Please try refreshing the page.",
+            "error",
+          );
+          setTimeout(() => setNotification(null, "error"), 5000);
+
+          /*
           authRedirectHandler({
             authType: "reauth",
             currentProjectRep,
             returnTo: `/${GlobalVariables.currentAWSnode.owner}/${GlobalVariables.currentAWSnode.repoName}`,
-          });
+          });*/
         },
       },
       {

--- a/src/contexts/ProjectContext.jsx
+++ b/src/contexts/ProjectContext.jsx
@@ -21,7 +21,7 @@ const ProjectContext = createContext();
  */
 export function ProjectProvider({ children, cad, loadProject }) {
   const [size, setSize] = useState(5);
-  const { authorizedUserOcto, authRedirectHandler } = useAuth();
+  const { authRedirectHandler } = useAuth();
   const { setNotification } = useAppState();
 
   // Track last saved data to avoid unnecessary saves
@@ -1397,6 +1397,7 @@ export function ProjectProvider({ children, cad, loadProject }) {
     meshRef = null,
     setErrorNotification = null,
     onSaveStart = null,
+    authorizedUserOcto = null,
   ) => {
     // Create a wrapper for setSaveProgress that prevents regression
     // This ensures the progress bar never goes backwards


### PR DESCRIPTION
This is a temporary fix for the doubling issues that we were seeing after loading project fixes for private projects were implemented. I'm not really sure where or when things went off course but the loading logic is in need of a major refactor. This PR also disables the reauthentication button which is continuing to create doubling issues until we are able to restructure the loading logic to support it without issues.