### PR TITLE
Check own project PRS

### DIFF
--- a/Lambda AWS Functions/check-user-prs/index.mjs
+++ b/Lambda AWS Functions/check-user-prs/index.mjs
@@ -1,0 +1,293 @@
+import { Octokit } from "@octokit/rest";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+
+const client = new DynamoDBClient({});
+const dynamo = DynamoDBDocumentClient.from(client);
+const date = new Date();
+const today = date.toISOString();
+
+const tableName = "abundance-projects";
+
+export const handler = async (event, context) => {
+  const octokit = new Octokit({
+    auth: process.env.GIT_ACCESS,
+  });
+
+  // Get the user from the request body
+  const body =
+    typeof event.body === "string" ? JSON.parse(event.body) : event.body;
+  const currentUser = body?.user;
+
+  if (!currentUser) {
+    return {
+      statusCode: 400,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Headers": "Content-Type",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ error: "Missing 'user' parameter" }),
+    };
+  }
+
+  console.log(`Checking PRs for user: ${currentUser}`);
+
+  try {
+    // Query only projects owned by the current user
+    const queryParams = {
+      TableName: tableName,
+      KeyConditionExpression: "#ow = :owner",
+      ExpressionAttributeNames: {
+        "#ow": "owner",
+      },
+      ExpressionAttributeValues: {
+        ":owner": currentUser,
+      },
+      ProjectionExpression:
+        "#ow, #repoName, #forks, #lastFoundGit, #privateRepo, #contentURL",
+      ExpressionAttributeNames: {
+        "#ow": "owner",
+        "#repoName": "repoName",
+        "#forks": "forks",
+        "#lastFoundGit": "lastFoundGit",
+        "#privateRepo": "privateRepo",
+        "#contentURL": "contentURL",
+      },
+    };
+
+    const queryCommand = new QueryCommand(queryParams);
+    const queryResult = await dynamo.send(queryCommand);
+    let userProjects = queryResult.Items || [];
+
+    // Handle pagination if there are more items
+    let lastEvaluatedKey = queryResult.LastEvaluatedKey;
+    while (lastEvaluatedKey) {
+      queryParams.ExclusiveStartKey = lastEvaluatedKey;
+      const nextResult = await dynamo.send(new QueryCommand(queryParams));
+      userProjects = userProjects.concat(nextResult.Items || []);
+      lastEvaluatedKey = nextResult.LastEvaluatedKey;
+    }
+
+    console.log(
+      `Found ${userProjects.length} projects for user ${currentUser}`,
+    );
+
+    if (userProjects.length === 0) {
+      return {
+        statusCode: 200,
+        headers: {
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Headers": "Content-Type",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          message: "No projects found for user",
+          pullRequests: [],
+        }),
+      };
+    }
+
+    await checkRateLimit();
+
+    function sleep(ms) {
+      return new Promise((resolve) => setTimeout(resolve, ms));
+    }
+
+    // Batch processing to avoid DynamoDB throttling
+    const BATCH_SIZE = 5;
+    const BATCH_DELAY_MS = 500;
+
+    // Filter to public repos only
+    let reposToCheck = userProjects.filter((repo) => !repo.privateRepo);
+
+    const allPullRequests = [];
+
+    for (let i = 0; i < reposToCheck.length; i += BATCH_SIZE) {
+      const batch = reposToCheck.slice(i, i + BATCH_SIZE);
+      const batchResults = await Promise.all(
+        batch.map((repo) =>
+          checkGithubAndUpdatePRs(
+            repo.owner,
+            repo.repoName,
+            repo.forks,
+            repo.lastFoundGit,
+            repo.contentURL,
+          ),
+        ),
+      );
+
+      // Collect all PRs from this batch
+      batchResults.forEach((result) => {
+        if (result && result.pullRequests) {
+          allPullRequests.push(...result.pullRequests);
+        }
+      });
+
+      if (i + BATCH_SIZE < reposToCheck.length) {
+        await sleep(BATCH_DELAY_MS);
+      }
+    }
+
+    console.log(
+      `Total PRs found across user's projects: ${allPullRequests.length}`,
+    );
+
+    return {
+      statusCode: 200,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Headers": "Content-Type",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        message: "Successfully checked user's pull requests",
+        projectsChecked: reposToCheck.length,
+        pullRequests: allPullRequests,
+      }),
+    };
+  } catch (error) {
+    console.error("Error checking user PRs:", error);
+    return {
+      statusCode: 500,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Headers": "Content-Type",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        error: "Failed to check pull requests",
+        message: error.message,
+      }),
+    };
+  }
+
+  async function checkUpdate(
+    owner,
+    repoName,
+    forks,
+    githubForks,
+    pullRequests,
+  ) {
+    const input = {
+      ExpressionAttributeValues: {
+        ":forks": githubForks,
+        ":lastFoundGit": today,
+        ":pullRequests": pullRequests || [],
+      },
+      ReturnValues: "ALL_NEW",
+      TableName: tableName,
+      UpdateExpression:
+        "SET lastFoundGit = :lastFoundGit, forks = :forks, pullRequests = :pullRequests REMOVE failureCount",
+      Key: {
+        owner: owner,
+        repoName: repoName,
+      },
+    };
+    const command = new UpdateCommand(input);
+    try {
+      await dynamo.send(command);
+      return pullRequests || [];
+    } catch (error) {
+      console.error(`Error updating PR data for ${owner}/${repoName}:`, error);
+      throw error;
+    }
+  }
+
+  async function checkRateLimit() {
+    const response = await fetch("https://api.github.com/rate_limit", {
+      headers: {
+        Authorization: `Bearer ${process.env.GIT_ACCESS}`,
+      },
+    });
+
+    if (!response.ok) {
+      console.error("Failed to fetch rate limit status.");
+      return null;
+    }
+
+    const data = await response.json();
+    console.log("Rate Limit Status:", data);
+    return data;
+  }
+
+  async function getPullRequests(owner, repoName) {
+    try {
+      const prsResponse = await octokit.rest.pulls.list({
+        owner: owner,
+        repo: repoName,
+        state: "open",
+        per_page: 100,
+      });
+
+      // Extract relevant PR data
+      const pullRequests = prsResponse.data.map((pr) => ({
+        owner: pr.head.repo?.owner?.login || owner,
+        repo: pr.head.repo?.name || repoName,
+        branch: pr.head.ref,
+        pullRequestNumber: pr.number,
+        url: pr.html_url,
+      }));
+
+      console.log(
+        `Found ${pullRequests.length} open PRs in ${owner}/${repoName}`,
+      );
+      return pullRequests;
+    } catch (error) {
+      console.error(`Error fetching PRs for ${owner}/${repoName}:`, error);
+      return [];
+    }
+  }
+
+  async function checkGithubAndUpdatePRs(
+    owner,
+    repoName,
+    forks,
+    lastFoundGit,
+    contentURL,
+  ) {
+    try {
+      // Check if repo exists
+      const repoResponse = await octokit.rest.repos.get({
+        owner: owner,
+        repo: repoName,
+      });
+
+      // Fetch pull requests if repo has open issues
+      let pullRequests = [];
+      if (repoResponse.data.open_issues_count > 0) {
+        pullRequests = await getPullRequests(owner, repoName);
+      }
+
+      // Update DynamoDB with new PR data
+      await checkUpdate(
+        owner,
+        repoName,
+        forks,
+        repoResponse.data.forks_count,
+        pullRequests,
+      );
+
+      return {
+        owner,
+        repoName,
+        pullRequests,
+      };
+    } catch (error) {
+      if (error.status === 404) {
+        console.log(`Project not found: ${owner}/${repoName}`);
+      } else {
+        console.error(`Error checking repo ${owner}/${repoName}:`, error);
+      }
+      return {
+        owner,
+        repoName,
+        pullRequests: [],
+      };
+    }
+  }
+};

