### PR TITLE
Better orientation selection for parts with inlays on one side

### DIFF
--- a/src/molecules/cutOrient.js
+++ b/src/molecules/cutOrient.js
@@ -151,7 +151,7 @@ export default class CutOrient extends Atom {
   saveAndDisplayOrientations(orientations, inputGeom) {
     this.orientations = orientations;
     this.orientationsFor = inputGeom;
-    this.orientationsForHashed = util.hashAssembly(inputGeom);
+    this.orientationsForHashed = util.leafCount(inputGeom);
     return GlobalVariables.cad.displayOrientation(
       inputGeom,
       this.orientations,
@@ -163,7 +163,7 @@ export default class CutOrient extends Atom {
   compute(inputs) {
     const inputGeom = inputs.geometry;
     if (
-      util.hashAssembly(inputGeom) != this.orientationsForHashed ||
+      util.leafCount(inputGeom) != this.orientationsForHashed ||
       this.orientations.length == 0
     ) {
       // No valid cached orientations, so we need to recompute them
@@ -219,7 +219,7 @@ export default class CutOrient extends Atom {
     //Save the readme text to the serial stream
     var valuesObj = super.serialize(values);
     valuesObj.orientations = this.orientations;
-    valuesObj.orientationsForHashed = util.hashAssembly(this.orientationsFor);
+    valuesObj.orientationsForHashed = util.leafCount(this.orientationsFor);
 
     return valuesObj;
   }

--- a/src/worker/cutlayout.ts
+++ b/src/worker/cutlayout.ts
@@ -102,8 +102,8 @@ async function displayOrientation(
   context: RequestContext,
 ): Promise<AbundanceObject> {
   console.log("displayOrientation called.");
-  const getCacheId = (geom: string, index: number) => {
-    return "faceToXY-" + index + "-" + geom;
+  const getCacheId = (geom: string, index: number, xOffset: number) => {
+    return `faceToXY-${index}-${geom}-${xOffset}`;
   };
   const padding = 1; //orientationConfig.units === "MM" ? 25 : 1;
 
@@ -115,7 +115,11 @@ async function displayOrientation(
     }
     let targetFaceIndex = orientations[index].downwardFaceIndex;
     index++;
-    const batchId = getCacheId(leaf.geometry, targetFaceIndex);
+    const batchId = getCacheId(
+      leaf.geometry,
+      targetFaceIndex,
+      bottomLeftTarget.x,
+    );
 
     // Extra batching logic to ensure that we can get cache hits on the "addSingular" operation below.
     const cachedResultOrContext: AbundanceObject | RequestContext =
@@ -151,8 +155,8 @@ async function displayOrientation(
     leaf.geometry = await util.geometryProvider!.addSingularToCache(
       result,
       cachedResultOrContext,
-      "faceToXY-",
-      [targetFaceIndex, leaf.geometry],
+      batchId,
+      [], // args are already integrated into batchId.
     );
     await util.geometryProvider!.endBatchOperation(cachedResultOrContext, leaf);
 

--- a/src/worker/cutlayout.ts
+++ b/src/worker/cutlayout.ts
@@ -415,7 +415,7 @@ async function rotateForLayout(
       .map((face, index) => ({
         f: face,
         i: index,
-        area: areaApprox(face.clone().UVBounds),
+        area: replicad.measureArea(face),
       }))
       .sort((a, b) => b.area - a.area);
 
@@ -979,20 +979,6 @@ function moveFaceToCuttingPlane(geom: Shape3D, face: Face): Shape3D {
     .clone()
     .rotate(transform.degrees, transform.point, transform.axis)
     .translate(0, 0, transform.offset);
-}
-
-/**
- * Calculates an approximate area from UV bounds.
- * @param {Object} bounds - The bounds object containing uMin, uMax, vMin, vMax properties
- * @returns {number} The approximate area calculated from the bounds
- */
-function areaApprox(bounds: {
-  uMin: number;
-  uMax: number;
-  vMin: number;
-  vMax: number;
-}): number {
-  return (bounds.uMax - bounds.uMin) * (bounds.vMax - bounds.vMin);
 }
 
 export {


### PR DESCRIPTION
use real area measure when picking faces in cut orient. Instead of bounding box approximation. Resolves a class of minor issue where we didn't measure some partial through cuts when selecting the down-faces during cut layout.

Also changes cutorient to be more stable against upstream changes. Any input with the same number of leaves will be treated as equivalent to the prior input. If this isn't the case the user can make a new cutorient atom to force recomputation.