### PR TITLE
Allow code atoms to skip disjointness enforcement

### DIFF
--- a/src/worker/code.ts
+++ b/src/worker/code.ts
@@ -649,7 +649,12 @@ async function executeTsCode(
       context,
       cacheId,
     );
-    if (util.isAssembly(abundanceObj)) {
+    // TODO: should we apply this claimsDisjoint check recursively? I feel like no?
+    if (
+      util.isAssembly(abundanceObj) &&
+      !abundanceObj.metadata?.claimsDisjoint == true
+    ) {
+      reportCadProgress("enforcing disjointness");
       const disjointAssembly = await assembly(abundanceObj.geometry, context);
 
       // Copy all properties from abundanceObj except geometry

--- a/src/worker/generated/ts-framework.generated.d.ts
+++ b/src/worker/generated/ts-framework.generated.d.ts
@@ -85,6 +85,19 @@ declare global {
       };
       constructor(other?: Partial<Assembly>);
       /**
+       * Skip the disjoint-ness enforcement on this assembly.
+       *
+       * By default the result of a code atom gets post-processed to enforce
+       * that all leafs are disjoint as is done during an assembly. Calling this
+       * method on a returned assembly or subassembly will cause this
+       * post-process to be skipped.
+       *
+       * The disjointness post processing can be computationally costly, but
+       * many atoms assume that input assemblies are disjoint, so call this
+       * method at your own risk.
+       */
+      skipDisjointPostprocess(): void;
+      /**
        * User-defined type guard. Lets callers narrow an `Assembly` to a leaf
        * (where `geometry` is a single replicad shape/drawing rather than an
        * `Assembly[]` branch) without manually checking `Array.isArray(...)`.

--- a/src/worker/generated/ts-framework.generated.d.ts
+++ b/src/worker/generated/ts-framework.generated.d.ts
@@ -96,7 +96,7 @@ declare global {
        * many atoms assume that input assemblies are disjoint, so call this
        * method at your own risk.
        */
-      skipDisjointPostprocess(): void;
+      skipDisjointPostprocess(): this;
       /**
        * User-defined type guard. Lets callers narrow an `Assembly` to a leaf
        * (where `geometry` is a single replicad shape/drawing rather than an

--- a/src/worker/generated/ts-framework.generated.d.ts
+++ b/src/worker/generated/ts-framework.generated.d.ts
@@ -128,6 +128,7 @@ declare global {
        */
       getSelectedFaces(): replicad.Face[];
       onLeafs(fn: (leaf: Assembly<LeafGeom>) => Assembly<LeafGeom> | null): Assembly | null;
+      leafCount(): number;
       filterLeafs(filterFn: (leaf: Assembly<LeafGeom>) => boolean): Assembly[];
       /**
        * True when this assembly is (or contains, for branches) 2D geometry —

--- a/src/worker/generated/ts-framework.generated.js
+++ b/src/worker/generated/ts-framework.generated.js
@@ -166,6 +166,14 @@ export function makeAbundanceFramework(replicad) {
         return fn(this);
       }
     }
+    leafCount() {
+      let i = 0;
+      this.onLeafs((leaf) => {
+        i++;
+        return leaf;
+      });
+      return i;
+    }
     //@ts-ignore
     filterLeafs(filterFn) {
       const result = [];

--- a/src/worker/generated/ts-framework.generated.js
+++ b/src/worker/generated/ts-framework.generated.js
@@ -66,6 +66,7 @@ export function makeAbundanceFramework(replicad) {
         this.metadata = {};
       }
       this.metadata.claimsDisjoint = true;
+      return this;
     }
     /**
      * User-defined type guard. Lets callers narrow an `Assembly` to a leaf

--- a/src/worker/generated/ts-framework.generated.js
+++ b/src/worker/generated/ts-framework.generated.js
@@ -50,6 +50,24 @@ export function makeAbundanceFramework(replicad) {
       }
     }
     /**
+     * Skip the disjoint-ness enforcement on this assembly.
+     *
+     * By default the result of a code atom gets post-processed to enforce
+     * that all leafs are disjoint as is done during an assembly. Calling this
+     * method on a returned assembly or subassembly will cause this
+     * post-process to be skipped.
+     *
+     * The disjointness post processing can be computationally costly, but
+     * many atoms assume that input assemblies are disjoint, so call this
+     * method at your own risk.
+     */
+    skipDisjointPostprocess() {
+      if (!this.metadata) {
+        this.metadata = {};
+      }
+      this.metadata.claimsDisjoint = true;
+    }
+    /**
      * User-defined type guard. Lets callers narrow an `Assembly` to a leaf
      * (where `geometry` is a single replicad shape/drawing rather than an
      * `Assembly[]` branch) without manually checking `Array.isArray(...)`.

--- a/src/worker/ts-framework.ts
+++ b/src/worker/ts-framework.ts
@@ -237,6 +237,15 @@ export class Assembly<G = any> {
     }
   }
 
+  leafCount(): number {
+    let i = 0;
+    this.onLeafs((leaf) => {
+      i++;
+      return leaf;
+    });
+    return i;
+  }
+
   //@ts-ignore
   filterLeafs(filterFn: (leaf: Assembly<LeafGeom>) => boolean): Assembly[] {
     const result: Assembly[] = [];

--- a/src/worker/ts-framework.ts
+++ b/src/worker/ts-framework.ts
@@ -119,11 +119,12 @@ export class Assembly<G = any> {
    * many atoms assume that input assemblies are disjoint, so call this
    * method at your own risk.
    */
-  skipDisjointPostprocess() {
+  skipDisjointPostprocess(): this {
     if (!this.metadata) {
       this.metadata = {};
     }
     this.metadata.claimsDisjoint = true;
+    return this;
   }
 
   /**

--- a/src/worker/ts-framework.ts
+++ b/src/worker/ts-framework.ts
@@ -108,6 +108,25 @@ export class Assembly<G = any> {
   }
 
   /**
+   * Skip the disjoint-ness enforcement on this assembly.
+   *
+   * By default the result of a code atom gets post-processed to enforce
+   * that all leafs are disjoint as is done during an assembly. Calling this
+   * method on a returned assembly or subassembly will cause this
+   * post-process to be skipped.
+   *
+   * The disjointness post processing can be computationally costly, but
+   * many atoms assume that input assemblies are disjoint, so call this
+   * method at your own risk.
+   */
+  skipDisjointPostprocess() {
+    if (!this.metadata) {
+      this.metadata = {};
+    }
+    this.metadata.claimsDisjoint = true;
+  }
+
+  /**
    * User-defined type guard. Lets callers narrow an `Assembly` to a leaf
    * (where `geometry` is a single replicad shape/drawing rather than an
    * `Assembly[]` branch) without manually checking `Array.isArray(...)`.


### PR DESCRIPTION
for code atoms which don't modify the input assembly (eg any of the select type inputs)
or code atoms know their result is disjoint (eg: extrude disjoint drawings in the same direction, or return a subset of the input etc).
The disjointness enforcement can take much longer than the code atom itself. This allows code atom authors to skip that enforcement when appropriate.