### PR TITLE
Remove keepout geometry before Cut Orient's layout

### DIFF
--- a/src/molecules/cutOrient.js
+++ b/src/molecules/cutOrient.js
@@ -5,6 +5,7 @@ import { proxy } from "comlink";
 import { Status } from "../prototypes/observableEntity.js";
 import * as THREE from "three";
 import * as util from "../worker/util.ts";
+import { extractKeepOut } from "../worker/tags.ts";
 
 /**
  * Orient all given parts to the best orientation for cutting. Returns a new assembly of the oriented parts.
@@ -161,7 +162,15 @@ export default class CutOrient extends Atom {
   }
 
   compute(inputs) {
-    const inputGeom = inputs.geometry;
+    // Keepout geometry never gets cut, so drop it before orienting. Leaving it in
+    // slows the orientation down and shifts the leaf ordering that the computed
+    // orientations are indexed by.
+    const inputGeom = extractKeepOut(inputs.geometry);
+    if (inputGeom === false) {
+      return Promise.reject(
+        new Error("No geometry to orient after keepout geometry is excluded"),
+      );
+    }
     if (
       util.leafCount(inputGeom) != this.orientationsForHashed ||
       this.orientations.length == 0


### PR DESCRIPTION
## Summary

`Cut Orient` now strips `keepout`-tagged geometry from its input before doing any orientation work.

## Why

`inputs.geometry` was used in three places, and keepout parts caused a problem in each:

- **`cad.orient(...)`** — `rotateForLayout` already filtered keepout internally, but `displayOrientation` did **not**. Orientations were indexed against the *filtered* leaf order and then applied while walking the *unfiltered* one, so any keepout part ahead of a real part shifted every subsequent face index. This was a correctness bug, not just a slowdown.
- **`displayOrientation` on the cached / manual-face-edit path** — same index mismatch, plus keepout parts were getting face-to-cutting-plane transforms and packing slots computed for them.
- **`util.leafCount(inputGeom)` as the orientation cache key** — counted keepout leaves, so editing or toggling keepout geometry invalidated cached orientations and forced a full recompute.

Filtering once at the top of `compute` fixes all three, and the atom's output assembly no longer carries keepout geometry — which matches what `cutlayout` does with it downstream anyway.

## Notes

- `extractKeepOut` comes from `src/worker/tags.ts`, which only depends on `./util` — already imported by this atom, so no new module weight in the main thread.
- If *everything* fed in is keepout, the atom now errors ("No geometry to orient after keepout geometry is excluded") instead of silently orienting keepout parts. `Promise.reject` rather than `throw`, because `updateValue` only catches rejections from `compute`.

## Testing

`eslint` and `prettier` pass on the changed file. The vitest suite could not be run in my working tree — `vite` fails to resolve the `replicad-shrink-wrap` package entry. That failure is pre-existing and unrelated: it reproduces with this change stashed, on test files that don't touch `cutOrient.js`. CI should be the real check here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)