### PR TITLE
Disable easedown for gcode generation.

### DIFF
--- a/KirimotoUpdate.js
+++ b/KirimotoUpdate.js
@@ -121,7 +121,7 @@ const generateGcode = (
         eng.setProcess({
           camDepthFirst: true,
           camEaseAngle: 40,
-          camEaseDown: true,
+          camEaseDown: false,
           camOriginTop: true,
           camOriginCenter: true,
           camStockOffset: false,


### PR DESCRIPTION
The issue here is that rampdown can be extremely slow if it happens to fall on a long edge of the shape. Eg: I ran into this with the maslow yesterday where rampdown landed on a ~4ft edge and took ~10 minutes. Whereas an edge like that should usually take ~ 1 minute.

Ultimately this is a workaround for whatever part of kirimoto is causing the ramped edge to be so slow.

With this change, the machine now starts it's next pass by moving the z axis only, then traversing xy at it's usual speed.


@alzatin lemme know if you'd prefer that this is a user-controlled option.