--- a/Lambda AWS Functions/check-user-prs/index.mjs
+++ b/Lambda AWS Functions/check-user-prs/index.mjs
@@ -14,8 +14,27 @@ const today = date.toISOString();
 const tableName = "abundance-projects";
 
 export const handler = async (event, context) => {
+  // Get the user's GitHub token from Authorization header
+  const authHeader =
+    event.headers?.authorization || event.headers?.Authorization;
+  const githubToken = authHeader?.replace("Bearer ", "");
+
+  if (!githubToken) {
+    return {
+      statusCode: 401,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Headers": "Content-Type",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        error: "Missing GitHub token in Authorization header",
+      }),
+    };
+  }
+
   const octokit = new Octokit({
-    auth: process.env.GIT_ACCESS,
+    auth: githubToken,
   });
 
   // Get the user from the request body
@@ -91,8 +110,6 @@ export const handler = async (event, context) => {
         }),
       };
     }
-
-    await checkRateLimit();
 
     function sleep(ms) {
       return new Promise((resolve) => setTimeout(resolve, ms));
@@ -196,23 +213,6 @@ export const handler = async (event, context) => {
       console.error(`Error updating PR data for ${owner}/${repoName}:`, error);
       throw error;
     }
-  }
-
-  async function checkRateLimit() {
-    const response = await fetch("https://api.github.com/rate_limit", {
-      headers: {
-        Authorization: `Bearer ${process.env.GIT_ACCESS}`,
-      },
-    });
-
-    if (!response.ok) {
-      console.error("Failed to fetch rate limit status.");
-      return null;
-    }
-
-    const data = await response.json();
-    console.log("Rate Limit Status:", data);
-    return data;
   }
 
   async function getPullRequests(owner, repoName) {

--- a/src/components/secondary/PRNotificationIcon.jsx
+++ b/src/components/secondary/PRNotificationIcon.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import GlobalVariables from "../../js/globalvariables.js";
+import { useAuth } from "../../contexts/AuthContext.jsx";
 
 /**
  * PRNotificationIcon displays pull requests across user's projects
@@ -15,6 +16,8 @@ function PRNotificationIcon({ allProjects = [] }) {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const dropdownRef = useRef(null);
   const buttonRef = useRef(null);
+
+  const { githubToken } = useAuth();
 
   // Collect all PRs from all projects
   const allPRs = (() => {
@@ -82,7 +85,10 @@ function PRNotificationIcon({ allProjects = [] }) {
         "https://hg5gsgv9te.execute-api.us-east-2.amazonaws.com/abundance-stage/check-user-prs",
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${githubToken}`,
+          },
           body: JSON.stringify({ user: GlobalVariables.currentUser }),
         },
       );

--- a/src/components/secondary/PRNotificationIcon.jsx
+++ b/src/components/secondary/PRNotificationIcon.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { useAuth } from "../../contexts/index.js";
+import GlobalVariables from "../../js/globalvariables.js";
 
 /**
  * PRNotificationIcon displays pull requests across user's projects
@@ -10,9 +10,9 @@ import { useAuth } from "../../contexts/index.js";
  */
 function PRNotificationIcon({ allProjects = [] }) {
   const navigate = useNavigate();
-  const { user } = useAuth();
   const [showDropdown, setShowDropdown] = useState(false);
   const [showModal, setShowModal] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
   const dropdownRef = useRef(null);
   const buttonRef = useRef(null);
 
@@ -65,6 +65,38 @@ function PRNotificationIcon({ allProjects = [] }) {
       `/pull/${pr.projectOwner}/${pr.projectName}/${pr.owner}/${pr.repo}?owner=${pr.projectOwner}&pull_number=${pr.pullRequestNumber}`,
     );
     setShowDropdown(false);
+  };
+
+  const handleRefresh = async () => {
+    if (isRefreshing) return;
+
+    setIsRefreshing(true);
+    try {
+      // TODO: Call check-user-prs Lambda to refresh PRs for current user's projects
+      console.log(
+        "Refreshing pull requests for user:",
+        GlobalVariables.currentUser,
+      );
+
+      const response = await fetch(
+        "https://hg5gsgv9te.execute-api.us-east-2.amazonaws.com/abundance-stage/check-user-prs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ user: GlobalVariables.currentUser }),
+        },
+      );
+      const data = await response.json();
+      console.log("Refresh response data:", data);
+      // Update allProjects or trigger parent component refresh
+
+      // Simulate a small delay to show the loading state
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    } catch (error) {
+      console.error("Error refreshing pull requests:", error);
+    } finally {
+      setIsRefreshing(false);
+    }
   };
 
   if (totalCount === 0) {
@@ -156,9 +188,47 @@ function PRNotificationIcon({ allProjects = [] }) {
                 fontSize: "12px",
                 fontWeight: "600",
                 color: "#666",
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
               }}
             >
-              Recent Pull Requests ({totalCount} total)
+              <span>Recent Pull Requests ({totalCount} total)</span>
+              <button
+                onClick={handleRefresh}
+                disabled={isRefreshing}
+                title="Refresh pull requests"
+                style={{
+                  background: "none",
+                  border: "none",
+                  cursor: isRefreshing ? "not-allowed" : "pointer",
+                  padding: "2px 4px",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: isRefreshing ? "#ccc" : "#666",
+                  fontSize: "14px",
+                  transition: "color 0.2s",
+                  opacity: isRefreshing ? 0.6 : 1,
+                }}
+                onMouseEnter={(e) =>
+                  !isRefreshing && (e.target.style.color = "#333")
+                }
+                onMouseLeave={(e) => (e.target.style.color = "#666")}
+              >
+                {isRefreshing ? (
+                  <span
+                    style={{
+                      animation: "spin 1s linear infinite",
+                      display: "inline-block",
+                    }}
+                  >
+                    ↻
+                  </span>
+                ) : (
+                  "↻"
+                )}
+              </button>
             </div>
 
             {/* Recent PRs List */}
@@ -410,6 +480,16 @@ function PRNotificationIcon({ allProjects = [] }) {
           </div>
         </div>
       )}
+      <style>{`
+        @keyframes spin {
+          from {
+            transform: rotate(0deg);
+          }
+          to {
+            transform: rotate(360deg);
+          }
+        }
+      `}</style>
     </>
   );
 }

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -16,6 +16,7 @@ const TOKEN_EXPIRY_DAYS = 60; // GitHub tokens typically expire after 60 days
 export function AuthProvider({ children }) {
   const [isAuthorized, setIsAuthorized] = useState(false);
   const [authorizedUserOcto, setAuthorizedUserOcto] = useState(null);
+  const [githubToken, setGithubToken] = useState(null);
   const [isRestoringSession, setIsRestoringSession] = useState(true);
   const [userScopes, setUserScopes] = useState([]);
   const [isReauthentication, setIsReauthentication] = useState(false);
@@ -109,6 +110,7 @@ export function AuthProvider({ children }) {
       GlobalVariables.currentUser = user.login;
       setIsAuthorized(true);
       setAuthorizedUserOcto(octokit);
+      setGithubToken(token);
       // Store scopes so we know token permissions without extra OAuth call
       setUserScopes(scopes);
       setIsRestoringSession(false);
@@ -206,6 +208,8 @@ export function AuthProvider({ children }) {
     setIsReauthentication,
     isReturningFromMode,
     setIsReturningFromMode,
+    githubToken,
+    setGithubToken,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;


### PR DESCRIPTION
This adds a lambda for refreshing one's own github projects information in the aws table. The UI feature is located in the drowpdown for the Recent PR notifications and it looks like a refresh icon. While doing this I have realized that setting our github token in local storage might not be the most secure thing we can do and I'm hoping to make changes to no longer set it in localStorage, which might mean authorization on every refresh but will hopefully mean more sound security. Eventually I'm hoping this feature will move out of a button and exist as a way of refreshing and checking for deleted projects when the user logs in diminishing the delay that exists between github, aws and abundance.